### PR TITLE
Activity Log mirrors docker logs in real time (#41)

### DIFF
--- a/webapp/main.py
+++ b/webapp/main.py
@@ -34,6 +34,12 @@ logging.basicConfig(
 )
 logger = logging.getLogger("main")
 
+# Tee app log records into the active job's activity log so the frontend
+# panel mirrors `docker compose logs -f`.
+from services.job_log_handler import install_job_log_handler
+
+install_job_log_handler()
+
 # Enable multi-threaded GDAL for rasterio.warp.reproject operations
 configure_gdal_threading()
 
@@ -41,7 +47,7 @@ configure_gdal_threading()
 # Application version (for cache busting)
 # ===========================================================================
 
-APP_VERSION = "1.0.7"  # Increment when static files change
+APP_VERSION = "1.0.8"  # Increment when static files change
 
 # ===========================================================================
 # FastAPI app
@@ -446,12 +452,17 @@ async def start_generation(
 
 
 @app.get("/status/{job_id}")
-async def get_job_status_public(job_id: str):
+async def get_job_status_public(job_id: str, since: int = 0):
     """
     Get the current status and progress of a generation job (PUBLIC endpoint).
 
     This endpoint is accessible via Cloudflare tunnel and does NOT require
     authentication. It's used for polling job progress from the frontend.
+
+    The optional `since` query parameter is the index of the next log entry
+    the client wants. The response slices `logs` to entries from that index
+    forward and reports `logs_total` so the client can advance its cursor.
+    This keeps poll payloads small under fast polling and long log streams.
     """
     from services.map_generator import get_job
 
@@ -463,6 +474,16 @@ async def get_job_status_public(job_id: str):
         raise HTTPException(status_code=404, detail="Job not found")
 
     job_data = job.to_dict()
+
+    logs = job_data.get("logs") or []
+    total = len(logs)
+    if since < 0:
+        since = 0
+    if since > total:
+        since = total
+    job_data["logs"] = logs[since:]
+    job_data["logs_total"] = total
+    job_data["logs_since"] = since
 
     # Add retention information if cleanup is scheduled
     with _cleanups_lock:

--- a/webapp/services/job_log_handler.py
+++ b/webapp/services/job_log_handler.py
@@ -1,0 +1,104 @@
+"""
+Tee Python `logging` records from app modules into the active job's
+activity log so the frontend Activity Log mirrors `docker compose logs`.
+
+A ContextVar tracks the current job for the running pipeline. The handler
+inspects each emitted record, filters to app loggers, formats it as the
+same {timestamp, level, message} dict used by `MapGenerationJob.add_log`,
+and appends to that job's logs list. Because ContextVar is propagated by
+asyncio tasks and `asyncio.to_thread`/anyio worker threads, log records
+from synchronous code dispatched off the event loop also reach the right job.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextvars import ContextVar
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from services.map_generator import MapGenerationJob
+
+
+# Logger name prefixes whose records should be teed into job.logs.
+# Excludes uvicorn, urllib3, asyncio, rasterio internals, etc.
+_APP_LOGGER_PREFIXES = ("main", "services.", "middleware.")
+_APP_LOGGER_EXACT = {"main", "services", "middleware"}
+
+# Hard cap on per-job log entries to prevent runaway memory if a service
+# spins in a tight logging loop. Jobs are short-lived (cleaned up after 10
+# minutes); this just protects against pathological cases.
+MAX_LOGS_PER_JOB = 5000
+
+# Map Python logging levels to the frontend's level names (info/success/warning/error).
+_LEVEL_MAP = {
+    logging.DEBUG: "info",
+    logging.INFO: "info",
+    logging.WARNING: "warning",
+    logging.ERROR: "error",
+    logging.CRITICAL: "error",
+}
+
+
+current_job_var: ContextVar[Optional["MapGenerationJob"]] = ContextVar(
+    "current_job", default=None
+)
+
+
+def _is_app_logger(name: str) -> bool:
+    if name in _APP_LOGGER_EXACT:
+        return True
+    return any(name.startswith(prefix) for prefix in _APP_LOGGER_PREFIXES)
+
+
+class JobLogHandler(logging.Handler):
+    """Append matching log records to the current job's activity log."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        job = current_job_var.get()
+        if job is None:
+            return
+        if not _is_app_logger(record.name):
+            return
+        try:
+            message = record.getMessage()
+        except Exception:
+            return
+
+        # Strip the `[job_id_prefix] ` tag that orchestrator log lines include —
+        # it's redundant in the per-job activity log.
+        job_id_tag = f"[{job.job_id}] "
+        if message.startswith(job_id_tag):
+            message = message[len(job_id_tag):]
+        else:
+            short_tag = f"[{job.job_id[:8]}"
+            if message.startswith(short_tag):
+                end = message.find("] ")
+                if end != -1:
+                    message = message[end + 2:]
+
+        entry = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "level": _LEVEL_MAP.get(record.levelno, "info"),
+            "message": message,
+        }
+        logs = job.logs
+        logs.append(entry)
+        overflow = len(logs) - MAX_LOGS_PER_JOB
+        if overflow > 0:
+            del logs[:overflow]
+
+
+_installed = False
+
+
+def install_job_log_handler(level: int = logging.INFO) -> JobLogHandler:
+    """Attach the handler to the root logger. Idempotent."""
+    global _installed
+    handler = JobLogHandler(level=level)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    if not _installed:
+        logging.getLogger().addHandler(handler)
+        _installed = True
+    return handler

--- a/webapp/services/map_generator.py
+++ b/webapp/services/map_generator.py
@@ -657,9 +657,15 @@ async def run_generation(job: MapGenerationJob):
     manages progress tracking and data flow between steps.
     """
     from config import OUTPUT_DIR
+    from services.job_log_handler import current_job_var
 
     output_dir = OUTPUT_DIR / job.job_id
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Bind this job to the current async context so JobLogHandler can route
+    # every logger.* call from app modules into job.logs. The token is reset
+    # in the outer finally block.
+    job_token = current_job_var.set(job)
 
     try:
         job.status = "running"
@@ -1187,3 +1193,5 @@ async def run_generation(job: MapGenerationJob):
         job.status = "failed"
         job.current_step = f"Error: {str(e)}"
         job.errors.append(str(e))
+    finally:
+        current_job_var.reset(job_token)

--- a/webapp/static/js/app.js
+++ b/webapp/static/js/app.js
@@ -195,7 +195,9 @@ let currentAccessToken = null;  // Access token for downloads
 let pollInterval = null;
 let lastLoggedStepCount = 0;
 let lastCurrentStep = '';
-let lastDisplayedLogCount = 0;
+// Cursor: index of the next log entry we want from the server.
+// Server returns logs[since:], so we advance by the number of entries received.
+let logsSinceCursor = 0;
 
 // ===========================================================================
 // Event handlers
@@ -483,8 +485,9 @@ function startPolling(jobId) {
 
     pollInterval = setInterval(async () => {
         try {
-            // Use public status endpoint that doesn't require auth
-            const resp = await fetch(`/status/${jobId}`);
+            // Use public status endpoint that doesn't require auth.
+            // Pass the log cursor so the server only returns new entries.
+            const resp = await fetch(`/status/${jobId}?since=${logsSinceCursor}`);
             const job = await resp.json();
 
             updateProgress(job);
@@ -506,7 +509,7 @@ function startPolling(jobId) {
         } catch (err) {
             console.error('Polling error:', err);
         }
-    }, 1500);
+    }, 500);
 }
 
 // ===========================================================================
@@ -552,7 +555,7 @@ function showProgress() {
     clearConsoleLog();
     lastLoggedStepCount = 0;
     lastCurrentStep = '';
-    lastDisplayedLogCount = 0;
+    logsSinceCursor = 0;
     addConsoleLog('Map generation job started', 'info');
 }
 
@@ -566,14 +569,14 @@ function updateProgress(job) {
     bar.style.width = job.progress + '%';
     bar.textContent = job.progress + '%';
 
-    // Display new log messages from job.logs
-    if (job.logs && Array.isArray(job.logs)) {
-        // Add only new log entries that we haven't displayed yet
-        for (let i = lastDisplayedLogCount; i < job.logs.length; i++) {
-            const logEntry = job.logs[i];
+    // Display new log messages from job.logs.
+    // The server already sliced these to entries since `logsSinceCursor`,
+    // so every entry here is new — append them all and advance the cursor.
+    if (job.logs && Array.isArray(job.logs) && job.logs.length > 0) {
+        for (const logEntry of job.logs) {
             addConsoleLog(logEntry.message, logEntry.level);
         }
-        lastDisplayedLogCount = job.logs.length;
+        logsSinceCursor += job.logs.length;
     }
 
     document.getElementById('progress-step').textContent = job.current_step;


### PR DESCRIPTION
## Summary

- Tee Python logger output from `main` / `services.*` / `middleware.*` modules into the active job's `logs` via a custom `JobLogHandler` bound by `ContextVar` to the running pipeline
- Activity Log panel now reflects the same firehose as `docker compose logs -f` (subtask start, mirror retries, fallback decisions) instead of just the ~25 high-level orchestrator milestones
- Cursor-based polling: `GET /status/{job_id}?since=N` slices logs server-side; frontend poll interval drops 1500ms -> 500ms
- Bumps `APP_VERSION` 1.0.7 -> 1.0.8 to bust the static asset cache

Closes #41

## Test plan

- [ ] Start a generation and confirm Activity Log shows live updates from elevation_service / osm_service / heightmap_generator etc., not just the orchestrator's `add_log` calls
- [ ] Confirm UI mirrors what `docker compose logs -f arma-map-generator` prints
- [ ] Confirm poll cadence ~500ms in browser devtools network tab
- [ ] Confirm payload size stays small as logs accumulate (only delta returned)
- [ ] Confirm completion / failure paths still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)