### PR TITLE
Fix STAC Bild sortby format (400 Bad Request)

### DIFF
--- a/webapp/services/lantmateriet/stac_orthophoto_service.py
+++ b/webapp/services/lantmateriet/stac_orthophoto_service.py
@@ -175,7 +175,7 @@ async def fetch_stac_orthophoto(
     search_url = f"{LANTMATERIET_CONFIG.stac_bild_endpoint}search"
     query = {
         "bbox": [w, s, e, n],
-        "sortby": "-datetime",   # newest imagery first
+        "sortby": [{"field": "properties.datetime", "direction": "desc"}],  # newest imagery first
         "limit": 50,
     }
 


### PR DESCRIPTION
## Summary

- Fixes a 400 Bad Request error from the Lantmäteriet STAC Bild search endpoint introduced in #27
- The `sortby` field was sent as a plain string (`"-datetime"`) but the API requires a list of OGC sort objects

## Root cause

The STAC Bild API uses the OGC STAC sort extension, which expects `sortby` to be an array of objects rather than a shorthand string:

| What was sent | API response |
|---|---|
| `"sortby": "-datetime"` | 400 — `"Input should be a valid list"` |
| `"sortby": ["-datetime"]` | 400 — `"Input should be a valid dictionary or object"` |
| `"sortby": [{"field": "properties.datetime", "direction": "desc"}]` | 200 ✓ |

The fix is a one-line change in `stac_orthophoto_service.py`. Without it, every Swedish map generation falls back to the WMS 2005 orthophoto layer instead of using STAC Bild.

## Test plan

- [ ] Generate a Swedish map with Lantmäteriet credentials — confirm no `400 Bad Request` in logs and the source reported is `"Lantmäteriet STAC Bild (most recent orthophoto)"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)