### PR TITLE
Fix 3 bugs found in map export verification

### DIFF
--- a/webapp/config/countries.py
+++ b/webapp/config/countries.py
@@ -46,7 +46,7 @@ COUNTRY_CRS: dict[str, str] = {
     "FI": "EPSG:3067",     # ETRS89 / TM35FIN
     "EE": "EPSG:3301",     # Estonian Coordinate System
     "LV": "EPSG:3059",     # LKS-92 / TM
-    "LT": "EPSG:4258",     # ETRS89 geographic
+    "LT": "EPSG:3346",     # LKS94 / Lithuania TM
     "DE": "EPSG:25832",
     "PL": "EPSG:2180",
     "GB": "EPSG:27700",

--- a/webapp/services/map_generator.py
+++ b/webapp/services/map_generator.py
@@ -443,8 +443,10 @@ def step_process_roads(
         with open(output_dir / "roads_enfusion_local.geojson", "w") as f:
             json.dump(road_geojson_local, f)
 
-    # Export CSV (with local coords if transformer available)
-    road_csv = export_roads_spline_csv(road_result, transformer=transformer)
+    # Export CSV (with local coords + elevation if transformer available)
+    road_csv = export_roads_spline_csv(
+        road_result, transformer=transformer, elevation_array=elevation_array,
+    )
     with open(output_dir / "roads_splines.csv", "w") as f:
         f.write(road_csv)
 

--- a/webapp/services/setup_guide_generator.py
+++ b/webapp/services/setup_guide_generator.py
@@ -372,7 +372,7 @@ The satellite image should align with your terrain features:
 - Water bodies should align with terrain low points
 - Forest areas should match the forest floor surface mask
 
-> **Source**: Sentinel-2 Cloudless imagery ({self.satellite.get('dimensions', 'unknown')} pixels)"""
+> **Source**: {self.satellite.get('source', 'Sentinel-2 Cloudless')} imagery ({self.satellite.get('dimensions', 'unknown')} pixels)"""
 
     def _phase_roads(self) -> str:
         road_count = self.roads.get("total_segments", 0)
@@ -529,7 +529,7 @@ To add lakes:
 | `Sourcefiles/heightmap.asc` | Primary heightmap (ESRI ASCII Grid) — **use this** |
 | `Sourcefiles/heightmap.png` | Alternative heightmap (16-bit PNG) |
 | `Sourcefiles/heightmap_preview.png` | Visual preview of elevation |
-| `Sourcefiles/satellite_map.png` | Sentinel-2 satellite imagery |
+| `Sourcefiles/satellite_map.png` | {self.satellite.get('source', 'Sentinel-2')} satellite imagery |
 | `Sourcefiles/surface_grass.png` | Surface mask: grass/meadow |
 | `Sourcefiles/surface_forest_floor.png` | Surface mask: deciduous forest floor |
 | `Sourcefiles/surface_pine_floor.png` | Surface mask: coniferous forest floor |


### PR DESCRIPTION
## Summary

Verified all 8 exported maps (DK, EE, FI, LT, LV, NO, PL, SE) and found three bugs:

- **Lithuania CRS was EPSG:4258** (geographic/degrees) instead of EPSG:3346 (LKS94 projected/metres) — metadata reported terrain dimensions in degrees, not metres
- **SETUP_GUIDE hardcoded "Sentinel-2 Cloudless"** as satellite source even when the actual source differs (e.g. Lantmäteriet orthophotos for Sweden)
- **roads_splines.csv had elevation=0.00** for all 83K+ spline points because the CSV export path bypassed DEM sampling — now uses `transformer.transform_points()` with `elevation_array`, matching the Enfusion `.layer` file behaviour

## Test plan

- [x] Lantmäteriet tests pass (60/61, 1 pre-existing isolation issue)
- [x] Road processor tests pass (24/25, 1 pre-existing assertion mismatch)
- [x] `export_roads_spline_csv()` signature is backward-compatible (new `elevation_array` defaults to `None`)
- [ ] Regenerate Lithuania map and verify `projected_width_m` is now in metres
- [ ] Regenerate Sweden map and verify SETUP_GUIDE shows correct satellite source
- [ ] Verify road CSV has non-zero elevation values after regeneration

🤖 Generated with [Claude Code](https://claude.com/claude-code)