### PR TITLE
Fix DK WCS timeouts by chunking requests at 2 km per axis (#42)

### DIFF
--- a/webapp/config/elevation.py
+++ b/webapp/config/elevation.py
@@ -75,6 +75,12 @@ ELEVATION_CONFIGS: dict[str, CountryElevationConfig] = {
         auth_env_var="DATAFORSYNINGEN_TOKEN",
         format="GTiff",  # Verified from DescribeCoverage: only supported format is "GTiff" (not "image/tiff")
         max_request_size=8192,  # Conservative limit for 0.4m data; 8192px = ~3.2km per axis
+        # The Dataforsyningen WCS upstream has a ~10s proxy timeout. A single
+        # 5km+ request over 0.4m native data (>200M source pixels) reliably
+        # returns 504 Gateway Timeout — see GitHub issue #42. Chunk to 2 km
+        # per axis (matches Norway's NHM-DTM at 1m) so each tile's server
+        # work stays within the timeout window.
+        max_area_m=2000,
     ),
     "SE": CountryElevationConfig(
         name="Sweden",

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -41,7 +41,7 @@ configure_gdal_threading()
 # Application version (for cache busting)
 # ===========================================================================
 
-APP_VERSION = "1.0.6"  # Increment when static files change
+APP_VERSION = "1.0.7"  # Increment when static files change
 
 # ===========================================================================
 # FastAPI app


### PR DESCRIPTION
## Summary

Closes #42. Selecting any Denmark area larger than ~3 km on either axis reliably returned **504 Gateway Timeout** from `api.dataforsyningen.dk` after three exponential-backoff retries (~45 s wasted before the AWS COP30 fallback kicked in).

## Root cause

The Dataforsyningen WCS upstream has a ~10 s proxy timeout. A single oversized request over 0.4 m native data — for the issue's 5.7 km × 5.7 km bbox that's >200 M source pixels the server has to read and resample — can't render within that window.

DK was the **only** high-res country WCS without `max_area_m` set. NO (2 km), EE (4 km), FI (10 km), and PL (5 km) all had chunking configured; DK was sending one giant request and timing out.

## Fix

Add `max_area_m=2000` to the DK config in [`webapp/config/elevation.py`](https://github.com/tubalainen/arma_reforger_base_map_generator_ng/blob/main/webapp/config/elevation.py). The existing chunked-fetch plumbing in `services/elevation_service.py` (already used by the other 4 countries) handles the rest — a 5.7 km selection becomes 9× ~2 km tiles instead of one impossible request, each tile small enough for the server to render within its 10 s window.

Choice of 2 km matches Norway's NHM-DTM, which serves 1 m data and has a similar dimensionLimit profile.

## Test plan

- [x] No regressions: 136 passed (unchanged), 24 pre-existing local-env failures (unchanged)
- [ ] Smoke test: regenerate the failing DK selection from #42 (~5.7 km × 5.7 km around Vejle area) and confirm the elevation source in `metadata.json` is `Denmark (0.4 m)` rather than `Copernicus DEM GLO-30 (AWS Open Data)`
- [ ] Smoke test: small DK selection (~1 km, single tile) still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)