### PR TITLE
Fix false-positive DEM truncation error on coastal/ocean areas

### DIFF
--- a/webapp/main.py
+++ b/webapp/main.py
@@ -41,7 +41,7 @@ configure_gdal_threading()
 # Application version (for cache busting)
 # ===========================================================================
 
-APP_VERSION = "1.0.1"  # Increment when static files change
+APP_VERSION = "1.0.2"  # Increment when static files change
 
 # ===========================================================================
 # FastAPI app

--- a/webapp/services/heightmap_generator.py
+++ b/webapp/services/heightmap_generator.py
@@ -153,17 +153,36 @@ def geotiff_to_array(geotiff_bytes: bytes) -> tuple[np.ndarray, dict]:
     # small corner with real data (rest is near-zero).  This happens
     # with some national WCS endpoints (e.g. Poland's geoportal) when
     # the requested area exceeds an undocumented size limit.
+    #
+    # Coastal/ocean selections are exempt: COP30 and similar global DEMs store
+    # ocean pixels at exactly 0.0 m (sea level), not as nodata, so a coastal
+    # area with 60-70% ocean coverage will legitimately hit the 50% threshold.
+    # We distinguish truncation from ocean by requiring that the non-near-zero
+    # (land) pixels are both numerous (≥10% of total) and show realistic
+    # elevation variation (std > 0.5 m).  Truncated responses have almost no
+    # valid data and/or zero variance; genuine coastal data has both.
     total_pixels = elevation.size
     near_zero_count = np.sum(np.abs(elevation) < 0.01)
     near_zero_pct = near_zero_count / total_pixels * 100
     if near_zero_pct > 50:
-        msg = (
-            f"DEM appears truncated: {near_zero_pct:.1f}% of pixels are near-zero "
-            f"({near_zero_count}/{total_pixels}). The elevation API silently "
-            f"returned incomplete data."
-        )
-        logger.error(msg)
-        raise ElevationTruncatedError(msg)
+        non_zero = elevation[np.abs(elevation) >= 0.01]
+        non_zero_pct = non_zero.size / total_pixels * 100
+        land_std = float(np.std(non_zero)) if non_zero.size > 0 else 0.0
+        if non_zero_pct >= 10 and land_std > 0.5:
+            # Enough land pixels with realistic variation → coastal/ocean area.
+            logger.warning(
+                f"DEM has {near_zero_pct:.1f}% near-zero pixels, but "
+                f"{non_zero_pct:.1f}% are valid land data (std={land_std:.1f}m). "
+                f"Treating as coastal/ocean area, not truncated."
+            )
+        else:
+            msg = (
+                f"DEM appears truncated: {near_zero_pct:.1f}% of pixels are near-zero "
+                f"({near_zero_count}/{total_pixels}). The elevation API silently "
+                f"returned incomplete data."
+            )
+            logger.error(msg)
+            raise ElevationTruncatedError(msg)
 
     logger.info(
         f"DEM: {elevation.shape}, "

--- a/webapp/services/map_generator.py
+++ b/webapp/services/map_generator.py
@@ -822,16 +822,25 @@ async def run_generation(job: MapGenerationJob):
             elevation_result["crs"] = "EPSG:4326"
             job.add_log("Downloaded fallback elevation from OpenTopography (30m)", "success")
 
-            heightmap_result = step_generate_heightmap(
-                dem_bytes=fallback_data,
-                osm_data=osm_data,
-                target_size=target_size,
-                target_resolution=target_resolution,
-                output_dir=output_dir,
-                job=job,
-            )
+            try:
+                heightmap_result = step_generate_heightmap(
+                    dem_bytes=fallback_data,
+                    osm_data=osm_data,
+                    target_size=target_size,
+                    target_resolution=target_resolution,
+                    output_dir=output_dir,
+                    job=job,
+                )
+            except ElevationTruncatedError as e2:
+                # Fallback also looks truncated — most likely a coastal/ocean
+                # selection where >50% of pixels are at sea level (0 m).
+                raise RuntimeError(
+                    f"Elevation data for this area appears to be mostly ocean or sea level. "
+                    f"Please select an area with sufficient land coverage. "
+                    f"Detail: {e2}"
+                ) from None
             job.add_log(
-                f"Heightmap generated using OpenTopography 30m fallback",
+                "Heightmap generated using OpenTopography 30m fallback",
                 "warning"
             )
 


### PR DESCRIPTION
## Summary

- **Root cause 1:** The near-zero safety check in `geotiff_to_array` fires on valid COP30 coastal data. COP30 stores ocean pixels at exactly 0.0 m (sea level, not nodata), so a selection with 60–70% ocean coverage (e.g. Tunisia's Mediterranean coast) trips the 50% threshold even though the land pixels are completely valid.
- **Root cause 2:** When the primary elevation source was already OpenTopography, the fallback handler re-downloaded the same COP30 data and raised an identical `ElevationTruncatedError`, surfacing as a confusing "During handling of the above exception, another exception occurred" double-traceback.

**Fix 1 — `heightmap_generator.py`:** When >50% of pixels are near-zero, check whether the remaining land pixels are substantial (≥10% of total) and show realistic elevation variation (std > 0.5 m). If so, log a warning and continue — it's a coastal/ocean area, not a truncated response. Truncated WCS data has almost no valid pixels and/or zero variance.

**Fix 2 — `map_generator.py`:** Wrap the fallback `step_generate_heightmap` call in its own `except ElevationTruncatedError` so a second failure produces one clear `RuntimeError` ("area appears to be mostly ocean — select an area with more land coverage") instead of a chained double-traceback.

Closes #23

## Test plan

- [ ] Generate a map for a coastal area (e.g. Tunisia, Sicily, Norwegian fjords) — should complete without truncation error
- [ ] Generate a map for a genuinely flat inland area — should still work
- [ ] Generate a map where a national WCS returns truncated data (e.g. large Poland selection) — `ElevationTruncatedError` should still fire and trigger the OpenTopography fallback correctly
- [ ] Confirm logs show "Treating as coastal/ocean area, not truncated" warning for >50% ocean selections

🤖 Generated with [Claude Code](https://claude.com/claude-code)