### PR TITLE
Unify polygon, rectangle and square in a single draw toolbar (#40)

### DIFF
--- a/webapp/main.py
+++ b/webapp/main.py
@@ -47,7 +47,7 @@ configure_gdal_threading()
 # Application version (for cache busting)
 # ===========================================================================
 
-APP_VERSION = "1.0.8"  # Increment when static files change
+APP_VERSION = "1.0.9"  # Increment when static files change
 
 # ===========================================================================
 # FastAPI app

--- a/webapp/static/css/style.css
+++ b/webapp/static/css/style.css
@@ -355,6 +355,16 @@ body {
     background-size: 270px 30px !important;
 }
 
+/* Custom Square draw tool — uses an inline SVG icon so it sits visually
+ * with polygon/rectangle/edit/delete in the same toolbar (issue #40). */
+.leaflet-draw-toolbar a.leaflet-draw-draw-square,
+.leaflet-retina .leaflet-draw-toolbar a.leaflet-draw-draw-square {
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18'><rect x='3' y='3' width='12' height='12' fill='none' stroke='%23464646' stroke-width='1.6'/><text x='9' y='12' font-family='Helvetica,Arial,sans-serif' font-size='6' font-weight='700' fill='%23464646' text-anchor='middle'>1:1</text></svg>") !important;
+    background-size: 18px 18px !important;
+    background-position: center center !important;
+    background-repeat: no-repeat !important;
+}
+
 .leaflet-draw-toolbar {
     border: 1px solid var(--border-default) !important;
     border-radius: 6px;

--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -38,7 +38,9 @@
                 <div class="sidebar-section">
                     <h6><i class="bi bi-vector-pen"></i> Area Selection</h6>
                     <p class="small mb-2">
-                        Use the <strong>⬜ Square</strong> tool (recommended) or polygon/rectangle tools to select your area.
+                        Use one of the drawing tools on the map &mdash;
+                        <strong>polygon</strong>, <strong>rectangle</strong>, or
+                        <strong>1:1 square</strong> (recommended for Enfusion).
                     </p>
                     <div id="selection-info" class="d-none">
                         <table class="table table-sm table-dark mb-1">
@@ -65,7 +67,7 @@
                     </div>
                     <div id="no-selection" class="text-center py-3">
                         <i class="bi bi-hand-index-thumb"></i>
-                        <p class="small mt-1">Click the polygon tool to start</p>
+                        <p class="small mt-1">Pick a drawing tool to start</p>
                     </div>
                 </div>
 

--- a/webapp/static/js/app.js
+++ b/webapp/static/js/app.js
@@ -47,19 +47,20 @@ map.addLayer(drawnItems);
 // Square drawing tool (custom Leaflet.Draw handler)
 // Forces 1:1 aspect ratio in metres so Enfusion heightmap isn't distorted.
 // ---------------------------------------------------------------------------
+const SHAPE_STYLE = {
+    color: '#26cd4d',
+    fillColor: '#26cd4d',
+    fillOpacity: 0.15,
+    weight: 2,
+};
+
 L.Draw.Square = L.Draw.Rectangle.extend({
     statics: {
         TYPE: 'square'
     },
 
     options: {
-        shapeOptions: {
-            color: '#539bf5',
-            fillColor: '#539bf5',
-            fillOpacity: 0.15,
-            weight: 2,
-            dashArray: '6, 4',
-        },
+        shapeOptions: { ...SHAPE_STYLE },
         metric: true,
     },
 
@@ -69,26 +70,20 @@ L.Draw.Square = L.Draw.Rectangle.extend({
     },
 
     _drawShape: function (latlng) {
-        // Get the start point and current mouse position
         const start = this._startLatLng;
         if (!start) return;
 
-        // Compute deltas in degrees
         const dLat = latlng.lat - start.lat;
         const dLng = latlng.lng - start.lng;
 
-        // Convert to approximate metres for squaring
         const midLat = (start.lat + latlng.lat) / 2;
         const mPerDegLat = 111320;
         const mPerDegLng = 111320 * Math.cos(midLat * Math.PI / 180);
 
         const widthM = Math.abs(dLng) * mPerDegLng;
         const heightM = Math.abs(dLat) * mPerDegLat;
-
-        // Use the larger dimension to make it square
         const sizeM = Math.max(widthM, heightM);
 
-        // Convert back to degree deltas, preserving direction
         const halfLngSpan = (sizeM / mPerDegLng);
         const halfLatSpan = (sizeM / mPerDegLat);
 
@@ -109,32 +104,22 @@ L.Draw.Square = L.Draw.Rectangle.extend({
     },
 });
 
-// Register the square draw handler with Leaflet.Draw toolbar
 L.drawLocal.draw.toolbar.buttons.square = 'Draw a square area (recommended)';
 
-// Custom toolbar that includes our Square tool
+// Standard draw toolbar (polygon + rectangle + edit/remove). The Square
+// button is injected into the same toolbar below so all three drawing
+// tools live in one uniform control group.
 const drawControl = new L.Control.Draw({
     position: 'topleft',
     draw: {
         polygon: {
             allowIntersection: false,
             drawError: { color: '#f85149', timeout: 1000 },
-            shapeOptions: {
-                color: '#26cd4d',
-                fillColor: '#26cd4d',
-                fillOpacity: 0.15,
-                weight: 2,
-            },
+            shapeOptions: { ...SHAPE_STYLE },
         },
         rectangle: {
-            shapeOptions: {
-                color: '#26cd4d',
-                fillColor: '#26cd4d',
-                fillOpacity: 0.15,
-                weight: 2,
-            },
+            shapeOptions: { ...SHAPE_STYLE },
         },
-        // Disable other draw tools
         polyline: false,
         circle: false,
         circlemarker: false,
@@ -147,42 +132,27 @@ const drawControl = new L.Control.Draw({
 });
 map.addControl(drawControl);
 
-// Add a separate custom button for Square drawing above the draw toolbar
-const squareControl = L.Control.extend({
-    options: { position: 'topleft' },
-    onAdd: function (map) {
-        const container = L.DomUtil.create('div', 'leaflet-bar leaflet-draw-toolbar');
-        const link = L.DomUtil.create('a', 'leaflet-draw-draw-square', container);
-        link.href = '#';
-        link.title = 'Draw a square area (recommended for Enfusion)';
-        link.innerHTML = '<span style="font-size:14px;font-weight:bold;line-height:26px;">⬜</span>';
-        link.style.display = 'flex';
-        link.style.alignItems = 'center';
-        link.style.justifyContent = 'center';
-        link.style.width = '26px';
-        link.style.height = '26px';
-        link.style.cursor = 'pointer';
+// Inject a Square button into the same toolbar row as polygon and rectangle.
+// Using the existing Leaflet.Draw toolbar gives us identical sizing, borders,
+// and hover styling — see issue #40.
+(function addSquareToolButton() {
+    const rectButton = document.querySelector('.leaflet-draw-draw-rectangle');
+    if (!rectButton || !rectButton.parentNode) return;
+    if (rectButton.parentNode.querySelector('.leaflet-draw-draw-square')) return;
 
-        L.DomEvent.on(link, 'click', function (e) {
-            L.DomEvent.stop(e);
-            // Start the square draw handler
-            const squareDraw = new L.Draw.Square(map, {
-                shapeOptions: {
-                    color: '#539bf5',
-                    fillColor: '#539bf5',
-                    fillOpacity: 0.15,
-                    weight: 2,
-                    dashArray: '6, 4',
-                },
-            });
-            squareDraw.enable();
-        });
+    const link = document.createElement('a');
+    link.className = 'leaflet-draw-draw-square';
+    link.href = '#';
+    link.title = 'Draw a square area (recommended for Enfusion)';
+    link.setAttribute('role', 'button');
 
-        L.DomEvent.disableClickPropagation(container);
-        return container;
-    },
-});
-map.addControl(new squareControl());
+    L.DomEvent.on(link, 'click', function (e) {
+        L.DomEvent.stop(e);
+        new L.Draw.Square(map, { shapeOptions: { ...SHAPE_STYLE } }).enable();
+    });
+
+    rectButton.parentNode.insertBefore(link, rectButton.nextSibling);
+})();
 
 // ===========================================================================
 // State


### PR DESCRIPTION
## Summary

- Move the Square tool from its own oddly-styled `L.Control` (purple ⬜ emoji button below the main toolbar) into the standard Leaflet.Draw toolbar so polygon, rectangle, and square share one uniform group with identical sizing, borders, and hover styling
- Square shape colour switched from blue dashed to the same green as polygon/rectangle (`#26cd4d`)
- New CSS rule gives the Square button a clean inline-SVG icon: outlined square with a small **1:1** label, matching the dark sprite style of the rest of the toolbar
- Sidebar copy updated to mention all three tools
- Bumps `APP_VERSION` 1.0.8 -> 1.0.9 to bust the static asset cache

Closes #40

## Test plan

- [ ] Map shows ONE toolbar group with: polygon, rectangle, square — followed by the edit/delete group below
- [ ] Square button icon (outlined square with "1:1") is visually consistent with polygon/rectangle
- [ ] Clicking square enables drawing; resulting shape is forced to 1:1 in metres
- [ ] Drawn square appears in the same green as polygon/rectangle
- [ ] Edit and delete still work for shapes drawn with the square tool
- [ ] Sidebar copy is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)