### PR TITLE
Auto-emit closed splines for forests + lakes in vegetation/water layers

### DIFF
--- a/webapp/main.py
+++ b/webapp/main.py
@@ -41,7 +41,7 @@ configure_gdal_threading()
 # Application version (for cache busting)
 # ===========================================================================
 
-APP_VERSION = "1.0.5"  # Increment when static files change
+APP_VERSION = "1.0.6"  # Increment when static files change
 
 # ===========================================================================
 # FastAPI app

--- a/webapp/services/enfusion_project_generator.py
+++ b/webapp/services/enfusion_project_generator.py
@@ -112,6 +112,8 @@ class EnfusionProjectGenerator:
         road_data: Optional[dict] = None,
         transformer=None,
         elevation_array=None,
+        forest_features: Optional[dict] = None,
+        water_features: Optional[dict] = None,
     ):
         """
         Initialize the project generator.
@@ -122,12 +124,21 @@ class EnfusionProjectGenerator:
             road_data: Optional processed road data for road layer generation.
             transformer: Optional CoordinateTransformer for road coordinate conversion.
             elevation_array: Optional DEM array (metres) for road elevation sampling.
+            forest_features: Optional GeoJSON FeatureCollection of forest polygons
+                             (from osm_data["forests"]). When supplied with a transformer,
+                             vegetation.layer is populated with one closed SplineShapeEntity
+                             per forest polygon (drag a Forest Generator prefab onto each).
+            water_features: Optional GeoJSON FeatureCollection of water polygons
+                            (from osm_data["water"]). Same treatment for water.layer
+                            (drag a Lake Generator prefab onto each spline).
         """
         self.map_name = sanitize_project_name(map_name)
         self.metadata = metadata
         self.road_data = road_data
         self.transformer = transformer
         self.elevation_array = elevation_array
+        self.forest_features = forest_features
+        self.water_features = water_features
 
         # Generate a deterministic GUID from the map name
         self.project_guid = generate_guid(self.map_name)
@@ -255,12 +266,12 @@ class EnfusionProjectGenerator:
 
         files["vegetation.layer"] = self._write_file(
             worlds_dir / f"{self.map_name}_vegetation.layer",
-            self._generate_placeholder_layer("vegetation")
+            self._generate_vegetation_layer()
         )
 
         files["water.layer"] = self._write_file(
             worlds_dir / f"{self.map_name}_water.layer",
-            self._generate_placeholder_layer("water")
+            self._generate_water_layer()
         )
 
         # Mission header
@@ -580,21 +591,215 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['destruction']} {{
         logger.info(f"Generated {len(entities)} spline-only road entities for roads layer")
         return "\n".join(entities) + "\n"
 
-    def _generate_placeholder_layer(self, layer_type: str) -> str:
-        """Generate a placeholder layer with a descriptive comment."""
-        comments = {
-            "vegetation": (
-                "// Vegetation layer — placeholder for Forest Generator entities.\n"
-                "// Use Reference/osm_forests.geojson and features.json for forest placement.\n"
-                "// Forest Generator prefabs: Prefabs/WEGenerators/Forest/ (FG_ prefix)\n"
-            ),
-            "water": (
-                "// Water layer — placeholder for Lake/River Generator entities.\n"
-                "// Use Reference/osm_water.geojson and features.json for water placement.\n"
-                "// Lake Generator prefabs: Prefabs/WEGenerators/Water/Lake/ (LG_ prefix)\n"
-            ),
-        }
-        return comments.get(layer_type, f"// {layer_type} layer — placeholder\n")
+    def _generate_vegetation_layer(self) -> str:
+        """
+        Emit one closed SplineShapeEntity per forest polygon.
+
+        The user opens the project in Workbench and drags a Forest Generator
+        prefab (Prefabs/WEGenerators/Forest/, FG_ prefix) onto each spline to
+        spawn the actual forest. Auto-attaching the prefab as a child entity
+        is deferred until we have a known-good Enfusion text-serialisation
+        example for parent-child entities.
+        """
+        header = (
+            "// Vegetation layer — one closed spline per forest polygon.\n"
+            "// To populate: drag a Forest Generator prefab from\n"
+            "//   Prefabs/WEGenerators/Forest/ (FG_ prefix, e.g. FG_PineForest_01.et)\n"
+            "// onto each spline in the World Editor and the generator will fill it\n"
+            "// with trees. Enable 'Avoid Roads' and 'Avoid Lakes' on the generator.\n"
+            "// Source data: Reference/osm_forests.geojson and features.json.\n"
+        )
+        body = self._polygon_features_to_splines(
+            self.forest_features,
+            entity_prefix="ForestArea",
+            empty_message="// No forest polygons found in this area.\n",
+        )
+        return header + body
+
+    def _generate_water_layer(self) -> str:
+        """
+        Emit one closed SplineShapeEntity per lake/pond/reservoir polygon.
+
+        Filters out non-polygon water features (rivers/streams are LineStrings
+        and don't fit the spline-area pattern; they'll be added in a future
+        iteration as separate river splines).
+
+        The user drags a Lake Generator prefab (Prefabs/WEGenerators/Water/Lake/,
+        LG_ prefix) onto each spline to spawn the lake.
+        """
+        header = (
+            "// Water layer — one closed spline per lake/pond/reservoir polygon.\n"
+            "// To populate: drag a Lake Generator prefab from\n"
+            "//   Prefabs/WEGenerators/Water/Lake/ (LG_ prefix, e.g. LG_Lake_01.et)\n"
+            "// onto each spline in the World Editor and enable\n"
+            "// 'Flatten By Bottom Plane' for natural water level.\n"
+            "// Rivers (LineString) are not included here; see roads.layer for\n"
+            "// the road network and a future release for river splines.\n"
+            "// Source data: Reference/osm_water.geojson and features.json.\n"
+        )
+        # Lake-like polygons only — rivers come in as LineString and are filtered
+        # naturally by the polygon-only loop, but a feature can still be tagged as
+        # a polygonal river (e.g. a wide watercourse). Restrict to standing-water
+        # types so we don't emit a Lake Generator for a moving river polygon.
+        body = self._polygon_features_to_splines(
+            self.water_features,
+            entity_prefix="Water",
+            filter_property="water_type",
+            filter_values=("lake", "pond", "reservoir", "water"),
+            empty_message="// No standing-water polygons found in this area.\n",
+        )
+        return header + body
+
+    def _polygon_features_to_splines(
+        self,
+        features: Optional[dict],
+        entity_prefix: str,
+        empty_message: str,
+        filter_property: Optional[str] = None,
+        filter_values: tuple[str, ...] = (),
+    ) -> str:
+        """
+        Convert GeoJSON polygon features into closed SplineShapeEntity blocks.
+
+        Each Polygon emits one entity from its exterior ring; each MultiPolygon
+        emits one entity per sub-polygon's exterior ring. Interior rings (holes)
+        are dropped — closed splines can't represent them, and the user can
+        manually mask out island areas if needed.
+
+        Points are projected from WGS84 to local terrain coordinates via the
+        same transformer + elevation_array path used for road splines, then
+        clipped to the terrain bounds. A polygon is skipped if fewer than 3
+        in-bounds points remain (degenerate / fully outside).
+
+        Args:
+            features: GeoJSON FeatureCollection or None.
+            entity_prefix: Per-entity name prefix, e.g. "ForestArea" → ForestArea_0.
+            empty_message: Comment to emit when there's nothing to write.
+            filter_property: Optional GeoJSON property name to filter on.
+            filter_values: Allowed values for filter_property (case-sensitive).
+
+        Returns:
+            Multi-line string suitable for appending to a .layer file.
+        """
+        if not self.transformer:
+            return "// (Coordinate transformer unavailable — splines cannot be projected.)\n"
+        if not features or not features.get("features"):
+            return empty_message
+
+        entities: list[str] = []
+        skipped_clipped = 0
+        skipped_filtered = 0
+
+        for feature in features["features"]:
+            if filter_property:
+                value = feature.get("properties", {}).get(filter_property, "")
+                if value not in filter_values:
+                    skipped_filtered += 1
+                    continue
+
+            geom = feature.get("geometry", {}) or {}
+            geom_type = geom.get("type", "")
+            coords = geom.get("coordinates", []) or []
+
+            # Collect every exterior ring this feature contributes
+            exterior_rings: list[list[list[float]]] = []
+            if geom_type == "Polygon" and coords:
+                exterior_rings.append(coords[0])
+            elif geom_type == "MultiPolygon" and coords:
+                for polygon in coords:
+                    if polygon:
+                        exterior_rings.append(polygon[0])
+            else:
+                continue  # Lines / points etc. — not handled here
+
+            for ring in exterior_rings:
+                entity = self._closed_spline_entity_from_ring(
+                    ring, entity_prefix, len(entities)
+                )
+                if entity is None:
+                    skipped_clipped += 1
+                    continue
+                entities.append(entity)
+
+        if skipped_clipped:
+            logger.info(
+                f"{entity_prefix}: skipped {skipped_clipped} polygon(s) — "
+                f"fewer than 3 in-bounds points after clipping"
+            )
+        if skipped_filtered:
+            logger.info(
+                f"{entity_prefix}: filtered out {skipped_filtered} feature(s) "
+                f"by {filter_property}"
+            )
+        logger.info(
+            f"{entity_prefix}: emitted {len(entities)} closed spline entit(y/ies)"
+        )
+
+        if not entities:
+            return empty_message
+        return "\n".join(entities) + "\n"
+
+    def _closed_spline_entity_from_ring(
+        self,
+        ring: list[list[float]],
+        entity_prefix: str,
+        index: int,
+    ) -> Optional[str]:
+        """
+        Project a single GeoJSON ring (list of [lon, lat] pairs) to a closed
+        SplineShapeEntity. Returns None if the ring has fewer than 3 in-bounds
+        points after clipping to the terrain.
+        """
+        if len(ring) < 3:
+            return None
+
+        # GeoJSON rings are typically explicitly closed (first==last). Drop the
+        # duplicate last point before projection; we'll re-close the spline below.
+        if len(ring) >= 2 and ring[0] == ring[-1]:
+            ring = ring[:-1]
+
+        wgs_points = [{"x": float(p[0]), "y": float(p[1])} for p in ring if len(p) >= 2]
+        if len(wgs_points) < 3:
+            return None
+
+        local_points = self.transformer.transform_points(
+            wgs_points,
+            elevation_array=self.elevation_array,
+        )
+
+        # Clip to terrain bounds with a small margin
+        margin = 1.0
+        in_bounds = [
+            pt for pt in local_points
+            if -margin <= pt["x"] <= self.terrain_width + margin
+            and -margin <= pt["z"] <= self.terrain_depth + margin
+        ]
+        if len(in_bounds) < 3:
+            return None
+
+        # Close the spline: append a final ShapePoint that repeats the origin
+        local_points = in_bounds + [in_bounds[0]]
+
+        origin = local_points[0]
+        point_defs = []
+        for j, pt in enumerate(local_points):
+            rel_x = pt["x"] - origin["x"]
+            rel_y = pt["y"] - origin["y"]
+            rel_z = pt["z"] - origin["z"]
+            point_defs.append(
+                f'   ShapePoint sp_{j} {{\n'
+                f'    Position {rel_x:.3f} {rel_y:.3f} {rel_z:.3f}\n'
+                f'   }}'
+            )
+
+        return (
+            f'SplineShapeEntity {entity_prefix}_{index} {{\n'
+            f' coords {origin["x"]:.3f} {origin["y"]:.3f} {origin["z"]:.3f}\n'
+            f' Points {{\n'
+            + "\n".join(point_defs) + "\n"
+            f' }}\n'
+            f'}}'
+        )
 
     def _generate_mission_conf(self) -> str:
         """Generate mission header .conf file."""

--- a/webapp/services/map_generator.py
+++ b/webapp/services/map_generator.py
@@ -1108,6 +1108,8 @@ async def run_generation(job: MapGenerationJob):
             road_data=road_result,
             transformer=transformer,
             elevation_array=heightmap_result.get("_elevation_array"),
+            forest_features=osm_data.get("forests"),
+            water_features=osm_data.get("water"),
         )
         enfusion_files = enfusion_gen.generate_all(output_dir, job=job)
 

--- a/webapp/services/setup_guide_generator.py
+++ b/webapp/services/setup_guide_generator.py
@@ -429,33 +429,44 @@ For road type/surface/width details:
         rivers = self.features.get("rivers", 0)
         forests = self.features.get("forest_areas", 0)
 
-        return f"""## Phase 6: Vegetation & Water (Optional — Manual Placement)
+        return f"""## Phase 6: Vegetation & Water (Generators)
+
+The vegetation and water layers already contain pre-drawn closed splines —
+one per forest/lake polygon, projected to Enfusion local coordinates and
+clipped to the terrain. You only need to drop a generator prefab onto each
+spline; the spline-drawing work is done.
 
 ### Step 6.1: Forest Generator
 
-Your terrain has **{forests}** forest areas identified from OpenStreetMap data.
+Your terrain has **{forests}** forest areas identified from OpenStreetMap.
+The vegetation layer contains a closed `SplineShapeEntity` for each.
 
-To add forests:
-1. Create a **closed Spline** shape matching the forest boundary
-2. Enable **Avoid Roads** and **Avoid Lakes** options
-3. Use prefabs from `Prefabs/WEGenerators/Forest/` (prefixed `FG_`)
-4. Drag the prefab onto the spline you created and wait (it generates a forest)
+For each spline:
+1. Select the spline in the World Editor (vegetation layer)
+2. Drag a Forest Generator prefab from `Prefabs/WEGenerators/Forest/`
+   (prefixed `FG_`) onto the spline — it will populate the area with trees
+3. Enable **Avoid Roads** and **Avoid Lakes** on the generator
 
-> **Optional reference**: `Reference/osm_forests.geojson` and `Reference/features.json`
-> contain forest boundary data in Enfusion local coordinates for positioning guidance.
+> **Tip**: Pick the prefab that matches the dominant tree type for your
+> region (e.g. `FG_PineForest_*` for Nordic coniferous areas).
+> Reference: `Reference/osm_forests.geojson` includes leaf_type metadata
+> (needleleaved / broadleaved) per polygon.
 
 ### Step 6.2: Water Bodies
 
 Your terrain has **{lakes}** lakes and **{rivers}** rivers/streams.
+The water layer contains a closed `SplineShapeEntity` per lake/pond/reservoir.
+(Rivers are LineStrings and aren't included in the water layer; use the
+roads layer or future river-spline output for them.)
 
-To add lakes:
-1. Create a **closed Spline** shape matching the lake boundary
-2. Add a **Lake Generator** entity as a child
-3. Use prefabs from `Prefabs/WEGenerators/Water/Lake/` (prefixed `LG_`)
-4. Set **Flatten By Bottom Plane** for natural water level
-5. Reference: `Reference/osm_water.geojson` and `Reference/features.json`
+For each spline:
+1. Select the spline in the World Editor (water layer)
+2. Drag a Lake Generator prefab from `Prefabs/WEGenerators/Water/Lake/`
+   (prefixed `LG_`) onto the spline
+3. Enable **Flatten By Bottom Plane** for natural water level
 
-> **Tip**: Water body coordinates in features.json are already in Enfusion local metres."""
+> **Tip**: Water body coordinates in features.json are already in Enfusion
+> local metres."""
 
     def _phase_testing(self) -> str:
         return f"""## Phase 7: Testing (5 minutes)

--- a/webapp/tests/test_enfusion_vegetation_water_layers.py
+++ b/webapp/tests/test_enfusion_vegetation_water_layers.py
@@ -1,0 +1,224 @@
+"""
+Tests for the auto-emitted vegetation.layer and water.layer in
+EnfusionProjectGenerator (added in v1.0.6).
+
+Pre-v1.0.6 these layers were single-comment placeholders. Now they emit one
+closed `SplineShapeEntity` per forest / lake polygon.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+WEBAPP_DIR = Path(__file__).parent.parent
+if str(WEBAPP_DIR) not in sys.path:
+    sys.path.insert(0, str(WEBAPP_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: a minimal stand-in for CoordinateTransformer so we don't need
+# pyproj installed locally to run these tests.
+# ---------------------------------------------------------------------------
+
+class _IdentityTransformer:
+    """
+    Minimal transformer that maps WGS84 lon/lat directly to local x/z by
+    multiplying by 1000 (so distances in the tests remain visually trackable).
+    Y comes back as 0 (no elevation sampling). Matches the public surface
+    of services.coordinate_transformer.CoordinateTransformer that
+    EnfusionProjectGenerator uses (only `transform_points` is called).
+    """
+
+    def transform_points(self, points, elevation_array=None):
+        return [
+            {"x": round(p["x"] * 1000, 3), "y": 0.0, "z": round(p["y"] * 1000, 3)}
+            for p in points
+        ]
+
+
+def _metadata_for_4km_terrain() -> dict:
+    """Standard 2049x2049 vertex / 4096m terrain metadata."""
+    return {
+        "heightmap": {"dimensions": "2049x2049", "grid_cell_size_m": 2.0},
+        "elevation": {
+            "min_elevation_m": 0,
+            "max_elevation_m": 100,
+            "height_scale": 0.03125,
+            "height_offset": 0,
+        },
+        "input": {"bbox": {"south": 0.0, "north": 4.0, "west": 0.0, "east": 4.0}},
+    }
+
+
+def _polygon_feature(coords, **props) -> dict:
+    return {
+        "type": "Feature",
+        "geometry": {"type": "Polygon", "coordinates": coords},
+        "properties": props,
+    }
+
+
+def _multipolygon_feature(coords, **props) -> dict:
+    return {
+        "type": "Feature",
+        "geometry": {"type": "MultiPolygon", "coordinates": coords},
+        "properties": props,
+    }
+
+
+@pytest.fixture
+def generator_factory():
+    """Construct an EnfusionProjectGenerator with our identity transformer."""
+    from services.enfusion_project_generator import EnfusionProjectGenerator
+
+    def _make(forest_features=None, water_features=None):
+        return EnfusionProjectGenerator(
+            map_name="TestMap",
+            metadata=_metadata_for_4km_terrain(),
+            transformer=_IdentityTransformer(),
+            elevation_array=None,
+            forest_features=forest_features,
+            water_features=water_features,
+        )
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# Vegetation layer tests
+# ---------------------------------------------------------------------------
+
+class TestVegetationLayer:
+    def test_no_forest_features_emits_empty_message(self, generator_factory):
+        gen = generator_factory(forest_features=None)
+        out = gen._generate_vegetation_layer()
+        assert "// Vegetation layer" in out  # header still present
+        assert "// No forest polygons" in out
+        assert "SplineShapeEntity" not in out
+
+    def test_single_polygon_emits_one_closed_spline(self, generator_factory):
+        # Square 1×1 polygon centered around (1, 1) WGS84 → (1000, 1000) local
+        ring = [
+            [0.5, 0.5], [1.5, 0.5], [1.5, 1.5], [0.5, 1.5], [0.5, 0.5]
+        ]
+        gen = generator_factory(forest_features={
+            "type": "FeatureCollection",
+            "features": [_polygon_feature([ring], type="forest")],
+        })
+        out = gen._generate_vegetation_layer()
+
+        # One entity with the expected name prefix
+        assert out.count("SplineShapeEntity ForestArea_0 {") == 1
+        # 4 unique points + 1 repeat for the close = 5 ShapePoint blocks
+        assert out.count("ShapePoint sp_") == 5
+        assert "ShapePoint sp_0" in out and "ShapePoint sp_4" in out
+        # The first and last shape points must be at the same relative position (closed)
+        first_pos = "Position 0.000 0.000 0.000"
+        assert out.count(first_pos) >= 2
+
+    def test_multipolygon_emits_one_spline_per_subpolygon(self, generator_factory):
+        ring_a = [[0.5, 0.5], [1.0, 0.5], [1.0, 1.0], [0.5, 1.0], [0.5, 0.5]]
+        ring_b = [[2.0, 2.0], [2.5, 2.0], [2.5, 2.5], [2.0, 2.5], [2.0, 2.0]]
+        gen = generator_factory(forest_features={
+            "type": "FeatureCollection",
+            "features": [_multipolygon_feature([[ring_a], [ring_b]], type="forest")],
+        })
+        out = gen._generate_vegetation_layer()
+        assert "SplineShapeEntity ForestArea_0 {" in out
+        assert "SplineShapeEntity ForestArea_1 {" in out
+
+    def test_polygon_with_holes_uses_only_exterior_ring(self, generator_factory):
+        # Outer square + inner hole — hole must be ignored (splines can't have holes)
+        outer = [[0.5, 0.5], [3.5, 0.5], [3.5, 3.5], [0.5, 3.5], [0.5, 0.5]]
+        hole = [[1.0, 1.0], [2.0, 1.0], [2.0, 2.0], [1.0, 2.0], [1.0, 1.0]]
+        gen = generator_factory(forest_features={
+            "type": "FeatureCollection",
+            "features": [_polygon_feature([outer, hole], type="forest")],
+        })
+        out = gen._generate_vegetation_layer()
+        # One spline entity (not two — the hole is dropped)
+        assert out.count("SplineShapeEntity ForestArea_") == 1
+        # And it has 5 ShapePoints (4 outer + 1 close), not 9 or more
+        assert out.count("ShapePoint sp_") == 5
+
+    def test_polygon_outside_terrain_is_skipped(self, generator_factory):
+        # Identity transformer × 1000: this polygon ends up at (10000, 10000) etc.
+        # Terrain is 4096m wide → fully out of bounds.
+        far_ring = [[10.0, 10.0], [11.0, 10.0], [11.0, 11.0], [10.0, 11.0], [10.0, 10.0]]
+        gen = generator_factory(forest_features={
+            "type": "FeatureCollection",
+            "features": [_polygon_feature([far_ring], type="forest")],
+        })
+        out = gen._generate_vegetation_layer()
+        assert "SplineShapeEntity" not in out
+        assert "// No forest polygons" in out
+
+    def test_no_transformer_emits_friendly_comment(self):
+        from services.enfusion_project_generator import EnfusionProjectGenerator
+        gen = EnfusionProjectGenerator(
+            map_name="TestMap",
+            metadata=_metadata_for_4km_terrain(),
+            transformer=None,
+            forest_features={
+                "type": "FeatureCollection",
+                "features": [_polygon_feature(
+                    [[[0.5, 0.5], [1.0, 0.5], [1.0, 1.0], [0.5, 1.0], [0.5, 0.5]]],
+                    type="forest",
+                )],
+            },
+        )
+        out = gen._generate_vegetation_layer()
+        assert "Coordinate transformer unavailable" in out
+        assert "SplineShapeEntity" not in out
+
+
+# ---------------------------------------------------------------------------
+# Water layer tests
+# ---------------------------------------------------------------------------
+
+class TestWaterLayer:
+    def test_lake_polygon_is_emitted(self, generator_factory):
+        ring = [[0.5, 0.5], [1.5, 0.5], [1.5, 1.5], [0.5, 1.5], [0.5, 0.5]]
+        gen = generator_factory(water_features={
+            "type": "FeatureCollection",
+            "features": [_polygon_feature([ring], water_type="lake")],
+        })
+        out = gen._generate_water_layer()
+        assert "SplineShapeEntity Water_0 {" in out
+
+    def test_river_polygon_is_filtered_out(self, generator_factory):
+        # water_type=river is excluded — only standing-water types qualify
+        ring = [[0.5, 0.5], [1.5, 0.5], [1.5, 1.5], [0.5, 1.5], [0.5, 0.5]]
+        gen = generator_factory(water_features={
+            "type": "FeatureCollection",
+            "features": [_polygon_feature([ring], water_type="river")],
+        })
+        out = gen._generate_water_layer()
+        assert "SplineShapeEntity" not in out
+        assert "// No standing-water polygons" in out
+
+    def test_mixed_features_only_emits_lake_like_polygons(self, generator_factory):
+        lake_ring = [[0.5, 0.5], [1.5, 0.5], [1.5, 1.5], [0.5, 1.5], [0.5, 0.5]]
+        pond_ring = [[2.0, 2.0], [2.5, 2.0], [2.5, 2.5], [2.0, 2.5], [2.0, 2.0]]
+        river_ring = [[3.0, 3.0], [3.5, 3.0], [3.5, 3.5], [3.0, 3.5], [3.0, 3.0]]
+        gen = generator_factory(water_features={
+            "type": "FeatureCollection",
+            "features": [
+                _polygon_feature([lake_ring], water_type="lake"),
+                _polygon_feature([pond_ring], water_type="pond"),
+                _polygon_feature([river_ring], water_type="river"),
+            ],
+        })
+        out = gen._generate_water_layer()
+        assert "SplineShapeEntity Water_0 {" in out
+        assert "SplineShapeEntity Water_1 {" in out
+        assert "SplineShapeEntity Water_2 {" not in out
+
+    def test_no_water_features_emits_empty_message(self, generator_factory):
+        gen = generator_factory(water_features=None)
+        out = gen._generate_water_layer()
+        assert "// Water layer" in out
+        assert "// No standing-water polygons" in out
+        assert "SplineShapeEntity" not in out


### PR DESCRIPTION
## Summary

`vegetation.layer` and `water.layer` used to be 3-line placeholder comments telling the user to manually draw a closed Spline for every forest and lake polygon, then drag a Forest/Lake Generator prefab onto each one. For a typical Swedish map (272 forest areas + ~10 standing-water polygons in the user's recent generation), that's hundreds of splines to hand-draw in the World Editor.

This PR makes both layers self-populating: each polygon's exterior ring is projected to local terrain coordinates with elevation sampling, clipped to the terrain bounds, and emitted as a closed `SplineShapeEntity` — using the same proven format as the existing road splines.

The user's remaining work shrinks to **dragging a generator prefab onto each pre-drawn spline**; the tedious spline-drawing is done.

## What's intentionally NOT in this PR

Auto-attaching the actual `Forest Generator` / `Lake Generator` prefab as a child entity. The exact Enfusion text-serialisation format for parent-child entities isn't documented in the codebase, and silently producing broken layers would be worse than leaving the prefab drop manual. A future PR can add this once we have a known-good example layer file from a Workbench project with hand-placed generators.

## Edge cases handled

- **Polygon holes** (interior rings) are dropped — closed splines can't represent them. The earlier v1.0.5 fix to surface masks already correctly carves the islands out of the water mask; the lake spline just covers the outer boundary, and the user can add ground cutouts manually if a generator over-fills.
- **MultiPolygon** features emit one spline per sub-polygon's exterior ring.
- **Out-of-bounds polygons** (fewer than 3 in-bounds points after clipping) are skipped.
- **Wide rivers tagged as polygons** are filtered out of the water layer (water_type filter to lake/pond/reservoir/water only) so they don't get a Lake Generator.
- **No transformer / no features** falls back to a clear comment in the layer file.

## Test plan

- [x] 10 new tests in `tests/test_enfusion_vegetation_water_layers.py`: empty inputs, single polygon, multipolygon, polygon-with-holes drops the hole, out-of-bounds skipped, no-transformer fallback, lake-only emission, river filter
- [x] Full suite: 126 → 136 passing, 24 pre-existing local-env failures unchanged
- [ ] Smoke test: regenerate the Östersund map; confirm `Worlds/SE_*_vegetation.layer` is now ~hundreds of KB instead of 215 bytes, and `Worlds/SE_*_water.layer` has 1+ `SplineShapeEntity Water_*` blocks
- [ ] Smoke test: open the generated project in Enfusion Workbench and confirm the splines show up on the vegetation and water layers in the right shapes
- [ ] Optional: drag an `FG_PineForest_*` prefab onto one of the forest splines and confirm a forest spawns

🤖 Generated with [Claude Code](https://claude.com/claude-code)