### PR TITLE
Skip empty surface mask PNGs and update SETUP_GUIDE accordingly

### DIFF
--- a/webapp/services/map_generator.py
+++ b/webapp/services/map_generator.py
@@ -594,6 +594,8 @@ def build_metadata(
         "surface_masks": {
             "count": surface_result["mask_count"],
             "surfaces": surface_result["surfaces"],
+            "surfaces_present": surface_result.get("surfaces_present", surface_result["surfaces"]),
+            "skipped_surfaces": surface_result.get("skipped_surfaces", []),
             "format": "8-bit grayscale PNG",
             "coverage": surface_result.get("coverage", {}),
             "block_saturation": surface_result.get("block_saturation", {}),
@@ -607,7 +609,7 @@ def build_metadata(
         "enfusion_import": {
             "heightmap_file": "heightmap.asc",
             "heightmap_png": "heightmap.png",
-            "surface_masks": [f"surface_{s}.png" for s in surface_result["surfaces"]],
+            "surface_masks": [f"surface_{s}.png" for s in surface_result.get("surfaces_present", surface_result["surfaces"])],
             "road_data": "roads_enfusion.geojson",
             "road_splines": "roads_splines.csv",
             "recommended_settings": {

--- a/webapp/services/setup_guide_generator.py
+++ b/webapp/services/setup_guide_generator.py
@@ -67,6 +67,12 @@ class SetupGuideGenerator:
             SURFACE_MATERIAL_MAP.get("grass", "Grass_01.emat"),
         )
 
+        # Only surfaces actually generated (non-empty masks)
+        # Falls back to full SURFACE_IMPORT_ORDER for backwards compatibility
+        self.surfaces_present = set(
+            self.surf.get("surfaces_present", ["grass"] + list(SURFACE_IMPORT_ORDER))
+        )
+
     def generate(self, output_dir: Path) -> Path:
         """
         Generate the full SETUP_GUIDE.md.
@@ -276,14 +282,15 @@ The default surface covers 100% of your terrain as the base layer.
 > **Why {self.recommended_default}?** Your terrain is {self.coverage_per_surface.get(self.recommended_default, {}).get('percentage', 'N/A')}% {self.recommended_default},
 > making it the optimal default surface."""]
 
-        # Step 3.3: Add surface materials
-        lines.append("""### Step 3.3: Add Surface Materials
+        # Step 3.3: Add surface materials (only for surfaces that were generated)
+        present_ordered = [s for s in SURFACE_IMPORT_ORDER if s in self.surfaces_present]
 
-For each surface mask, you need to add the corresponding material to the Paint panel:""")
+        lines.append(f"""### Step 3.3: Add Surface Materials
 
-        for i, surface_name in enumerate(SURFACE_IMPORT_ORDER, 1):
+{len(present_ordered)} surface mask(s) were generated for this area. Add the corresponding materials to the Paint panel:""")
+
+        for i, surface_name in enumerate(present_ordered, 1):
             material = SURFACE_MATERIAL_MAP.get(surface_name, "Unknown.emat")
-            pct = self.coverage_per_surface.get(surface_name, {}).get("percentage", "?")
             alternatives = SURFACE_MATERIAL_ALTERNATIVES.get(surface_name, [])
             alt_str = f" (alternatives: {', '.join(a.split('/')[-1] for a in alternatives)})" if alternatives else ""
 
@@ -300,21 +307,22 @@ Import masks in this specific order (most specific surfaces first):
 > to import all masks at once. If using batch import, ensure files are named to match
 > the surface materials. Otherwise, import individually:""")
 
-        for i, surface_name in enumerate(SURFACE_IMPORT_ORDER, 1):
+        verification_text = {
+            "rock": "Mountain peaks and steep slopes should now show rock texture",
+            "pine_floor": "Coniferous forest areas should show pine needle/bark texture",
+            "forest_floor": "Deciduous forest areas should show dark earth/leaf litter texture",
+            "asphalt": "Roads and urban areas should show paved surface",
+            "gravel": "Gravel roads and tracks should show gravel texture",
+            "dirt": "Farmland and dirt paths should show bare earth texture",
+            "sand": "Beaches, shorelines, and underwater seabed should show sand texture",
+            "water_edge": "Near-water transition zones should show wet/muddy texture",
+        }
+
+        for i, surface_name in enumerate(present_ordered, 1):
             material = SURFACE_MATERIAL_MAP.get(surface_name, "Unknown.emat")
             material_short = material.split("/")[-1].replace(".emat", "")
             pct = self.coverage_per_surface.get(surface_name, {}).get("percentage", "?")
-
-            verification = {
-                "rock": "Mountain peaks and steep slopes should now show rock texture",
-                "pine_floor": "Coniferous forest areas should show pine needle/bark texture",
-                "forest_floor": "Deciduous forest areas should show dark earth/leaf litter texture",
-                "asphalt": "Roads and urban areas should show paved surface",
-                "gravel": "Gravel roads and tracks should show gravel texture",
-                "dirt": "Farmland and dirt paths should show bare earth texture",
-                "sand": "Beaches, shorelines, and underwater seabed should show sand texture",
-                "water_edge": "Near-water transition zones should show wet/muddy texture",
-            }.get(surface_name, "Surface should be visible in the expected areas")
+            verification = verification_text.get(surface_name, "Surface should be visible in the expected areas")
 
             lines.append(f"""
 #### Step 3.4.{i}: Import {surface_name.replace('_', ' ').title()} ({pct}% coverage)
@@ -507,6 +515,25 @@ To add lakes:
 - Coordinates: **{crs}**
 - All reference data uses Enfusion local metres (origin at terrain SW corner)."""
 
+    def _surface_mask_file_table(self) -> str:
+        """Return markdown table rows for surface masks present in this generation."""
+        descriptions = {
+            "forest_floor": "Surface mask: deciduous forest floor",
+            "pine_floor": "Surface mask: coniferous forest floor",
+            "asphalt": "Surface mask: paved areas",
+            "gravel": "Surface mask: gravel roads",
+            "dirt": "Surface mask: farmland/dirt",
+            "rock": "Surface mask: rock/slopes",
+            "sand": "Surface mask: sand/seabed",
+            "water_edge": "Surface mask: water edge/mud",
+        }
+        rows = []
+        for name in SURFACE_IMPORT_ORDER:
+            if name in self.surfaces_present:
+                desc = descriptions.get(name, f"Surface mask: {name.replace('_', ' ')}")
+                rows.append(f"| `Sourcefiles/surface_{name}.png` | {desc} |")
+        return "\n".join(rows) + ("\n" if rows else "")
+
     def _appendix_files(self) -> str:
         return f"""## Appendix A: File Reference
 
@@ -530,16 +557,8 @@ To add lakes:
 | `Sourcefiles/heightmap.png` | Alternative heightmap (16-bit PNG) |
 | `Sourcefiles/heightmap_preview.png` | Visual preview of elevation |
 | `Sourcefiles/satellite_map.png` | {self.satellite.get('source', 'Sentinel-2')} satellite imagery |
-| `Sourcefiles/surface_grass.png` | Surface mask: grass/meadow |
-| `Sourcefiles/surface_forest_floor.png` | Surface mask: deciduous forest floor |
-| `Sourcefiles/surface_pine_floor.png` | Surface mask: coniferous forest floor |
-| `Sourcefiles/surface_asphalt.png` | Surface mask: paved areas |
-| `Sourcefiles/surface_gravel.png` | Surface mask: gravel roads |
-| `Sourcefiles/surface_dirt.png` | Surface mask: farmland/dirt |
-| `Sourcefiles/surface_rock.png` | Surface mask: rock/slopes |
-| `Sourcefiles/surface_sand.png` | Surface mask: sand/seabed |
-| `Sourcefiles/surface_water_edge.png` | Surface mask: water edge/mud |
-| `Sourcefiles/surface_preview.png` | Combined surface preview |
+| `Sourcefiles/surface_grass.png` | Surface mask: grass/meadow (always present) |
+{self._surface_mask_file_table()}| `Sourcefiles/surface_preview.png` | Combined surface preview |
 
 ### Reference Files (for manual placement)
 | File | Purpose |

--- a/webapp/services/surface_mask_generator.py
+++ b/webapp/services/surface_mask_generator.py
@@ -717,9 +717,10 @@ def generate_surface_masks(
         )
 
     # =========================================================================
-    # Step 7: Save mask files
+    # Step 7: Save mask files (only those with actual coverage)
     # =========================================================================
     masks = {}
+    skipped_surfaces = []
 
     def _save_mask(name: str, data: np.ndarray):
         path = output_dir / f"surface_{name}.png"
@@ -728,9 +729,24 @@ def generate_surface_masks(
         masks[name] = str(path)
 
     for name, array in mask_arrays.items():
-        _save_mask(name, array)
+        # Grass is always saved (it's the complement/default surface).
+        # All others are only saved when at least one pixel has non-zero coverage.
+        if name == "grass" or np.any(array > 0):
+            _save_mask(name, array)
+        else:
+            skipped_surfaces.append(name)
+            logger.info(f"Skipping surface_{name}.png — no coverage in this area")
+
+    if skipped_surfaces:
+        logger.info(f"Omitted {len(skipped_surfaces)} empty surface masks: {', '.join(skipped_surfaces)}")
+        if job:
+            job.add_log(
+                f"Omitted {len(skipped_surfaces)} surface masks with no coverage: "
+                f"{', '.join(skipped_surfaces)}",
+                "info",
+            )
     if job:
-        job.add_log(f"Saved {len(mask_arrays)} surface mask files")
+        job.add_log(f"Saved {len(masks)} surface mask files")
 
     # =========================================================================
     # Step 8: Compute coverage statistics
@@ -816,11 +832,15 @@ def generate_surface_masks(
             "success"
         )
 
+    surfaces_present = [s for s in mask_arrays.keys() if s in masks]
+
     return {
         "masks": masks,
         "mask_count": len(masks) - (1 if "preview" in masks else 0),
         "dimensions": f"{w}x{h}",
         "surfaces": list(mask_arrays.keys()),
+        "surfaces_present": surfaces_present,
+        "skipped_surfaces": skipped_surfaces,
         "coverage": coverage_stats,
         "block_saturation": {
             "violations": saturation_final["violations"],


### PR DESCRIPTION
## Problem

All 9 `surface_*.png` files were always included in the ZIP regardless of whether the surface type was actually present in the selected area. A landlocked terrain with no water would still get `surface_sand.png` and `surface_water_edge.png` (both all-black). An area with no OSM forest data would still get `surface_forest_floor.png` and `surface_pine_floor.png`. The SETUP_GUIDE.md also always listed all 9 surfaces in the import instructions.

## Solution

### `surface_mask_generator.py`
- Only saves `surface_*.png` when at least one pixel is non-zero
- `grass` is always saved (it's the complement/default and always has coverage)
- Logs which surfaces were omitted at INFO level and in the job activity log
- Returns `surfaces_present` and `skipped_surfaces` in the result dict

### `map_generator.py`
- Threads `surfaces_present` and `skipped_surfaces` into `metadata.surface_masks`
- `enfusion_import.surface_masks` list now only references files that exist

### `setup_guide_generator.py`
- **Step 3.3** (Add surface materials): only lists materials for present surfaces
- **Step 3.4** (Import surface masks): only shows import steps for present surfaces
- **Appendix A** file table: only lists surface PNG files that are in the ZIP
- Backwards-compatible: falls back to full surface list if metadata lacks `surfaces_present`

## Examples of what gets omitted

| Area type | Typically omitted surfaces |
|-----------|---------------------------|
| Landlocked flat terrain | `sand`, `water_edge`, `rock` |
| Dense forest, no roads | `asphalt`, `gravel`, `dirt` |
| Urban area | `pine_floor`, `forest_floor` |
| Small island | `dirt`, `pine_floor`, `forest_floor` |

## Test plan

- [ ] Generate a landlocked terrain — confirm `surface_sand.png` and `surface_water_edge.png` absent from ZIP
- [ ] Generate a terrain with no forest OSM data — confirm `surface_forest_floor.png` and `surface_pine_floor.png` absent
- [ ] Confirm `surface_grass.png` is always present
- [ ] Confirm SETUP_GUIDE.md Step 3.3/3.4 only lists surfaces actually in the ZIP
- [ ] Confirm Appendix A file table only lists present surface files
- [ ] Generate a coastal terrain — confirm `surface_sand.png` is still included

🤖 Generated with [Claude Code](https://claude.ai/claude-code)