### PR TITLE
Honor GeoJSON polygon holes when rasterizing (fixes islands rendered as water)

### DIFF
--- a/webapp/main.py
+++ b/webapp/main.py
@@ -41,7 +41,7 @@ configure_gdal_threading()
 # Application version (for cache busting)
 # ===========================================================================
 
-APP_VERSION = "1.0.4"  # Increment when static files change
+APP_VERSION = "1.0.5"  # Increment when static files change
 
 # ===========================================================================
 # FastAPI app

--- a/webapp/services/utils/rasterize.py
+++ b/webapp/services/utils/rasterize.py
@@ -5,12 +5,22 @@ Replaces the O(n^2) per-pixel shapely.Point.contains() approach with
 vectorized polygon/line drawing, which is orders of magnitude faster.
 
 Used by both heightmap_generator and surface_mask_generator.
+
+Polygon-with-holes handling:
+    GeoJSON Polygons store the exterior ring as coordinates[0] and interior
+    rings (holes) as coordinates[1..]. PIL's ImageDraw.polygon doesn't
+    natively support holes, so we render each polygon feature into its own
+    temporary image (exterior=255, holes=0) and OR-composite the result
+    into the shared mask. That way a hole in one feature can never erase
+    pixels owned by a different feature — critical for cases like Lake
+    Storsjön (one polygon with island holes) overlapping a smaller pond
+    polygon that happens to sit inside an island.
 """
 
 from __future__ import annotations
 
 import numpy as np
-from PIL import Image, ImageDraw
+from PIL import Image, ImageChops, ImageDraw
 from scipy import ndimage
 
 
@@ -37,14 +47,17 @@ def rasterize_features_to_mask(
     Returns:
         Binary uint8 mask (0 or 1).
     """
-    mask_img = Image.new("L", (width, height), 0)
-    draw = ImageDraw.Draw(mask_img)
     west, south, east, north = bbox_wgs84
-
     lng_range = east - west
     lat_range = north - south
     if lng_range <= 0 or lat_range <= 0:
         return np.zeros((height, width), dtype=np.uint8)
+
+    # Polygons and lines accumulate into separate images so polygon holes
+    # never erase line pixels, then are merged at the end.
+    polygon_img = Image.new("L", (width, height), 0)
+    line_img = Image.new("L", (width, height), 0)
+    line_draw = ImageDraw.Draw(line_img)
 
     has_polygons = False
 
@@ -67,33 +80,34 @@ def rasterize_features_to_mask(
 
         if geom_type == "Polygon" and coords:
             has_polygons = True
-            for ring in coords:
-                pixels = _coords_to_pixels(ring, west, north, lng_range, lat_range, width, height)
-                if len(pixels) >= 3:
-                    draw.polygon(pixels, fill=255)
+            polygon_img = _composite_polygon_with_holes(
+                polygon_img, coords,
+                west, north, lng_range, lat_range, width, height,
+            )
 
         elif geom_type == "MultiPolygon" and coords:
             has_polygons = True
             for polygon_rings in coords:
-                for ring in polygon_rings:
-                    pixels = _coords_to_pixels(ring, west, north, lng_range, lat_range, width, height)
-                    if len(pixels) >= 3:
-                        draw.polygon(pixels, fill=255)
+                polygon_img = _composite_polygon_with_holes(
+                    polygon_img, polygon_rings,
+                    west, north, lng_range, lat_range, width, height,
+                )
 
         elif geom_type == "LineString" and coords:
             pixels = _coords_to_pixels(coords, west, north, lng_range, lat_range, width, height)
             if len(pixels) >= 2:
                 line_width = max(1, buffer_px * 2) if buffer_px > 0 else 1
-                draw.line(pixels, fill=255, width=line_width)
+                line_draw.line(pixels, fill=255, width=line_width)
 
         elif geom_type == "MultiLineString" and coords:
             for line_coords in coords:
                 pixels = _coords_to_pixels(line_coords, west, north, lng_range, lat_range, width, height)
                 if len(pixels) >= 2:
                     line_width = max(1, buffer_px * 2) if buffer_px > 0 else 1
-                    draw.line(pixels, fill=255, width=line_width)
+                    line_draw.line(pixels, fill=255, width=line_width)
 
-    mask = np.array(mask_img)
+    # Merge polygon and line layers (per-pixel max)
+    mask = np.array(ImageChops.lighter(polygon_img, line_img))
 
     # Apply morphological dilation for polygon buffer
     if buffer_px > 0 and has_polygons:
@@ -104,6 +118,36 @@ def rasterize_features_to_mask(
 
     # Convert 0/255 to 0/1
     return (mask > 0).astype(np.uint8)
+
+
+def _composite_polygon_with_holes(
+    accumulator: Image.Image,
+    rings: list,
+    west: float,
+    north: float,
+    lng_range: float,
+    lat_range: float,
+    width: int,
+    height: int,
+) -> Image.Image:
+    """
+    Render one Polygon (list of rings) and OR-composite it into the accumulator.
+
+    `rings[0]` is the exterior (drawn with fill=255), `rings[1..]` are interior
+    holes (drawn with fill=0). The temporary image is then merged via
+    ImageChops.lighter so the holes only mask this polygon's own exterior —
+    they cannot erase pixels contributed by previously-drawn polygons.
+    """
+    if not rings:
+        return accumulator
+    feature_img = Image.new("L", (width, height), 0)
+    feature_draw = ImageDraw.Draw(feature_img)
+    for i, ring in enumerate(rings):
+        pixels = _coords_to_pixels(ring, west, north, lng_range, lat_range, width, height)
+        if len(pixels) >= 3:
+            fill = 255 if i == 0 else 0
+            feature_draw.polygon(pixels, fill=fill)
+    return ImageChops.lighter(accumulator, feature_img)
 
 
 def _coords_to_pixels(

--- a/webapp/tests/test_rasterize.py
+++ b/webapp/tests/test_rasterize.py
@@ -1,0 +1,210 @@
+"""
+Tests for services/utils/rasterize.py.
+
+Focuses on the polygon-with-holes behaviour that was broken pre-v1.0.5
+(every ring was filled, so islands inside lake polygons were rendered as
+water just like the lake itself).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+WEBAPP_DIR = Path(__file__).parent.parent
+if str(WEBAPP_DIR) not in sys.path:
+    sys.path.insert(0, str(WEBAPP_DIR))
+
+from services.utils.rasterize import rasterize_features_to_mask  # noqa: E402
+
+
+# A 1°×1° bbox with width/height = 100 px → 1 pixel ≈ 0.01° on each side.
+BBOX = (0.0, 0.0, 1.0, 1.0)
+W, H = 100, 100
+
+
+def _polygon_feature(coords: list[list[list[float]]]) -> dict:
+    """Build a single-feature GeoJSON FeatureCollection for a Polygon."""
+    return {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {"type": "Polygon", "coordinates": coords},
+                "properties": {},
+            }
+        ],
+    }
+
+
+def _multipolygon_feature(coords: list[list[list[list[float]]]]) -> dict:
+    return {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {"type": "MultiPolygon", "coordinates": coords},
+                "properties": {},
+            }
+        ],
+    }
+
+
+class TestPolygonHoles:
+    def test_polygon_without_holes_fills_interior(self):
+        # Square covering the whole bbox
+        square = [[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]]
+        mask = rasterize_features_to_mask(_polygon_feature(square), W, H, BBOX)
+        # Allow 1 pixel slack on each edge for half-open boundaries
+        assert mask[H // 2, W // 2] == 1
+        assert mask.sum() > 0.95 * W * H
+
+    def test_polygon_with_hole_excludes_hole_interior(self):
+        # Outer 1°×1° square with an inner 0.5°×0.5° square hole centered at (0.5, 0.5)
+        outer = [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]
+        hole = [[0.25, 0.25], [0.75, 0.25], [0.75, 0.75], [0.25, 0.75], [0.25, 0.25]]
+        mask = rasterize_features_to_mask(_polygon_feature([outer, hole]), W, H, BBOX)
+
+        # Pixel at the centre (in the hole) must be 0 (LAND, not water)
+        assert mask[H // 2, W // 2] == 0, (
+            "Centre pixel should be inside the hole and unmasked — "
+            "this is the regression: pre-v1.0.5 it was incorrectly filled."
+        )
+        # Pixel near a corner (in the outer ring, outside the hole) must be 1
+        assert mask[5, 5] == 1
+        assert mask[H - 5, W - 5] == 1
+
+    def test_multipolygon_holes_respected(self):
+        # Two separate polygons, both with holes
+        poly_a = [
+            [[0.0, 0.0], [0.4, 0.0], [0.4, 0.4], [0.0, 0.4], [0.0, 0.0]],   # outer
+            [[0.1, 0.1], [0.3, 0.1], [0.3, 0.3], [0.1, 0.3], [0.1, 0.1]],   # hole
+        ]
+        poly_b = [
+            [[0.6, 0.6], [1.0, 0.6], [1.0, 1.0], [0.6, 1.0], [0.6, 0.6]],   # outer
+            [[0.7, 0.7], [0.9, 0.7], [0.9, 0.9], [0.7, 0.9], [0.7, 0.7]],   # hole
+        ]
+        mask = rasterize_features_to_mask(_multipolygon_feature([poly_a, poly_b]), W, H, BBOX)
+
+        # Poly A: ring centre should be filled, hole centre should be empty
+        py, px = int(H * (1 - 0.05)), int(W * 0.05)  # near (0.05, 0.05) in geo
+        assert mask[py, px] == 1
+        py, px = int(H * (1 - 0.2)), int(W * 0.2)  # near (0.2, 0.2) — inside hole
+        assert mask[py, px] == 0
+
+        # Poly B: same pattern
+        py, px = int(H * (1 - 0.65)), int(W * 0.65)
+        assert mask[py, px] == 1
+        py, px = int(H * (1 - 0.8)), int(W * 0.8)  # inside hole
+        assert mask[py, px] == 0
+
+        # Gap between A and B should be empty
+        py, px = int(H * (1 - 0.5)), int(W * 0.5)
+        assert mask[py, px] == 0
+
+    def test_holes_in_one_polygon_dont_erase_other_polygons(self):
+        # Polygon A has a hole. Polygon B's exterior sits inside that hole.
+        # Pre-v1.0.5 either (a) hole was ignored (filled = bug), or
+        # (b) a single-image hole-fill would erase B if A came after B.
+        poly_a = {
+            "type": "Feature",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]],
+                    [[0.2, 0.2], [0.8, 0.2], [0.8, 0.8], [0.2, 0.8], [0.2, 0.2]],
+                ],
+            },
+            "properties": {},
+        }
+        poly_b = {
+            "type": "Feature",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [[0.4, 0.4], [0.6, 0.4], [0.6, 0.6], [0.4, 0.6], [0.4, 0.4]],
+                ],
+            },
+            "properties": {},
+        }
+        # Order: B first, then A. A's hole punch must NOT erase B.
+        gj = {"type": "FeatureCollection", "features": [poly_b, poly_a]}
+        mask = rasterize_features_to_mask(gj, W, H, BBOX)
+
+        # Centre of the map is inside B → must be 1
+        assert mask[H // 2, W // 2] == 1, (
+            "Polygon B's interior must survive Polygon A's hole punch — "
+            "compositing must be per-feature."
+        )
+        # Inside A's exterior but outside the hole and outside B → 1
+        assert mask[10, 10] == 1
+        # Inside A's hole and outside B → 0
+        py, px = int(H * (1 - 0.25)), int(W * 0.25)
+        assert mask[py, px] == 0
+
+
+class TestEmptyAndDegenerate:
+    def test_empty_features_returns_zero_mask(self):
+        mask = rasterize_features_to_mask({"features": []}, W, H, BBOX)
+        assert mask.shape == (H, W)
+        assert mask.sum() == 0
+
+    def test_degenerate_bbox_returns_zero_mask(self):
+        square = [[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]]
+        mask = rasterize_features_to_mask(
+            _polygon_feature(square), W, H, (1.0, 1.0, 1.0, 1.0)
+        )
+        assert mask.sum() == 0
+
+
+class TestLines:
+    def test_linestring_is_drawn(self):
+        gj = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "LineString",
+                        "coordinates": [[0.0, 0.5], [1.0, 0.5]],
+                    },
+                    "properties": {},
+                }
+            ],
+        }
+        mask = rasterize_features_to_mask(gj, W, H, BBOX, buffer_px=1)
+        # The horizontal centre row should have at least one painted pixel
+        assert mask[H // 2].sum() > 0
+
+    def test_polygon_holes_dont_erase_lines(self):
+        # Polygon with hole AND a line crossing the hole
+        gj = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]],
+                            [[0.3, 0.3], [0.7, 0.3], [0.7, 0.7], [0.3, 0.7], [0.3, 0.3]],
+                        ],
+                    },
+                    "properties": {},
+                },
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "LineString",
+                        "coordinates": [[0.0, 0.5], [1.0, 0.5]],
+                    },
+                    "properties": {},
+                },
+            ],
+        }
+        mask = rasterize_features_to_mask(gj, W, H, BBOX, buffer_px=1)
+        # The line crosses the hole at the centre — it must still be drawn
+        assert mask[H // 2, W // 2] == 1


### PR DESCRIPTION
## Summary

The user reported that for a Swedish map containing an island in the middle of Lake Storsjön, **the island was missing from every surface mask** — `surface_grass.png`, `surface_pine_floor.png`, `surface_dirt.png`, `surface_preview.png` all had a big black hole where the island should be, while only the southern shore strip and a small upper-right corner showed land surfaces.

## Root cause

`rasterize_features_to_mask` in `services/utils/rasterize.py` had this loop for both `Polygon` and `MultiPolygon`:

```python
for ring in coords:
    pixels = _coords_to_pixels(ring, ...)
    if len(pixels) >= 3:
        draw.polygon(pixels, fill=255)
```

GeoJSON Polygons store the exterior boundary as `coordinates[0]` and **interior rings (holes)** as `coordinates[1..]` ([RFC 7946](https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.6)). The loop iterated every ring and filled it with white — so for Lake Storsjön, the lake exterior was correctly filled as water, and then the islands inside (interior rings) were *also* filled as water, erasing them from the land masks.

## Fix — per-feature compositing

Each polygon feature is now rendered into its own temporary PIL image with `exterior=255` and `interior rings=0`, then OR-merged into the shared accumulator via `ImageChops.lighter`. This handles two important cases:

1. **Polygon with island hole** — the hole correctly leaves that area unmasked
2. **Two separate polygons where one's hole overlaps the other's interior** — per-feature compositing means a hole in feature A can never erase pixels contributed by feature B (a single shared `draw.polygon(fill=0)` would have, depending on draw order)

Lines are accumulated into a separate image so polygon holes can't punch out road/river-line pixels either.

## Test plan

- [x] 8 new tests in `tests/test_rasterize.py` covering polygons without holes, polygons with holes, multipolygons with holes, the cross-feature-overlap case, empty/degenerate inputs, and lines
- [x] All 8 pass; full suite goes 118 → 126 passing, 24 pre-existing failures unchanged
- [ ] Smoke test: regenerate the Östersund/Storsjön map (job `6UYfFxRkynAuOxp7…`) and confirm `surface_preview.png` shows green land where the islands are (not blue water), `surface_grass.png` and `surface_pine_floor.png` cover the island areas, and the surface coverage stats jump from grass: 4.7% / pine: 12.1% to something land-dominant
- [ ] Smoke test: regenerate a map with a small lake on a forested island (the trickiest geometry) and confirm both the island land surfaces and the small lake water render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)