### PR TITLE
Phase 2: buildings layer + L12 road de-conflict (v1.2.0)

### DIFF
--- a/webapp/config/__init__.py
+++ b/webapp/config/__init__.py
@@ -9,6 +9,7 @@ Configuration is split into focused modules:
 - countries: COUNTRY_BOUNDS, COUNTRY_CRS, COUNTRY_NAMES, TREELINE_ELEVATION
 - elevation: CountryElevationConfig, ELEVATION_CONFIGS, EU_DEM_CONFIG, API keys
 - roads: ROAD_DEFAULT_SURFACE, OSM_ROAD_TAGS, ROAD_DEFAULT_WIDTH, ROAD_ENFUSION_PREFAB, KNOWN_ROAD_PREFABS, validate_road_prefab
+- buildings: BUILDING_PREFAB_BASE, KNOWN_BUILDING_PREFABS, validate_building_prefab
 - surfaces: SURFACE_CLASSES
 - endpoints: OVERPASS_*, OPENTOPOGRAPHY_*, SENTINEL2_*, CORINE_*, TREE_COVER_*
 - terrain: MAX_TERRAIN_SIZE, DEFAULT_GRID_CELL_SIZE, height scale defaults
@@ -37,6 +38,11 @@ from config.roads import (
     ROAD_DEFAULT_SURFACE, OSM_ROAD_TAGS,
     ROAD_DEFAULT_WIDTH, ROAD_ENFUSION_PREFAB,
     KNOWN_ROAD_PREFABS, validate_road_prefab,
+)
+
+# Building classification
+from config.buildings import (
+    BUILDING_PREFAB_BASE, KNOWN_BUILDING_PREFABS, validate_building_prefab,
 )
 
 # Surface classes

--- a/webapp/config/buildings.py
+++ b/webapp/config/buildings.py
@@ -1,0 +1,56 @@
+"""
+Building classification + Enfusion prefab catalog.
+
+Same architecture as ``config.roads``: a known-good prefab catalog plus a
+validator. The audit (Phase 2 / task A2) explicitly flagged that we do not
+ship a verified list of stock-Reforger ``Building_*.et`` prefab paths, so
+this catalog starts EMPTY.
+
+When the catalog is empty the buildings layer falls back to emitting a
+visible footprint outline per real-world building (the same closed-spline
+pattern used for forests/lakes), giving the user pre-positioned markers to
+drag prefabs onto. Once the user (or a future contributor with Workbench
+access) confirms prefab paths, populate ``KNOWN_BUILDING_PREFABS`` and the
+generator automatically upgrades to fully auto-placed entities — no code
+change required.
+
+Building category labels come from ``feature_extractor.extract_building_features``
+which maps OSM ``building`` tags to the categories below.
+"""
+
+from __future__ import annotations
+
+# Path under the ArmaReforger data root where building prefabs live.
+# Kept generic on purpose — confirm against your install before committing
+# specific subdirectories to ``KNOWN_BUILDING_PREFABS``.
+BUILDING_PREFAB_BASE = "Prefabs/Structures"
+
+# Known-good (category -> .et path) mappings. Empty by default so we never
+# fabricate paths that fail to resolve in Workbench. Add an entry only after
+# you have confirmed the path exists in a stock Reforger install.
+#
+# Example future entry:
+#     "Building_House": "Prefabs/Structures/Civilian/SmallHouse_01.et",
+#
+# The category strings are produced by feature_extractor.extract_building_features
+# and currently include:
+#     Building_Apartments, Building_Barn, Building_Church, Building_Commercial,
+#     Building_Garage, Building_Generic, Building_House, Building_Industrial,
+#     Building_Residential, Building_Shed
+KNOWN_BUILDING_PREFABS: dict[str, str] = {}
+
+
+def validate_building_prefab(category: str | None) -> str | None:
+    """
+    Look up the verified Enfusion prefab path for a building category.
+
+    Returns the full ``Prefabs/.../Whatever.et`` string if the category has a
+    confirmed mapping in ``KNOWN_BUILDING_PREFABS``, otherwise returns ``None``.
+
+    The buildings-layer emitter uses ``None`` as a signal to fall back to
+    footprint-outline mode (a visible spline marker the user can wire
+    manually) rather than fabricating a prefab path.
+    """
+    if not category:
+        return None
+    return KNOWN_BUILDING_PREFABS.get(category)

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -47,7 +47,7 @@ configure_gdal_threading()
 # Application version (for cache busting)
 # ===========================================================================
 
-APP_VERSION = "1.0.9"  # Increment when static files change
+APP_VERSION = "1.2.0"  # Increment when static files change OR a new release ships
 
 # ===========================================================================
 # FastAPI app

--- a/webapp/services/enfusion_project_generator.py
+++ b/webapp/services/enfusion_project_generator.py
@@ -20,6 +20,8 @@ import re
 from pathlib import Path
 from typing import Optional
 
+import math
+
 from config.enfusion import (
     ARMA_REFORGER_GUID,
     PLATFORM_CONFIGS,
@@ -116,6 +118,7 @@ class EnfusionProjectGenerator:
         elevation_array=None,
         forest_features: Optional[dict] = None,
         water_features: Optional[dict] = None,
+        building_data: Optional[dict] = None,
     ):
         """
         Initialize the project generator.
@@ -133,6 +136,14 @@ class EnfusionProjectGenerator:
             water_features: Optional GeoJSON FeatureCollection of water polygons
                             (from osm_data["water"]). Same treatment for water.layer
                             (drag a Lake Generator prefab onto each spline).
+            building_data: Optional dict from feature_extractor.extract_building_features
+                           with a "buildings" list. When supplied, buildings.layer is
+                           populated with one entity per building (positioned prefab
+                           instance if a validated Enfusion prefab is in
+                           config.buildings.KNOWN_BUILDING_PREFABS, otherwise a
+                           closed-spline footprint marker the user wires manually).
+                           Buildings whose centroid falls inside an asphalt-road
+                           buffer are dropped (audit task L12).
         """
         self.map_name = sanitize_project_name(map_name)
         self.metadata = metadata
@@ -141,6 +152,7 @@ class EnfusionProjectGenerator:
         self.elevation_array = elevation_array
         self.forest_features = forest_features
         self.water_features = water_features
+        self.building_data = building_data
 
         # Generate a deterministic GUID from the map name
         self.project_guid = generate_guid(self.map_name)
@@ -276,6 +288,11 @@ class EnfusionProjectGenerator:
             self._generate_water_layer()
         )
 
+        files["buildings.layer"] = self._write_file(
+            worlds_dir / f"{self.map_name}_buildings.layer",
+            self._generate_buildings_layer()
+        )
+
         # Mission header
         files["mission.conf"] = self._write_file(
             missions_dir / f"{self.map_name}.conf",
@@ -342,6 +359,9 @@ Layer vegetation {{
 }}
 Layer water {{
  Index 5
+}}
+Layer buildings {{
+ Index 6
 }}
 '''
 
@@ -671,6 +691,229 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['destruction']} {{
         )
         return header + body
 
+    # -----------------------------------------------------------------------
+    # Buildings layer (Phase 2 / task A2 + L12)
+    # -----------------------------------------------------------------------
+
+    def _generate_buildings_layer(self) -> str:
+        """
+        Emit one entity per extracted building.
+
+        Two emission modes per building, decided by whether
+        ``config.buildings.KNOWN_BUILDING_PREFABS`` has a verified Enfusion
+        prefab path for the building's category:
+
+        * **Validated prefab** → emit a positioned prefab instance using the
+          ``${guid}path/to/prefab.et { coords X Y Z }`` syntax (the same
+          pattern the managers / roads layers use successfully).
+        * **No validated prefab** (the default until the user confirms paths
+          for a stock Reforger install) → emit a closed-spline footprint
+          marker on the building's exterior ring. The user sees the actual
+          building outline in the World Editor and drags a prefab onto it.
+
+        Buildings whose centroid falls inside the asphalt-road exclusion
+        zone (half road width + 1.5 m safety) are dropped (audit task L12)
+        — placing buildings on top of a generated road would produce visible
+        Z-fighting and block traffic.
+        """
+        header = (
+            "// Buildings layer — one entity per extracted OSM building.\n"
+            "// Buildings with a verified Enfusion prefab in\n"
+            "//   config/buildings.py::KNOWN_BUILDING_PREFABS\n"
+            "// are emitted as auto-positioned prefab instances. Buildings\n"
+            "// whose category has no verified prefab are emitted as closed\n"
+            "// footprint splines — drag a Building_*.et prefab from\n"
+            "// Prefabs/Structures/ onto each spline to wire it up.\n"
+            "// Buildings overlapping asphalt roads are dropped (L12).\n"
+            "// Source data: Reference/osm_buildings.geojson and features.json.\n"
+        )
+
+        if not self.transformer:
+            return header + "// (Coordinate transformer unavailable — buildings cannot be placed.)\n"
+        if not self.building_data:
+            return header + "// No building data available.\n"
+
+        buildings = self.building_data.get("buildings", [])
+        if not buildings:
+            return header + "// No buildings found in this area.\n"
+
+        exclusion_zone = self._build_road_exclusion_zone()
+
+        entities: list[str] = []
+        skipped_road_overlap = 0
+        skipped_out_of_bounds = 0
+        prefab_count = 0
+        marker_count = 0
+
+        for building in buildings:
+            center_lonlat = building.get("center")
+            if not center_lonlat or len(center_lonlat) < 2:
+                continue
+            lon, lat = float(center_lonlat[0]), float(center_lonlat[1])
+
+            # L12 — drop buildings that would sit on top of an asphalt road.
+            if exclusion_zone is not None and self._point_inside_geometry(
+                lon, lat, exclusion_zone
+            ):
+                skipped_road_overlap += 1
+                continue
+
+            # Transform the centroid to terrain-local coords (with elevation
+            # sampling) for positioning the entity.
+            local_pts = self.transformer.transform_points(
+                [{"x": lon, "y": lat, "z": 0}],
+                elevation_array=self.elevation_array,
+            )
+            if not local_pts:
+                skipped_out_of_bounds += 1
+                continue
+            origin = local_pts[0]
+            margin = 1.0
+            if not (
+                -margin <= origin["x"] <= self.terrain_width + margin
+                and -margin <= origin["z"] <= self.terrain_depth + margin
+            ):
+                skipped_out_of_bounds += 1
+                continue
+
+            prefab_path = building.get("enfusion_prefab")
+            building_name_raw = building.get("name", "") or ""
+            building_name = building_name_raw.replace('"', "'")
+            building_type = building.get("building_type", "yes")
+            comment = (
+                f' // {building_name} ({building_type})'
+                if building_name
+                else f' // {building_type}'
+            )
+
+            if prefab_path:
+                prefab_ref = f"${{{ARMA_REFORGER_GUID}}}{prefab_path}"
+                entities.append(
+                    f'{prefab_ref} {{{comment}\n'
+                    f' coords {origin["x"]:.3f} {origin["y"]:.3f} {origin["z"]:.3f}\n'
+                    f'}}'
+                )
+                prefab_count += 1
+            else:
+                # Footprint marker: emit the exterior ring as a closed spline
+                # the user can right-click → Add Child Entity → BuildingEntity.
+                geom = building.get("geometry") or {}
+                ring = self._building_exterior_ring(geom)
+                if ring is None:
+                    # Fall back to a tiny spline at the centroid so the
+                    # building still appears in the editor hierarchy.
+                    ring = [
+                        [lon - 0.00001, lat - 0.00001],
+                        [lon + 0.00001, lat - 0.00001],
+                        [lon + 0.00001, lat + 0.00001],
+                        [lon - 0.00001, lat + 0.00001],
+                        [lon - 0.00001, lat - 0.00001],
+                    ]
+                entity = self._closed_spline_entity_from_ring(
+                    ring, "Building", len(entities), comment_suffix=comment
+                )
+                if entity is None:
+                    skipped_out_of_bounds += 1
+                    continue
+                entities.append(entity)
+                marker_count += 1
+
+        if skipped_road_overlap:
+            logger.info(
+                f"Buildings: dropped {skipped_road_overlap} that overlapped "
+                f"asphalt roads (L12 de-conflict)"
+            )
+        if skipped_out_of_bounds:
+            logger.info(
+                f"Buildings: dropped {skipped_out_of_bounds} that were "
+                f"outside terrain bounds or had no usable footprint"
+            )
+        logger.info(
+            f"Buildings layer: {prefab_count} auto-placed prefab instance(s), "
+            f"{marker_count} footprint marker(s)"
+        )
+
+        if not entities:
+            return header + "// No buildings remained after L12 filtering.\n"
+        return header + "\n".join(entities) + "\n"
+
+    def _build_road_exclusion_zone(self):
+        """
+        Build a single shapely geometry covering all asphalt road centerlines
+        buffered by half the road width plus a 1.5 m safety margin (L12).
+
+        Returns ``None`` if shapely is unavailable, no road data is provided,
+        or there are no asphalt roads in the area.
+        """
+        if not self.road_data:
+            return None
+        try:
+            from shapely.geometry import LineString
+            from shapely.ops import unary_union
+        except ImportError:  # pragma: no cover - shapely is a hard dep
+            logger.warning(
+                "shapely not available — skipping building/road L12 de-conflict"
+            )
+            return None
+
+        # Convert meter buffer widths to degrees using the area centroid's
+        # latitude. Errs on the larger-buffer side by dividing by the smaller
+        # m_per_deg value (longitude shrinks toward the poles).
+        bbox = self.metadata.get("input", {}).get("bbox", {}) or {}
+        center_lat = (bbox.get("south", 0) + bbox.get("north", 0)) / 2
+        m_per_deg_lat = 110540.0
+        m_per_deg_lon = 111320.0 * math.cos(math.radians(center_lat or 0.0))
+        smaller_m_per_deg = min(m_per_deg_lat, max(m_per_deg_lon, 1.0))
+        deg_per_m = 1.0 / smaller_m_per_deg
+
+        safety_margin_m = 1.5
+        buffered: list = []
+        for road in self.road_data.get("roads", []) or []:
+            if road.get("surface") != "asphalt":
+                continue
+            pts = road.get("spline_points", [])
+            if len(pts) < 2:
+                continue
+            try:
+                line = LineString([(float(p["x"]), float(p["y"])) for p in pts])
+            except (KeyError, ValueError, TypeError):
+                continue
+            try:
+                width_m = float(road.get("width_m", 4))
+            except (TypeError, ValueError):
+                width_m = 4.0
+            half_width_deg = (width_m / 2 + safety_margin_m) * deg_per_m
+            buffered.append(line.buffer(half_width_deg))
+
+        if not buffered:
+            return None
+        return unary_union(buffered)
+
+    @staticmethod
+    def _point_inside_geometry(lon: float, lat: float, geometry) -> bool:
+        """Cheap point-in-geometry test using shapely."""
+        try:
+            from shapely.geometry import Point
+        except ImportError:  # pragma: no cover
+            return False
+        try:
+            return geometry.contains(Point(lon, lat))
+        except Exception:  # pragma: no cover - defensive
+            return False
+
+    @staticmethod
+    def _building_exterior_ring(geom: dict) -> Optional[list]:
+        """Return the exterior ring of a Polygon or first-MultiPolygon geometry."""
+        if not geom:
+            return None
+        gtype = geom.get("type")
+        coords = geom.get("coordinates") or []
+        if gtype == "Polygon" and coords:
+            return coords[0]
+        if gtype == "MultiPolygon" and coords and coords[0]:
+            return coords[0][0]
+        return None
+
     def _polygon_features_to_splines(
         self,
         features: Optional[dict],
@@ -765,11 +1008,16 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['destruction']} {{
         ring: list[list[float]],
         entity_prefix: str,
         index: int,
+        comment_suffix: str = "",
     ) -> Optional[str]:
         """
         Project a single GeoJSON ring (list of [lon, lat] pairs) to a closed
         SplineShapeEntity. Returns None if the ring has fewer than 3 in-bounds
         points after clipping to the terrain.
+
+        ``comment_suffix`` is appended to the entity declaration line as a
+        trailing ``// ...`` comment so callers can label the spline (e.g. with
+        the OSM name + building type).
         """
         if len(ring) < 3:
             return None
@@ -814,7 +1062,7 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['destruction']} {{
             )
 
         return (
-            f'SplineShapeEntity {entity_prefix}_{index} {{\n'
+            f'SplineShapeEntity {entity_prefix}_{index} {{{comment_suffix}\n'
             f' coords {origin["x"]:.3f} {origin["y"]:.3f} {origin["z"]:.3f}\n'
             f' Points {{\n'
             + "\n".join(point_defs) + "\n"

--- a/webapp/services/feature_extractor.py
+++ b/webapp/services/feature_extractor.py
@@ -390,6 +390,13 @@ def extract_building_features(
 
         prefab_category = prefab_categories.get(building_type, "Building_Generic")
 
+        # Look up the verified Enfusion prefab path. None when the catalog
+        # doesn't have an entry for this category — the buildings-layer
+        # emitter falls back to a footprint-outline marker in that case
+        # rather than fabricating a path that fails to resolve in Workbench.
+        from config.buildings import validate_building_prefab
+        validated_prefab = validate_building_prefab(prefab_category)
+
         buildings.append({
             "osm_id": props.get("osm_id"),
             "name": props.get("name", ""),
@@ -399,6 +406,7 @@ def extract_building_features(
             "rotation_deg": rotation,
             "footprint_area_m2": footprint_area,
             "prefab_category": prefab_category,
+            "enfusion_prefab": validated_prefab,
             "geometry": geom,
         })
 

--- a/webapp/services/map_generator.py
+++ b/webapp/services/map_generator.py
@@ -1142,6 +1142,7 @@ async def run_generation(job: MapGenerationJob):
             elevation_array=heightmap_result.get("_elevation_array"),
             forest_features=osm_data.get("forests"),
             water_features=osm_data.get("water"),
+            building_data=features.get("buildings"),
         )
         enfusion_files = enfusion_gen.generate_all(output_dir, job=job)
 

--- a/webapp/services/setup_guide_generator.py
+++ b/webapp/services/setup_guide_generator.py
@@ -502,7 +502,35 @@ For each spline:
 3. Enable **Flatten By Bottom Plane** for natural water level
 
 > **Tip**: Water body coordinates in features.json are already in Enfusion
-> local metres."""
+> local metres.
+
+### Step 6.3: Buildings
+
+Your terrain has **{self.features.get('buildings', 0)}** building footprints
+extracted from OpenStreetMap. The buildings layer (`{self.map_name}_buildings.layer`)
+emits one entity per building, in one of two modes depending on whether the
+generator has a confirmed Enfusion prefab path for the building's category:
+
+- **Auto-placed** (when a verified prefab is configured for the category):
+  the entity is a positioned `Building_*.et` prefab instance — appears in
+  the editor at the correct position with no further wiring needed.
+- **Footprint marker** (default until prefab paths are confirmed): the
+  entity is a closed `SplineShapeEntity` tracing the building's exterior
+  ring. You can right-click the spline > Add Child Entity > **BuildingEntity**
+  and set the prefab from `Prefabs/Structures/`.
+
+Buildings whose centroid would have fallen on top of an asphalt road have
+been dropped automatically (so traffic/pathing isn't broken).
+
+> **To enable auto-placement for your install**: edit
+> `webapp/config/buildings.py::KNOWN_BUILDING_PREFABS` and add entries
+> mapping the category labels (e.g. `Building_House`,
+> `Building_Apartments`) to the actual `.et` paths from your stock
+> Reforger install. No code changes required — the layer generator will
+> pick up the catalog on the next map generation.
+
+> Source data: `Reference/osm_buildings.geojson` and `features.json`
+> (look for the `buildings` array)."""
 
     def _phase_testing(self) -> str:
         return f"""## Phase 7: Testing (5 minutes)

--- a/webapp/tests/test_enfusion_buildings_layer.py
+++ b/webapp/tests/test_enfusion_buildings_layer.py
@@ -1,0 +1,290 @@
+"""
+Tests for the Phase 2 buildings layer (audit task A2 + L12).
+
+The buildings layer emits one entity per OSM building, in one of two modes:
+
+* **Auto-placed prefab instance** when ``config.buildings.KNOWN_BUILDING_PREFABS``
+  has a verified path for the building's category. Uses the
+  ``${guid}path/to/prefab.et { coords X Y Z }`` syntax.
+* **Footprint-spline marker** when the catalog has no entry — emits a closed
+  ``SplineShapeEntity`` over the exterior ring so the user can manually wire
+  a building prefab as a child entity.
+
+Buildings whose centroid falls inside an asphalt-road exclusion zone (half
+road width + 1.5 m safety) are dropped (L12).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+WEBAPP_DIR = Path(__file__).parent.parent
+if str(WEBAPP_DIR) not in sys.path:
+    sys.path.insert(0, str(WEBAPP_DIR))
+
+
+class _IdentityTransformer:
+    """Multiplies WGS84 lon/lat by 1000 to get terrain-local x/z metres."""
+
+    def transform_points(self, points, elevation_array=None):
+        return [
+            {"x": round(p["x"] * 1000, 3), "y": 0.0, "z": round(p["y"] * 1000, 3)}
+            for p in points
+        ]
+
+
+def _metadata_for_4km_terrain() -> dict:
+    return {
+        "heightmap": {"dimensions": "2049x2049", "grid_cell_size_m": 2.0},
+        "elevation": {
+            "min_elevation_m": 0,
+            "max_elevation_m": 100,
+            "height_scale": 0.03125,
+            "height_offset": 0,
+        },
+        "input": {"bbox": {"south": 0.0, "north": 4.0, "west": 0.0, "east": 4.0}},
+    }
+
+
+def _building(idx, lon, lat, building_type="house", prefab=None, name=""):
+    """Synthetic building dict matching extract_building_features output."""
+    # Tiny 0.0001-degree square footprint around (lon, lat)
+    d = 0.0001
+    return {
+        "osm_id": 4000 + idx,
+        "name": name,
+        "building_type": building_type,
+        "height_m": 6,
+        "center": [lon, lat],
+        "rotation_deg": 0,
+        "footprint_area_m2": 100,
+        "prefab_category": f"Building_{building_type.capitalize()}",
+        "enfusion_prefab": prefab,
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [[
+                [lon - d, lat - d],
+                [lon + d, lat - d],
+                [lon + d, lat + d],
+                [lon - d, lat + d],
+                [lon - d, lat - d],
+            ]],
+        },
+    }
+
+
+def _asphalt_road(idx, lon_start, lat_start, lon_end, lat_end, width_m=6):
+    return {
+        "osm_id": 1000 + idx,
+        "name": f"Road_{idx}",
+        "highway_type": "primary",
+        "surface": "asphalt",
+        "width_m": width_m,
+        "is_bridge": False,
+        "is_tunnel": False,
+        "enfusion_prefab": "RG_Road_Asphalt_6m",
+        "spline_points": [
+            {"x": lon_start, "y": lat_start, "z": 0},
+            {"x": lon_end, "y": lat_end, "z": 0},
+        ],
+        "point_count": 2,
+    }
+
+
+@pytest.fixture
+def make_generator():
+    from services.enfusion_project_generator import EnfusionProjectGenerator
+
+    _SENTINEL = object()
+
+    def _make(buildings=_SENTINEL, roads=None):
+        if buildings is _SENTINEL:
+            building_data = None
+        elif buildings is None:
+            building_data = None
+        else:
+            building_data = {"buildings": list(buildings)}
+        return EnfusionProjectGenerator(
+            map_name="TestMap",
+            metadata=_metadata_for_4km_terrain(),
+            road_data={"roads": roads or []},
+            transformer=_IdentityTransformer(),
+            elevation_array=None,
+            building_data=building_data,
+        )
+    return _make
+
+
+def _shapely_available() -> bool:
+    try:
+        import shapely  # noqa: F401
+        from shapely.geometry import LineString  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+requires_shapely = pytest.mark.skipif(
+    not _shapely_available(),
+    reason="shapely not installed in this environment — L12 path is skipped at runtime too",
+)
+
+
+# ---------------------------------------------------------------------------
+# validate_building_prefab — Phase 2 honest "we don't fabricate paths" guard
+# ---------------------------------------------------------------------------
+
+class TestValidateBuildingPrefab:
+    def test_unknown_category_returns_none(self):
+        from config.buildings import validate_building_prefab
+        # Default catalog ships empty so every category is unknown.
+        assert validate_building_prefab("Building_House") is None
+
+    def test_none_input_returns_none(self):
+        from config.buildings import validate_building_prefab
+        assert validate_building_prefab(None) is None
+        assert validate_building_prefab("") is None
+
+    def test_known_category_returns_path(self, monkeypatch):
+        # Simulate a future expansion of the catalog.
+        from config import buildings as buildings_config
+        monkeypatch.setitem(
+            buildings_config.KNOWN_BUILDING_PREFABS,
+            "Building_House",
+            "Prefabs/Structures/Civilian/Test_House.et",
+        )
+        assert (
+            buildings_config.validate_building_prefab("Building_House")
+            == "Prefabs/Structures/Civilian/Test_House.et"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Buildings layer — emission modes
+# ---------------------------------------------------------------------------
+
+class TestBuildingsLayerEmission:
+    def test_no_building_data_emits_friendly_comment(self, make_generator):
+        # building_data=None (not even an empty dict) → distinct message.
+        gen = make_generator(buildings=None)
+        out = gen._generate_buildings_layer()
+        assert "// Buildings layer" in out
+        assert "No building data available" in out
+        assert "SplineShapeEntity" not in out
+
+    def test_empty_building_list_emits_friendly_comment(self, make_generator):
+        gen = make_generator(buildings=[])
+        out = gen._generate_buildings_layer()
+        assert "No buildings found" in out
+        assert "SplineShapeEntity" not in out
+
+    def test_unvalidated_building_emits_footprint_spline(self, make_generator):
+        gen = make_generator(buildings=[
+            _building(0, lon=1.0, lat=1.0, building_type="house", prefab=None,
+                      name="Test House")
+        ])
+        out = gen._generate_buildings_layer()
+
+        # Footprint marker mode: closed spline named Building_0
+        assert "SplineShapeEntity Building_0 {" in out
+        # Comment carries the human-readable name + type
+        assert "Test House" in out
+        # No actual ${guid}prefab.et reference was emitted for this building.
+        from config.enfusion import ARMA_REFORGER_GUID
+        assert f"${{{ARMA_REFORGER_GUID}}}" not in out
+
+    def test_validated_building_emits_prefab_instance(self, make_generator):
+        from config.enfusion import ARMA_REFORGER_GUID
+        b = _building(0, lon=1.0, lat=1.0, building_type="house",
+                      prefab="Prefabs/Structures/Civilian/Test_House.et")
+        gen = make_generator(buildings=[b])
+        out = gen._generate_buildings_layer()
+
+        expected_ref = (
+            f"${{{ARMA_REFORGER_GUID}}}"
+            "Prefabs/Structures/Civilian/Test_House.et"
+        )
+        assert expected_ref in out
+        # Prefab-instance mode does NOT emit a SplineShapeEntity for this building.
+        assert "SplineShapeEntity Building_0 {" not in out
+
+    def test_building_outside_terrain_skipped(self, make_generator):
+        # Identity ×1000: lon=10 → x=10000m, terrain only 4096m wide.
+        gen = make_generator(buildings=[
+            _building(0, lon=10.0, lat=10.0, building_type="house"),
+        ])
+        out = gen._generate_buildings_layer()
+        # No entity for this building.
+        assert "Building_0" not in out
+
+    def test_each_building_gets_one_entity(self, make_generator):
+        gen = make_generator(buildings=[
+            _building(0, lon=0.5, lat=0.5),
+            _building(1, lon=1.0, lat=1.0),
+            _building(2, lon=1.5, lat=1.5),
+        ])
+        out = gen._generate_buildings_layer()
+        # Three footprint markers (none have validated prefabs).
+        assert out.count("SplineShapeEntity Building_") == 3
+
+
+# ---------------------------------------------------------------------------
+# L12 — buildings overlapping asphalt roads are dropped
+# ---------------------------------------------------------------------------
+
+@requires_shapely
+class TestL12RoadDeconflict:
+    def test_building_on_asphalt_road_is_dropped(self, make_generator):
+        # Asphalt road running along latitude=1.0 from lon=0.5 to lon=2.0
+        road = _asphalt_road(0, 0.5, 1.0, 2.0, 1.0, width_m=8)
+        # Building centroid sits ON the road — should be dropped.
+        on_road = _building(0, lon=1.0, lat=1.0, name="OnRoad")
+        # Building 100 m off the road — should survive.
+        off_road = _building(1, lon=1.0, lat=1.01, name="OffRoad")
+
+        gen = make_generator(buildings=[on_road, off_road], roads=[road])
+        out = gen._generate_buildings_layer()
+
+        assert "OnRoad" not in out
+        assert "OffRoad" in out
+
+    def test_non_asphalt_road_does_not_exclude_buildings(self, make_generator):
+        # Gravel roads should NOT trigger L12 — the audit only excludes
+        # buildings on paved roads (gravel/dirt tracks can have farmhouses
+        # right next to them).
+        gravel = _asphalt_road(0, 0.5, 1.0, 2.0, 1.0)
+        gravel["surface"] = "gravel"
+        on_gravel = _building(0, lon=1.0, lat=1.0, name="OnGravel")
+
+        gen = make_generator(buildings=[on_gravel], roads=[gravel])
+        out = gen._generate_buildings_layer()
+        assert "OnGravel" in out
+
+    def test_no_road_data_skips_l12_check(self, make_generator):
+        b = _building(0, lon=1.0, lat=1.0, name="Standalone")
+        gen = make_generator(buildings=[b], roads=None)
+        out = gen._generate_buildings_layer()
+        assert "Standalone" in out
+
+
+# ---------------------------------------------------------------------------
+# Integration — buildings.layer is part of generate_all + world.ent index
+# ---------------------------------------------------------------------------
+
+class TestBuildingsLayerWiring:
+    def test_world_ent_includes_buildings_layer(self, make_generator):
+        gen = make_generator()
+        ent = gen._generate_world_ent()
+        assert "Layer buildings {" in ent
+
+    def test_generate_all_writes_buildings_layer(self, tmp_path, make_generator):
+        gen = make_generator(buildings=[_building(0, lon=1.0, lat=1.0)])
+        files = gen.generate_all(tmp_path)
+        assert "buildings.layer" in files
+        layer_path = Path(files["buildings.layer"])
+        assert layer_path.exists()
+        content = layer_path.read_text(encoding="utf-8")
+        assert "Buildings layer" in content


### PR DESCRIPTION
## Summary

Phase 2 of the audit roadmap. The pipeline already extracts every OSM building footprint with position/rotation/type — this PR turns that data into an auto-emitted `buildings.layer` so the user no longer hand-places hundreds of structures.

Plus the version-bump rule: `APP_VERSION` is now part of the same PR as the feature work, so the live UI matches the git tag (v1.1.0 had shipped with the UI still showing 1.0.9).

## What's in the layer

Each extracted building emits **one entity**, in one of two modes decided by whether the building's category has a verified prefab in `config/buildings.py::KNOWN_BUILDING_PREFABS`:

- **Auto-placed prefab instance** — uses the `\${guid}path/to/Building_*.et { coords X Y Z }` syntax the managers / roads layers already use. Loads ready-to-go.
- **Footprint-spline marker** *(default until prefab paths are confirmed)* — closed `SplineShapeEntity` tracing the building's exterior ring. The user can right-click → Add Child Entity → BuildingEntity to wire it manually. Same UX as v1.0.6 forest/lake splines.

`KNOWN_BUILDING_PREFABS` ships **empty on purpose**. The audit flagged that we don't have a verified list of stock-Reforger `Building_*.et` paths, and v1.1.0 + L10 already demonstrated what fabricated paths cost (silently broken layers). The catalog grows by config edit, not code change — append a confirmed entry and the generator auto-upgrades that category from footprint-marker mode to auto-placed mode on the next generation.

## L12 — road de-conflict

Buildings whose centroid falls inside an **asphalt road** buffer (half road width + 1.5 m safety) are dropped. Gravel and dirt tracks don't trigger the rule — farmhouses next to gravel tracks are realistic. Built once per generation from the same `road_data` the roads layer uses; gracefully skipped if `shapely` isn't installed.

## Files changed

| Concern | File |
|---|---|
| Version bump (1.0.9 → 1.2.0) | webapp/main.py |
| Building prefab catalog + validator | webapp/config/buildings.py *(new)*, webapp/config/__init__.py |
| Per-building enfusion_prefab field | webapp/services/feature_extractor.py |
| Layer emission + L12 + world.ent index | webapp/services/enfusion_project_generator.py |
| Pass building data through pipeline | webapp/services/map_generator.py |
| SETUP_GUIDE.md §6.3 (Buildings) | webapp/services/setup_guide_generator.py |
| Tests (13 new cases) | webapp/tests/test_enfusion_buildings_layer.py *(new)* |

## Test plan

- [x] `pytest tests/test_enfusion_buildings_layer.py tests/test_enfusion_roads_layer.py tests/test_setup_guide_generator.py tests/test_enfusion_vegetation_water_layers.py tests/test_road_processor.py` — 61 passed locally (3 L12 cases skip without shapely; CI has it). No regressions in Phase 1 tests.
- [x] APP_VERSION verified to drive both `/api/health` and the version badge via `app-version` span in index.html
- [ ] Smoke-test in Workbench: generate a small Sweden / Norway map containing buildings, open `buildings.layer`, confirm: a) one closed `SplineShapeEntity Building_N` per building outside roads, b) buildings on asphalt roads are absent
- [ ] After deploy, pull `:latest` and confirm the version badge shows **1.2.0** (no longer 1.0.9)

## What's next (Phase 3)

Phase 3 is forest/lake generator child auto-attachment using the same `\${guid}` pattern roads + buildings (when validated) now use successfully. The v1.0.6 deferral note about parent-child syntax is resolved — we have a known-good example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)