### PR TITLE
Add direct COP30 AWS Open Data fetcher (no API key required)

### DIFF
--- a/webapp/main.py
+++ b/webapp/main.py
@@ -41,7 +41,7 @@ configure_gdal_threading()
 # Application version (for cache busting)
 # ===========================================================================
 
-APP_VERSION = "1.0.2"  # Increment when static files change
+APP_VERSION = "1.0.3"  # Increment when static files change
 
 # ===========================================================================
 # FastAPI app

--- a/webapp/services/elevation_service.py
+++ b/webapp/services/elevation_service.py
@@ -1107,11 +1107,30 @@ async def fetch_elevation(
             if job:
                 job.add_log(f"Failed to fetch from {config.name}, will try fallback source...", "warning")
 
-    # Fallback: OpenTopography Copernicus DEM 30 m
-    logger.info("Using OpenTopography Copernicus DEM 30 m fallback...")
+    # Fallback 1: COP30 directly from AWS Open Data — same data as OpenTopography
+    # serves, but no API key and no rate limit. Try this first; if it fails,
+    # fall through to OpenTopography (different infrastructure, same dataset).
+    from services.global_dem.cop30_aws import fetch_elevation_cop30_aws
+
+    logger.info("Trying Copernicus DEM 30 m directly from AWS Open Data...")
     if job:
-        job.add_log("Using OpenTopography Copernicus DEM 30m as fallback...")
+        job.add_log("Trying Copernicus DEM 30m directly from AWS Open Data (no API key)...")
         job.progress = 15
+    data = await fetch_elevation_cop30_aws(bbox, job=job)
+    if data:
+        result["data"] = data
+        result["source"] = "Copernicus DEM GLO-30 (AWS Open Data)"
+        result["resolution_m"] = 30
+        result["crs"] = "EPSG:4326"
+        if job:
+            job.add_log(f"Successfully fetched elevation data from AWS COP30 ({len(data)} bytes)", "success")
+            job.progress = 23
+        return result
+
+    # Fallback 2: OpenTopography Copernicus DEM 30 m (same data, different host)
+    logger.info("AWS COP30 unavailable — trying OpenTopography COP30 fallback...")
+    if job:
+        job.add_log("AWS COP30 unavailable, falling back to OpenTopography COP30...", "warning")
     data = await fetch_elevation_opentopography(bbox, "COP30")
     if data:
         result["data"] = data

--- a/webapp/services/global_dem/__init__.py
+++ b/webapp/services/global_dem/__init__.py
@@ -1,0 +1,1 @@
+"""Global DEM fetchers (worldwide elevation sources, no country routing)."""

--- a/webapp/services/global_dem/cop30_aws.py
+++ b/webapp/services/global_dem/cop30_aws.py
@@ -1,0 +1,212 @@
+"""
+Copernicus DEM GLO-30 (COP30) direct fetch from AWS Open Data.
+
+Worldwide 30 m elevation, no API key required. Identical pixel data to what
+OpenTopography serves for `demtype=COP30`, but accessed directly from the
+AWS Open Data bucket (`copernicus-dem-30m`) so there's no rate limit and no
+`OPENTOPOGRAPHY_API_KEY` dependency.
+
+Tiles are 1°×1° COGs anchored at their SW corner. URL pattern:
+
+    https://copernicus-dem-30m.s3.amazonaws.com/
+        Copernicus_DSM_COG_10_<lat>_00_<lon>_00_DEM/
+        Copernicus_DSM_COG_10_<lat>_00_<lon>_00_DEM.tif
+
+Where <lat> is `N00`–`N89` / `S01`–`S90` (zero-padded 2 digits) and
+<lon> is `E000`–`E179` / `W001`–`W180` (zero-padded 3 digits).
+
+Tiles over open ocean (no land in the cell) simply don't exist — a 404 is
+expected and treated as "no data here" rather than an error.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+import math
+from typing import Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+COP30_AWS_BASE = "https://copernicus-dem-30m.s3.amazonaws.com"
+TILE_REQUEST_TIMEOUT = 60.0
+MAX_CONCURRENT_DOWNLOADS = 8
+
+
+def _tile_id(lat_int: int, lon_int: int) -> str:
+    """Return the COP30 tile basename for the 1°×1° cell anchored at (lat_int, lon_int)."""
+    lat_str = f"N{lat_int:02d}" if lat_int >= 0 else f"S{abs(lat_int):02d}"
+    lon_str = f"E{lon_int:03d}" if lon_int >= 0 else f"W{abs(lon_int):03d}"
+    return f"Copernicus_DSM_COG_10_{lat_str}_00_{lon_str}_00_DEM"
+
+
+def _tile_url(lat_int: int, lon_int: int) -> str:
+    tid = _tile_id(lat_int, lon_int)
+    return f"{COP30_AWS_BASE}/{tid}/{tid}.tif"
+
+
+def _tiles_intersecting_bbox(bbox: dict) -> list[tuple[int, int]]:
+    """
+    Return list of (lat_int, lon_int) tile origins that intersect the bbox.
+
+    Each tile covers [lat, lat+1) × [lon, lon+1) so we floor the south/west
+    edges and ceil the north/east edges.
+    """
+    lat_min = math.floor(bbox["south"])
+    lat_max = math.ceil(bbox["north"])
+    lon_min = math.floor(bbox["west"])
+    lon_max = math.ceil(bbox["east"])
+
+    # If the bbox edge sits exactly on a tile boundary, ceil() would add an
+    # extra empty row/column — clamp it back.
+    if lat_max == lat_min:
+        lat_max += 1
+    if lon_max == lon_min:
+        lon_max += 1
+
+    return [(lat, lon) for lat in range(lat_min, lat_max) for lon in range(lon_min, lon_max)]
+
+
+async def _fetch_tile(
+    client: httpx.AsyncClient,
+    semaphore: asyncio.Semaphore,
+    lat_int: int,
+    lon_int: int,
+) -> Optional[bytes]:
+    url = _tile_url(lat_int, lon_int)
+    async with semaphore:
+        try:
+            resp = await client.get(url, timeout=TILE_REQUEST_TIMEOUT)
+        except httpx.HTTPError as e:
+            logger.warning(f"COP30 tile request failed ({lat_int},{lon_int}): {e}")
+            return None
+
+    if resp.status_code == 404:
+        logger.debug(
+            f"COP30 tile not present at {lat_int},{lon_int} "
+            f"(open ocean cells have no tile)"
+        )
+        return None
+    if resp.status_code != 200:
+        logger.warning(
+            f"COP30 tile {lat_int},{lon_int} returned HTTP {resp.status_code}"
+        )
+        return None
+
+    content = resp.content
+    if len(content) < 4 or content[:4] not in (b"II*\x00", b"MM\x00*"):
+        logger.warning(
+            f"COP30 tile {lat_int},{lon_int} did not return valid TIFF "
+            f"(first 8 bytes: {content[:8]!r})"
+        )
+        return None
+
+    return content
+
+
+async def fetch_elevation_cop30_aws(
+    bbox: dict,
+    job=None,
+) -> Optional[bytes]:
+    """
+    Fetch COP30 elevation directly from AWS Open Data.
+
+    Args:
+        bbox: dict with west, south, east, north in EPSG:4326
+        job:  optional MapGenerationJob for progress logging
+
+    Returns:
+        Merged GeoTIFF bytes cropped to the requested bbox, or None on failure
+        (e.g. no land cells in the bbox, or all tile requests failed).
+    """
+    tiles = _tiles_intersecting_bbox(bbox)
+    if not tiles:
+        logger.error(f"COP30: no tiles intersect bbox {bbox}")
+        return None
+
+    n_tiles = len(tiles)
+    logger.info(f"COP30 AWS: fetching {n_tiles} tile(s) for bbox {bbox}")
+    if job:
+        job.add_log(
+            f"Downloading {n_tiles} Copernicus DEM tile(s) from AWS Open Data..."
+        )
+
+    semaphore = asyncio.Semaphore(MAX_CONCURRENT_DOWNLOADS)
+    async with httpx.AsyncClient(follow_redirects=True) as client:
+        tile_bytes = await asyncio.gather(
+            *[_fetch_tile(client, semaphore, lat, lon) for lat, lon in tiles]
+        )
+
+    valid = [(t, b) for t, b in zip(tiles, tile_bytes) if b is not None]
+    if not valid:
+        logger.error(
+            f"COP30 AWS: all {n_tiles} tile fetches failed (or area is "
+            f"entirely open ocean with no tiles)"
+        )
+        return None
+
+    if len(valid) < n_tiles:
+        logger.info(
+            f"COP30 AWS: {len(valid)}/{n_tiles} tile(s) returned data — "
+            f"the rest are likely ocean cells without tiles"
+        )
+
+    return _merge_and_crop(valid, bbox)
+
+
+def _merge_and_crop(valid_tiles: list[tuple[tuple[int, int], bytes]], bbox: dict) -> Optional[bytes]:
+    """Merge tile bytes via rasterio and crop to bbox; return GeoTIFF bytes."""
+    import rasterio
+    from rasterio.merge import merge as rasterio_merge
+
+    memfiles: list = []
+    datasets: list = []
+    try:
+        for _, tiff_bytes in valid_tiles:
+            mf = rasterio.MemoryFile(tiff_bytes)
+            ds = mf.open()
+            memfiles.append(mf)
+            datasets.append(ds)
+
+        merged_arr, merged_transform = rasterio_merge(
+            datasets,
+            bounds=(bbox["west"], bbox["south"], bbox["east"], bbox["north"]),
+        )
+
+        profile = datasets[0].profile.copy()
+        profile.update(
+            driver="GTiff",
+            width=merged_arr.shape[2],
+            height=merged_arr.shape[1],
+            transform=merged_transform,
+            count=merged_arr.shape[0],
+        )
+
+        out = io.BytesIO()
+        with rasterio.open(out, "w", **profile) as dst:
+            dst.write(merged_arr)
+        result = out.getvalue()
+
+        logger.info(
+            f"COP30 AWS: merged {len(valid_tiles)} tile(s) into "
+            f"{merged_arr.shape[2]}×{merged_arr.shape[1]} px GeoTIFF "
+            f"({len(result)} bytes)"
+        )
+        return result
+    except Exception as e:
+        logger.error(f"COP30 AWS: failed to merge tiles: {e}")
+        return None
+    finally:
+        for ds in datasets:
+            try:
+                ds.close()
+            except Exception:
+                pass
+        for mf in memfiles:
+            try:
+                mf.close()
+            except Exception:
+                pass

--- a/webapp/services/map_generator.py
+++ b/webapp/services/map_generator.py
@@ -808,19 +808,27 @@ async def run_generation(job: MapGenerationJob):
             )
             job.progress = 42
 
+            # Prefer AWS Open Data (no API key) and fall back to OpenTopography
+            # if that fails — both serve identical COP30 data.
+            from services.global_dem.cop30_aws import fetch_elevation_cop30_aws
             from services.elevation_service import fetch_elevation_opentopography
-            fallback_data = await fetch_elevation_opentopography(bbox, "COP30")
+
+            fallback_data = await fetch_elevation_cop30_aws(bbox, job=job)
+            fallback_source_label = "AWS Open Data"
+            if not fallback_data:
+                fallback_data = await fetch_elevation_opentopography(bbox, "COP30")
+                fallback_source_label = "OpenTopography"
             if not fallback_data:
                 raise RuntimeError(
                     f"Elevation data from {original_source} was truncated, "
-                    f"and OpenTopography fallback also failed."
+                    f"and both AWS and OpenTopography fallbacks also failed."
                 )
 
             elevation_result["data"] = fallback_data
-            elevation_result["source"] = "Copernicus DEM GLO-30 (OpenTopography, fallback)"
+            elevation_result["source"] = f"Copernicus DEM GLO-30 ({fallback_source_label}, fallback)"
             elevation_result["resolution_m"] = 30
             elevation_result["crs"] = "EPSG:4326"
-            job.add_log("Downloaded fallback elevation from OpenTopography (30m)", "success")
+            job.add_log(f"Downloaded fallback elevation from {fallback_source_label} (30m)", "success")
 
             try:
                 heightmap_result = step_generate_heightmap(

--- a/webapp/tests/test_cop30_aws.py
+++ b/webapp/tests/test_cop30_aws.py
@@ -1,0 +1,117 @@
+"""
+Tests for services/global_dem/cop30_aws.py.
+
+Covers tile-id derivation, bbox→tile-list logic, and the async fetcher's
+behaviour when AWS returns 200 / 404 / non-TIFF data. Network is mocked.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+WEBAPP_DIR = Path(__file__).parent.parent
+if str(WEBAPP_DIR) not in sys.path:
+    sys.path.insert(0, str(WEBAPP_DIR))
+
+from services.global_dem.cop30_aws import (  # noqa: E402
+    _tile_id,
+    _tile_url,
+    _tiles_intersecting_bbox,
+    fetch_elevation_cop30_aws,
+)
+
+
+class TestTileId:
+    def test_northern_hemisphere_eastern(self):
+        assert _tile_id(52, 13) == "Copernicus_DSM_COG_10_N52_00_E013_00_DEM"
+
+    def test_southern_hemisphere_western(self):
+        assert _tile_id(-34, -58) == "Copernicus_DSM_COG_10_S34_00_W058_00_DEM"
+
+    def test_equator_prime_meridian(self):
+        assert _tile_id(0, 0) == "Copernicus_DSM_COG_10_N00_00_E000_00_DEM"
+
+    def test_zero_padding(self):
+        assert _tile_id(5, 7) == "Copernicus_DSM_COG_10_N05_00_E007_00_DEM"
+        assert _tile_id(-5, -7) == "Copernicus_DSM_COG_10_S05_00_W007_00_DEM"
+
+    def test_url_format(self):
+        url = _tile_url(52, 13)
+        assert url.startswith("https://copernicus-dem-30m.s3.amazonaws.com/")
+        assert url.endswith("Copernicus_DSM_COG_10_N52_00_E013_00_DEM.tif")
+        # Tile ID appears twice — once as folder, once as filename
+        assert url.count("Copernicus_DSM_COG_10_N52_00_E013_00_DEM") == 2
+
+
+class TestTilesIntersectingBbox:
+    def test_single_tile(self):
+        # 0.2° wide bbox entirely inside a single 1° tile
+        bbox = {"west": 13.1, "south": 52.1, "east": 13.3, "north": 52.3}
+        tiles = _tiles_intersecting_bbox(bbox)
+        assert tiles == [(52, 13)]
+
+    def test_two_tiles_horizontal(self):
+        # Bbox spans an east-west tile boundary (13°/14° E)
+        bbox = {"west": 13.5, "south": 52.1, "east": 14.5, "north": 52.3}
+        tiles = _tiles_intersecting_bbox(bbox)
+        assert set(tiles) == {(52, 13), (52, 14)}
+
+    def test_four_tiles_corner(self):
+        # Bbox spans both a lat and a lon boundary
+        bbox = {"west": 13.5, "south": 52.5, "east": 14.5, "north": 53.5}
+        tiles = _tiles_intersecting_bbox(bbox)
+        assert set(tiles) == {(52, 13), (52, 14), (53, 13), (53, 14)}
+
+    def test_southern_hemisphere(self):
+        bbox = {"west": -58.5, "south": -34.8, "east": -57.5, "north": -33.5}
+        tiles = _tiles_intersecting_bbox(bbox)
+        # floor(-34.8)=-35, ceil(-33.5)=-33 → lats -35,-34
+        # floor(-58.5)=-59, ceil(-57.5)=-57 → lons -59,-58
+        assert set(tiles) == {(-35, -59), (-35, -58), (-34, -59), (-34, -58)}
+
+    def test_bbox_on_tile_boundary_does_not_explode(self):
+        # If a bbox edge sits exactly on an integer, we shouldn't add an extra empty tile
+        bbox = {"west": 13.0, "south": 52.0, "east": 13.5, "north": 52.5}
+        tiles = _tiles_intersecting_bbox(bbox)
+        assert tiles == [(52, 13)]
+
+
+class TestFetchElevationAws:
+    """Async fetch tests with httpx mocked."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_all_tiles_404(self):
+        bbox = {"west": -10.5, "south": -10.5, "east": -10.0, "north": -10.0}
+        # Mock httpx response: 404 for every tile (open ocean)
+        mock_resp = AsyncMock()
+        mock_resp.status_code = 404
+        mock_resp.content = b""
+
+        with patch("services.global_dem.cop30_aws.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+            result = await fetch_elevation_cop30_aws(bbox)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_response_is_not_tiff(self):
+        bbox = {"west": 13.1, "south": 52.1, "east": 13.3, "north": 52.3}
+        mock_resp = AsyncMock()
+        mock_resp.status_code = 200
+        mock_resp.content = b"<?xml version='1.0'?><Error>Not Found</Error>"
+
+        with patch("services.global_dem.cop30_aws.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+            result = await fetch_elevation_cop30_aws(bbox)
+
+        assert result is None


### PR DESCRIPTION
## Summary

- Worldwide elevation outside the 6 country-specific providers (SE/NO/EE/FI/DK/PL) previously required `OPENTOPOGRAPHY_API_KEY` and was rate-limited by the OpenTopography free tier.
- This PR adds a no-auth fetcher (`services/global_dem/cop30_aws.py`) that pulls **identical** COP30 pixel data directly from the AWS Open Data bucket `copernicus-dem-30m`. Tiles are 1°×1° COGs; the fetcher computes intersecting tiles, downloads them concurrently (max 8), then merges + crops with rasterio.
- New fallback chain: `country WCS → AWS COP30 (new) → OpenTopography COP30 → SRTM → ALOS`. OpenTopography is kept as a same-data backup in case AWS is unavailable.
- The v1.0.2 truncation-fallback path in `map_generator.py` was also updated to prefer AWS over OpenTopography.

## Why this matters

- Removes a hard dependency on a free-tier API key for ~95% of users
- Eliminates the OpenTopography rate-limit failure mode
- Foundation for Priority A2 (GEBCO bathymetry merge) which will reuse the same tile-fetch + rasterio merge plumbing

## Edge cases handled

- **Open-ocean cells** — AWS returns 404 (no tile exists). Treated as "no land here", not an error. Fetcher succeeds as long as ≥1 tile in the bbox returns data.
- **Bbox on tile boundary** — `_tiles_intersecting_bbox` clamps so an edge sitting exactly on an integer doesn't add an empty extra tile.
- **Multi-tile bboxes** — concurrent download with `asyncio.Semaphore(8)`.
- **Non-TIFF response** — magic-byte validation; logged + skipped.

## Test plan

- [x] 12 new unit tests in `tests/test_cop30_aws.py`, all passing — covers tile-id derivation (N/S/E/W hemispheres, zero-padding, equator), bbox→tile-list (1, 2, 4 tiles, southern hemisphere, boundary clamping), and async fetcher behaviour for 404 / non-TIFF responses
- [x] Full test suite still passes (no regressions vs `main`)
- [ ] Smoke test: generate a map for a non-(SE/NO/EE/FI/DK/PL) location and confirm `metadata.json` shows `Copernicus DEM GLO-30 (AWS Open Data)` as the source
- [ ] Smoke test: generate a coastal-island map and confirm partial-tile-coverage (some 404s, some 200s) still produces a valid heightmap

🤖 Generated with [Claude Code](https://claude.com/claude-code)