### PR TITLE
Fix Lantmäteriet OGC endpoints, broken sand/water_edge masks, container TZ

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,9 @@ RATE_LIMIT_GENERATE_PER_HOUR=10
 # Trusted proxy IPs for forwarded headers (comma-separated)
 # Used when behind nginx/Cloudflare
 FORWARDED_ALLOW_IPS=127.0.0.1
+
+# Container timezone — controls timestamps in server logs.
+# Defaults to UTC if unset. Set to your local timezone so server logs
+# match the browser UI timestamps.
+# Examples: Europe/Stockholm, Europe/Berlin, America/New_York
+TZ=UTC

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,10 @@ services:
       - PYTHONUNBUFFERED=1
       # Trust proxy headers from nginx/reverse proxy
       - FORWARDED_ALLOW_IPS=127.0.0.1
+      # Container timezone — controls timestamps in server logs so they
+      # match the operator's wall clock and the browser UI. Defaults to UTC
+      # if not set in .env. Examples: Europe/Stockholm, America/New_York.
+      - TZ=${TZ:-UTC}
     restart: unless-stopped
     # Resource limits
     # Large maps (20+ km) with high-res elevation (1m LiDAR) need extra resources.

--- a/webapp/config/lantmateriet.py
+++ b/webapp/config/lantmateriet.py
@@ -26,6 +26,11 @@ class LantmaterietConfig:
     stac_bild_endpoint: str = "https://api.lantmateriet.se/stac-bild/v1/"
     stac_vektor_endpoint: str = "https://api.lantmateriet.se/stac-vektor/v1"
 
+    # OGC API Features (vector water + landcover; same Basic Auth as STAC).
+    # Consumed by services/lantmateriet/{hydrografi_service,marktacke_service}.py.
+    hydrografi_endpoint: str = "https://api.lantmateriet.se/ogc-features/v1/hydrografi"
+    marktacke_endpoint: str = "https://api.lantmateriet.se/ogc-features/v1/marktacke"
+
     # WMS/WMTS Services (WMS orthophotos used as fallback for STAC Bild)
     orthophoto_wms: str = "https://maps.lantmateriet.se/historiska-ortofoton/wms/v1"
     topowebb_wmts: str = "https://maps.lantmateriet.se/open/topowebb-ccby/v1/wmts"

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -41,7 +41,7 @@ configure_gdal_threading()
 # Application version (for cache busting)
 # ===========================================================================
 
-APP_VERSION = "1.0.3"  # Increment when static files change
+APP_VERSION = "1.0.4"  # Increment when static files change
 
 # ===========================================================================
 # FastAPI app

--- a/webapp/services/surface_mask_generator.py
+++ b/webapp/services/surface_mask_generator.py
@@ -556,16 +556,20 @@ def generate_surface_masks(
         return soft_edge_mask(farmland_binary, transition_px=5) * 0.6
 
     def _compute_sand():
-        """Sandy beaches, shorelines, and underwater seabed."""
+        """Sandy shoreline transition zone around water polygons.
+
+        Previously this also painted underwater pixels as sand ("seabed").
+        That assumption is wrong for inland Sweden — Lake Storsjön is not a
+        beach — and produced surface_sand.png masks where the entire lake
+        polygon was painted full-coverage sand (often >30% of the map).
+        Underwater pixels now fall through to the project's default surface;
+        the water layer covers them visually anyway.
+        """
         if np.any(water_binary):
             water_dilated = ndimage.binary_dilation(water_binary, iterations=sand_transition_px)
             shore_zone = water_dilated & ~water_binary
-            sand_shore = soft_edge_mask(shore_zone, transition_px=sand_transition_px)
-        else:
-            sand_shore = np.zeros((h, w), dtype=np.float32)
-        # Underwater areas get full sand coverage (seabed)
-        seabed = water_binary.astype(np.float32)
-        return np.maximum(sand_shore, seabed)
+            return soft_edge_mask(shore_zone, transition_px=sand_transition_px)
+        return np.zeros((h, w), dtype=np.float32)
 
     def _compute_water_edge():
         """Near-water transition zone (outer ring beyond immediate shoreline)."""
@@ -605,7 +609,10 @@ def generate_surface_masks(
 
     logger.debug("Normalizing surface masks...")
 
-    # Water pixels: zero non-seabed masks, sand provides seabed coverage
+    # Zero all surface masks on water pixels — the water layer covers the
+    # underwater terrain in-game, so what we paint there isn't visible.
+    # Leaving them at 0 lets Enfusion fall back to the project's default
+    # surface for those pixels.
     water_mask_bool = water_binary.astype(bool)
 
     rock_float[water_mask_bool] = 0
@@ -614,8 +621,8 @@ def generate_surface_masks(
     asphalt_float[water_mask_bool] = 0
     gravel_float[water_mask_bool] = 0
     dirt_float[water_mask_bool] = 0
+    sand_float[water_mask_bool] = 0
     water_edge_float[water_mask_bool] = 0
-    # sand_float already has seabed = 1.0 on water pixels (from _compute_sand)
 
     # Stack all non-grass masks
     mask_stack = np.stack([
@@ -728,14 +735,30 @@ def generate_surface_masks(
         img.save(str(path))
         masks[name] = str(path)
 
+    # A mask is "meaningful" only if it has more than a trivial amount of
+    # actual coverage. Anti-aliased polygon edges produce a few thousand
+    # dim non-zero pixels along boundaries, which used to ship as nearly-
+    # empty PNGs (e.g. surface_water_edge.png at 0.0% coverage with only
+    # faint outlines). Require >0.1% of pixels to have meaningful intensity
+    # (>=64/255 ≈ 25%) before considering the mask worth saving.
+    total_pixels = h * w
+    min_meaningful_pixels = max(1, total_pixels // 1000)  # 0.1% of pixels
+    meaningful_intensity_threshold = 64  # 25% of 255
+
     for name, array in mask_arrays.items():
         # Grass is always saved (it's the complement/default surface).
-        # All others are only saved when at least one pixel has non-zero coverage.
-        if name == "grass" or np.any(array > 0):
+        if name == "grass":
+            _save_mask(name, array)
+            continue
+        meaningful_pixels = int((array >= meaningful_intensity_threshold).sum())
+        if meaningful_pixels >= min_meaningful_pixels:
             _save_mask(name, array)
         else:
             skipped_surfaces.append(name)
-            logger.info(f"Skipping surface_{name}.png — no coverage in this area")
+            logger.info(
+                f"Skipping surface_{name}.png — only {meaningful_pixels} "
+                f"meaningful pixels (<{min_meaningful_pixels} threshold)"
+            )
 
     if skipped_surfaces:
         logger.info(f"Omitted {len(skipped_surfaces)} empty surface masks: {', '.join(skipped_surfaces)}")


### PR DESCRIPTION
## Summary

Three related issues observed during a Swedish map generation (job `ViQ2rvAdUUbB4YxR` over Östersund/Storsjön).

### 1. Lantmäteriet Hydrografi/Marktäcke fall back to OSM with attribute errors

```
WARNING Lantmäteriet water unavailable ('LantmaterietConfig' object has no attribute 'hydrografi_endpoint'), falling back to OpenStreetMap...
WARNING Lantmäteriet land cover unavailable ('LantmaterietConfig' object has no attribute 'marktacke_endpoint'), falling back to OpenStreetMap...
```

The service code (`hydrografi_service.py`, `marktacke_service.py`), the existing config test (`test_config_ogc_features_endpoints` in `tests/test_lantmateriet.py:81`), and the OGC client docs all reference these fields — but they were never added to the `LantmaterietConfig` dataclass. Added them with the URL shape the OGC client already documents.

### 2. surface_sand.png paints entire lakes as sand

The reported job over central Sweden generated `surface_sand.png` with **30.7% sand coverage** — actually Lake Storsjön being painted as full-coverage sand. The cause: `_compute_sand` had a `seabed = water_binary` line that treated every underwater pixel as sandy seabed.

This is wrong for inland Sweden (and most maps); a Swedish lake bed is not sand. Sand is now only the shore transition zone; underwater pixels fall through to the project's default surface (the water layer covers them visually in-game anyway). The matching "sand provides seabed coverage" comment in the normalization step was updated and `sand_float` is now zeroed on water pixels for consistency with the other masks.

### 3. surface_water_edge.png shipped nearly empty

The mask had **0.0% coverage** but still saved as a PNG full of faint anti-aliased polygon outlines. The skip rule was `np.any(array > 0)` which fires on a single non-zero pixel. Replaced with "≥0.1% of pixels at ≥25% intensity" so meaningless masks are dropped consistently across all surfaces.

### 4. Container TZ defaults to UTC

Server log timestamps didn't match the browser UI. Added `TZ` env var (defaults to UTC, settable via `.env`) so operators can align them — e.g. `TZ=Europe/Stockholm`.

## Test plan

- [x] `tests/test_lantmateriet.py::TestLantmaterietConfig::test_config_ogc_features_endpoints` — was failing on `main` due to missing attrs; now passes
- [x] Full test suite: 24 failures → 24 (same set, all pre-existing module-import issues unrelated to this change), 117 → 118 passing
- [ ] Smoke test: regenerate the Swedish Östersund map; confirm `surface_sand.png` shows only thin shore zones (not the lake interior), `surface_water_edge.png` is omitted from the export, and `surface_preview.png` shows the lake as deep blue with no yellow sand overlay
- [ ] Smoke test: generate a coastal map (e.g. Mediterranean) and confirm `surface_sand.png` still produces a meaningful shoreline transition
- [ ] Confirm `metadata.json` lists Lantmäteriet (not OSM) as the water source for SE selections after Lantmäteriet credentials are configured
- [ ] After a `docker compose up -d` with `TZ=Europe/Stockholm` in `.env`, confirm log timestamps match the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)