### PR TITLE
Phase 3: Forest/lake generator auto-attach + river splines (v1.2.1)

### DIFF
--- a/webapp/config/__init__.py
+++ b/webapp/config/__init__.py
@@ -45,6 +45,16 @@ from config.buildings import (
     BUILDING_PREFAB_BASE, KNOWN_BUILDING_PREFABS, validate_building_prefab,
 )
 
+# Forest classification
+from config.forests import (
+    KNOWN_FOREST_PREFABS, validate_forest_prefab, forest_type_from_osm,
+)
+
+# Lake / water-body classification
+from config.lakes import (
+    KNOWN_LAKE_PREFABS, validate_lake_prefab,
+)
+
 # Surface classes
 from config.surfaces import SURFACE_CLASSES
 

--- a/webapp/config/forests.py
+++ b/webapp/config/forests.py
@@ -1,0 +1,53 @@
+"""
+Forest classification + Enfusion Forest Generator prefab catalog.
+
+Same architecture as config.buildings: catalog ships empty so we never
+fabricate paths that fail to resolve in Workbench. Populate
+KNOWN_FOREST_PREFABS with confirmed FG_*.et paths from a stock Reforger
+install and the vegetation layer will auto-attach the generator child to
+every matching forest spline on the next generation.
+"""
+
+from __future__ import annotations
+
+# forest_type → Enfusion FG_*.et path. Empty by default.
+# Keys are produced by forest_type_from_osm() from raw OSM feature properties.
+# Valid keys: "coniferous", "deciduous", "mixed", "scrub", "heath"
+#
+# Example (confirm paths against your Reforger install before committing):
+#   "coniferous": "Prefabs/WEGenerators/Forest/FG_PineForest_01.et",
+#   "deciduous":  "Prefabs/WEGenerators/Forest/FG_DeciduousForest_01.et",
+#   "mixed":      "Prefabs/WEGenerators/Forest/FG_MixedForest_01.et",
+KNOWN_FOREST_PREFABS: dict[str, str] = {}
+
+
+def validate_forest_prefab(forest_type: str | None) -> str | None:
+    """
+    Return the verified FG_*.et path for a forest type, or None if not cataloged.
+    None signals the vegetation-layer emitter to fall back to spline-only mode.
+    """
+    if not forest_type:
+        return None
+    return KNOWN_FOREST_PREFABS.get(forest_type)
+
+
+def forest_type_from_osm(props: dict) -> str:
+    """
+    Map raw OSM feature properties to a forest_type catalog key.
+
+    Mirrors the classification logic in feature_extractor.extract_forest_features
+    so the vegetation-layer emitter and the feature extractor agree on type names.
+    """
+    leaf_type = props.get("leaf_type", "")
+    area_type = props.get("type", "")
+    if leaf_type == "needleleaved":
+        return "coniferous"
+    if leaf_type == "broadleaved":
+        return "deciduous"
+    if leaf_type == "mixed":
+        return "mixed"
+    if area_type == "scrub":
+        return "scrub"
+    if area_type == "heath":
+        return "heath"
+    return "mixed"

--- a/webapp/config/lakes.py
+++ b/webapp/config/lakes.py
@@ -1,0 +1,31 @@
+"""
+Lake / water-body classification + Enfusion Lake Generator prefab catalog.
+
+Same architecture as config.buildings and config.forests: catalog ships empty.
+Populate KNOWN_LAKE_PREFABS with confirmed LG_*.et paths from a stock
+Reforger install and the water layer will auto-attach the generator child to
+every matching lake/pond/reservoir spline on the next generation.
+"""
+
+from __future__ import annotations
+
+# water_type → Enfusion LG_*.et path. Empty by default.
+# Keys match the water_type OSM property values used in the water layer.
+# Valid keys: "lake", "pond", "reservoir", "water"
+#
+# Example (confirm paths against your Reforger install before committing):
+#   "lake":      "Prefabs/WEGenerators/Water/Lake/LG_Lake_01.et",
+#   "pond":      "Prefabs/WEGenerators/Water/Lake/LG_Lake_Small_01.et",
+#   "reservoir": "Prefabs/WEGenerators/Water/Lake/LG_Lake_01.et",
+#   "water":     "Prefabs/WEGenerators/Water/Lake/LG_Lake_01.et",
+KNOWN_LAKE_PREFABS: dict[str, str] = {}
+
+
+def validate_lake_prefab(water_type: str | None) -> str | None:
+    """
+    Return the verified LG_*.et path for a water body type, or None if not cataloged.
+    None signals the water-layer emitter to fall back to spline-only mode.
+    """
+    if not water_type:
+        return None
+    return KNOWN_LAKE_PREFABS.get(water_type)

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -47,7 +47,7 @@ configure_gdal_threading()
 # Application version (for cache busting)
 # ===========================================================================
 
-APP_VERSION = "1.2.0"  # Increment when static files change OR a new release ships
+APP_VERSION = "1.2.1"  # Increment when static files change OR a new release ships
 
 # ===========================================================================
 # FastAPI app

--- a/webapp/services/enfusion_project_generator.py
+++ b/webapp/services/enfusion_project_generator.py
@@ -26,6 +26,8 @@ from config.enfusion import (
     ARMA_REFORGER_GUID,
     PLATFORM_CONFIGS,
     ROAD_PREFAB_BASE,
+    FOREST_PREFAB_BASE,
+    LAKE_PREFAB_BASE,
     WORLD_ENTITY_DEFAULTS,
     TERRAIN_LOD_DEFAULTS,
     WORLD_PREFABS,
@@ -34,8 +36,19 @@ from config.enfusion import (
     compute_height_scale,
 )
 from config.roads import validate_road_prefab
+from config.forests import validate_forest_prefab, forest_type_from_osm
+from config.lakes import validate_lake_prefab
 
 logger = logging.getLogger(__name__)
+
+# Estimated river widths by OSM water_type (same values as feature_extractor)
+_RIVER_WIDTH_M = {
+    "river": 15.0,
+    "stream": 3.0,
+    "canal": 8.0,
+    "ditch": 1.5,
+    "drain": 2.0,
+}
 
 
 # ---------------------------------------------------------------------------
@@ -636,60 +649,177 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['destruction']} {{
         """
         Emit one closed SplineShapeEntity per forest polygon.
 
-        The user opens the project in Workbench and drags a Forest Generator
-        prefab (Prefabs/WEGenerators/Forest/, FG_ prefix) onto each spline to
-        spawn the actual forest. Auto-attaching the prefab as a child entity
-        is deferred until we have a known-good Enfusion text-serialisation
-        example for parent-child entities.
+        When config.forests.KNOWN_FOREST_PREFABS has a confirmed FG_*.et path
+        for the polygon's forest type (coniferous / deciduous / mixed / scrub /
+        heath), a ForestGeneratorEntity child is auto-attached using the same
+        ${guid}path.et { coords 0 0 0 } pattern established for roads (v1.1.0)
+        and buildings (v1.2.0).
+
+        The catalog ships empty (never fabricate paths). Once a user or
+        contributor adds confirmed entries, the generator auto-upgrades those
+        forest types to auto-attached mode on the next generation — no code
+        change required.
         """
         header = (
             "// Vegetation layer — one closed spline per forest polygon.\n"
-            "// To populate: drag a Forest Generator prefab from\n"
-            "//   Prefabs/WEGenerators/Forest/ (FG_ prefix, e.g. FG_PineForest_01.et)\n"
-            "// onto each spline in the World Editor and the generator will fill it\n"
-            "// with trees. Enable 'Avoid Roads' and 'Avoid Lakes' on the generator.\n"
+            "// Forest Generator prefab auto-attached when a confirmed FG_*.et path\n"
+            "// exists in config/forests.py::KNOWN_FOREST_PREFABS for the forest type.\n"
+            "// Catalog ships empty — add entries to upgrade from manual to auto mode.\n"
+            "// Until populated: drag a Forest Generator from\n"
+            "//   Prefabs/WEGenerators/Forest/ onto each spline manually.\n"
+            "// Enable 'Avoid Roads' and 'Avoid Lakes' on the generator.\n"
             "// Source data: Reference/osm_forests.geojson and features.json.\n"
         )
+
+        def _forest_child(feature: dict) -> Optional[str]:
+            props = feature.get("properties", {}) or {}
+            ft = forest_type_from_osm(props)
+            path = validate_forest_prefab(ft)
+            return path  # None → spline-only fallback
+
         body = self._polygon_features_to_splines(
             self.forest_features,
             entity_prefix="ForestArea",
             empty_message="// No forest polygons found in this area.\n",
+            child_prefab_fn=_forest_child,
         )
         return header + body
 
     def _generate_water_layer(self) -> str:
         """
-        Emit one closed SplineShapeEntity per lake/pond/reservoir polygon.
+        Emit closed SplineShapeEntity per lake/pond/reservoir polygon AND open
+        SplineShapeEntity per river/stream LineString.
 
-        Filters out non-polygon water features (rivers/streams are LineStrings
-        and don't fit the spline-area pattern; they'll be added in a future
-        iteration as separate river splines).
+        Lakes: when config.lakes.KNOWN_LAKE_PREFABS has a confirmed LG_*.et
+        path for the water_type, a LakeGeneratorEntity child is auto-attached.
+        Rivers: always emitted as open splines (no generator child — river
+        generator paths TBD); the width comment shows an OSM-derived estimate.
 
-        The user drags a Lake Generator prefab (Prefabs/WEGenerators/Water/Lake/,
-        LG_ prefix) onto each spline to spawn the lake.
+        The lake catalog ships empty (same pattern as forests/buildings).
         """
         header = (
-            "// Water layer — one closed spline per lake/pond/reservoir polygon.\n"
-            "// To populate: drag a Lake Generator prefab from\n"
-            "//   Prefabs/WEGenerators/Water/Lake/ (LG_ prefix, e.g. LG_Lake_01.et)\n"
-            "// onto each spline in the World Editor and enable\n"
-            "// 'Flatten By Bottom Plane' for natural water level.\n"
-            "// Rivers (LineString) are not included here; see roads.layer for\n"
-            "// the road network and a future release for river splines.\n"
+            "// Water layer — lakes/ponds/reservoirs as closed splines,\n"
+            "// rivers/streams/canals as open splines.\n"
+            "// Lake Generator prefab auto-attached when a confirmed LG_*.et path\n"
+            "// exists in config/lakes.py::KNOWN_LAKE_PREFABS for the water type.\n"
+            "// Catalog ships empty — add entries to upgrade from manual to auto mode.\n"
+            "// Until populated: drag a Lake Generator from\n"
+            "//   Prefabs/WEGenerators/Water/Lake/ onto each lake spline manually.\n"
+            "// Enable 'Flatten By Bottom Plane' for natural water level.\n"
             "// Source data: Reference/osm_water.geojson and features.json.\n"
         )
-        # Lake-like polygons only — rivers come in as LineString and are filtered
-        # naturally by the polygon-only loop, but a feature can still be tagged as
-        # a polygonal river (e.g. a wide watercourse). Restrict to standing-water
-        # types so we don't emit a Lake Generator for a moving river polygon.
-        body = self._polygon_features_to_splines(
+
+        def _lake_child(feature: dict) -> Optional[str]:
+            water_type = (feature.get("properties", {}) or {}).get("water_type", "")
+            return validate_lake_prefab(water_type)  # None → spline-only fallback
+
+        lake_body = self._polygon_features_to_splines(
             self.water_features,
             entity_prefix="Water",
             filter_property="water_type",
             filter_values=("lake", "pond", "reservoir", "water"),
             empty_message="// No standing-water polygons found in this area.\n",
+            child_prefab_fn=_lake_child,
         )
-        return header + body
+        river_body = self._generate_river_splines()
+        return header + lake_body + river_body
+
+    def _generate_river_splines(self) -> str:
+        """
+        Emit one open SplineShapeEntity per river/stream/canal LineString.
+
+        Rivers are open (not closed) so they don't need to form a polygon.
+        A width comment shows the OSM-derived estimate in metres. No generator
+        child is auto-attached — river generator prefab paths are TBD.
+        """
+        if not self.transformer or not self.water_features:
+            return ""
+
+        features = self.water_features.get("features", []) or []
+        river_features = [
+            f for f in features
+            if (f.get("properties", {}) or {}).get("water_type", "") in _RIVER_WIDTH_M
+            and (f.get("geometry", {}) or {}).get("type") == "LineString"
+        ]
+        if not river_features:
+            return ""
+
+        section_header = (
+            "\n// River / stream splines — open SplineShapeEntity per waterway.\n"
+            "// Width estimate (metres) shown in the entity comment.\n"
+            "// Add a river generator child manually if your project uses one.\n"
+        )
+
+        entities: list[str] = []
+        skipped = 0
+
+        for i, feature in enumerate(river_features):
+            props = (feature.get("properties", {}) or {})
+            geom = (feature.get("geometry", {}) or {})
+            coords = geom.get("coordinates", []) or []
+
+            wgs_points = [
+                {"x": float(c[0]), "y": float(c[1])}
+                for c in coords if len(c) >= 2
+            ]
+            if len(wgs_points) < 2:
+                skipped += 1
+                continue
+
+            local_points = self.transformer.transform_points(
+                wgs_points,
+                elevation_array=self.elevation_array,
+            )
+
+            margin = 1.0
+            in_bounds = [
+                pt for pt in local_points
+                if -margin <= pt["x"] <= self.terrain_width + margin
+                and -margin <= pt["z"] <= self.terrain_depth + margin
+            ]
+            if len(in_bounds) < 2:
+                skipped += 1
+                continue
+
+            origin = in_bounds[0]
+            point_defs = []
+            for j, pt in enumerate(in_bounds):
+                rel_x = pt["x"] - origin["x"]
+                rel_y = pt["y"] - origin["y"]
+                rel_z = pt["z"] - origin["z"]
+                point_defs.append(
+                    f'   ShapePoint sp_{j} {{\n'
+                    f'    Position {rel_x:.3f} {rel_y:.3f} {rel_z:.3f}\n'
+                    f'   }}'
+                )
+
+            water_type = props.get("water_type", "river")
+            width_m = _RIVER_WIDTH_M.get(water_type, 5.0)
+            name = props.get("name", "") or ""
+            comment = (
+                f' // {name} (~{width_m:.0f}m)' if name
+                else f' // {water_type} (~{width_m:.0f}m)'
+            )
+
+            entities.append(
+                f'SplineShapeEntity River_{i} {{{comment}\n'
+                f' coords {origin["x"]:.3f} {origin["y"]:.3f} {origin["z"]:.3f}\n'
+                f' Points {{\n'
+                + "\n".join(point_defs) + "\n"
+                f' }}\n'
+                f'}}'
+            )
+
+        if skipped:
+            logger.info(
+                f"River splines: skipped {skipped} segment(s) — "
+                f"< 2 in-bounds points after clipping"
+            )
+        logger.info(f"River splines: emitted {len(entities)} open spline(s)")
+
+        if not entities:
+            return ""
+        return section_header + "\n".join(entities) + "\n"
 
     # -----------------------------------------------------------------------
     # Buildings layer (Phase 2 / task A2 + L12)
@@ -921,6 +1051,7 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['destruction']} {{
         empty_message: str,
         filter_property: Optional[str] = None,
         filter_values: tuple[str, ...] = (),
+        child_prefab_fn=None,
     ) -> str:
         """
         Convert GeoJSON polygon features into closed SplineShapeEntity blocks.
@@ -941,6 +1072,9 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['destruction']} {{
             empty_message: Comment to emit when there's nothing to write.
             filter_property: Optional GeoJSON property name to filter on.
             filter_values: Allowed values for filter_property (case-sensitive).
+            child_prefab_fn: Optional callable(feature) → str|None. When it
+                returns a non-None path, a generator child entity is added to
+                the spline using the ${guid}path.et { coords 0 0 0 } syntax.
 
         Returns:
             Multi-line string suitable for appending to a .layer file.
@@ -961,6 +1095,8 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['destruction']} {{
                     skipped_filtered += 1
                     continue
 
+            child_prefab = child_prefab_fn(feature) if child_prefab_fn else None
+
             geom = feature.get("geometry", {}) or {}
             geom_type = geom.get("type", "")
             coords = geom.get("coordinates", []) or []
@@ -978,7 +1114,8 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['destruction']} {{
 
             for ring in exterior_rings:
                 entity = self._closed_spline_entity_from_ring(
-                    ring, entity_prefix, len(entities)
+                    ring, entity_prefix, len(entities),
+                    child_prefab=child_prefab,
                 )
                 if entity is None:
                     skipped_clipped += 1
@@ -1009,6 +1146,7 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['destruction']} {{
         entity_prefix: str,
         index: int,
         comment_suffix: str = "",
+        child_prefab: Optional[str] = None,
     ) -> Optional[str]:
         """
         Project a single GeoJSON ring (list of [lon, lat] pairs) to a closed
@@ -1016,8 +1154,11 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['destruction']} {{
         points after clipping to the terrain.
 
         ``comment_suffix`` is appended to the entity declaration line as a
-        trailing ``// ...`` comment so callers can label the spline (e.g. with
-        the OSM name + building type).
+        trailing ``// ...`` comment so callers can label the spline.
+
+        ``child_prefab``: when not None, a generator child block is appended
+        inside the entity using the ``${guid}path.et { coords 0 0 0 }`` syntax
+        established for roads (v1.1.0) and buildings (v1.2.0).
         """
         if len(ring) < 3:
             return None
@@ -1061,13 +1202,22 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['destruction']} {{
                 f'   }}'
             )
 
+        child_block = ""
+        if child_prefab:
+            child_block = (
+                f' ${{{ARMA_REFORGER_GUID}}}{child_prefab} {{\n'
+                f'  coords 0 0 0\n'
+                f' }}\n'
+            )
+
         return (
             f'SplineShapeEntity {entity_prefix}_{index} {{{comment_suffix}\n'
             f' coords {origin["x"]:.3f} {origin["y"]:.3f} {origin["z"]:.3f}\n'
             f' Points {{\n'
             + "\n".join(point_defs) + "\n"
             f' }}\n'
-            f'}}'
+            + child_block
+            + f'}}'
         )
 
     def _generate_mission_conf(self) -> str:

--- a/webapp/services/setup_guide_generator.py
+++ b/webapp/services/setup_guide_generator.py
@@ -467,42 +467,66 @@ if the .layer file was hand-edited), re-attach it the original way:
 
         return f"""## Phase 6: Vegetation & Water (Generators)
 
-The vegetation and water layers already contain pre-drawn closed splines —
-one per forest/lake polygon, projected to Enfusion local coordinates and
-clipped to the terrain. You only need to drop a generator prefab onto each
-spline; the spline-drawing work is done.
+The vegetation and water layers contain pre-drawn splines projected to
+Enfusion local coordinates and clipped to the terrain. When a Forest or
+Lake Generator prefab path is configured in the catalog (see below), the
+generator child is auto-attached and the area fills with trees or water on
+world load — no manual prefab-dropping needed.
+
+By default the catalogs ship empty (the same safe pattern used for buildings),
+so manual wiring is the fallback until you confirm the prefab paths match your
+stock Reforger install.
 
 ### Step 6.1: Forest Generator
 
 Your terrain has **{forests}** forest areas identified from OpenStreetMap.
 The vegetation layer contains a closed `SplineShapeEntity` for each.
 
-For each spline:
+**If Forest Generator prefabs are auto-attached** (catalog populated):
+- The generator child already exists inside each spline — open the project
+  in Workbench, select any `ForestArea_*` spline, and you will see the
+  `FG_*.et` child in the entity tree. No further wiring needed.
+- Enable **Avoid Roads** and **Avoid Lakes** on each generator if not set.
+
+**If the catalog is empty** (default — manual wiring):
 1. Select the spline in the World Editor (vegetation layer)
 2. Drag a Forest Generator prefab from `Prefabs/WEGenerators/Forest/`
    (prefixed `FG_`) onto the spline — it will populate the area with trees
 3. Enable **Avoid Roads** and **Avoid Lakes** on the generator
 
-> **Tip**: Pick the prefab that matches the dominant tree type for your
-> region (e.g. `FG_PineForest_*` for Nordic coniferous areas).
-> Reference: `Reference/osm_forests.geojson` includes leaf_type metadata
-> (needleleaved / broadleaved) per polygon.
+> **To enable auto-attachment**: edit
+> `webapp/config/forests.py::KNOWN_FOREST_PREFABS` and add entries mapping
+> forest type keys (`"coniferous"`, `"deciduous"`, `"mixed"`) to the actual
+> `FG_*.et` paths from your Reforger install. No code changes — just config
+> edits. The leaf_type metadata in `Reference/osm_forests.geojson` shows
+> which type applies to each polygon.
 
 ### Step 6.2: Water Bodies
 
-Your terrain has **{lakes}** lakes and **{rivers}** rivers/streams.
-The water layer contains a closed `SplineShapeEntity` per lake/pond/reservoir.
-(Rivers are LineStrings and aren't included in the water layer; use the
-roads layer or future river-spline output for them.)
+Your terrain has **{lakes}** lakes/ponds/reservoirs and **{rivers}** rivers/streams.
 
-For each spline:
-1. Select the spline in the World Editor (water layer)
+**Lakes (closed splines)**: The water layer contains one closed `SplineShapeEntity`
+per lake/pond/reservoir.
+
+**If Lake Generator prefabs are auto-attached** (catalog populated):
+- The `LG_*.et` child already exists inside each spline — no manual wiring needed.
+- Enable **Flatten By Bottom Plane** on each generator if not set.
+
+**If the catalog is empty** (default — manual wiring):
+1. Select the lake spline in the World Editor (water layer)
 2. Drag a Lake Generator prefab from `Prefabs/WEGenerators/Water/Lake/`
    (prefixed `LG_`) onto the spline
 3. Enable **Flatten By Bottom Plane** for natural water level
 
-> **Tip**: Water body coordinates in features.json are already in Enfusion
-> local metres.
+> **To enable auto-attachment**: edit
+> `webapp/config/lakes.py::KNOWN_LAKE_PREFABS` and add entries mapping
+> water type keys (`"lake"`, `"pond"`, `"reservoir"`) to confirmed `LG_*.et`
+> paths. No code changes needed.
+
+**Rivers (open splines)**: The water layer also contains one open
+`SplineShapeEntity` per river/stream/canal LineString, labelled with the
+OSM name and estimated width. These are pre-positioned markers — add a
+river generator child manually if your project uses one.
 
 ### Step 6.3: Buildings
 

--- a/webapp/tests/test_phase3_generators.py
+++ b/webapp/tests/test_phase3_generators.py
@@ -1,0 +1,349 @@
+"""
+Tests for Phase 3 features:
+  A3 — ForestGeneratorEntity child auto-attached to forest splines
+  A4 — LakeGeneratorEntity child auto-attached to lake splines
+  A5 — River/stream LineStrings emitted as open splines in water.layer
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+WEBAPP_DIR = Path(__file__).parent.parent
+if str(WEBAPP_DIR) not in sys.path:
+    sys.path.insert(0, str(WEBAPP_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers (duplicate-free: same identity transformer as existing tests)
+# ---------------------------------------------------------------------------
+
+class _IdentityTransformer:
+    def transform_points(self, points, elevation_array=None):
+        return [
+            {"x": round(p["x"] * 1000, 3), "y": 0.0, "z": round(p["y"] * 1000, 3)}
+            for p in points
+        ]
+
+
+def _metadata():
+    return {
+        "heightmap": {"dimensions": "2049x2049", "grid_cell_size_m": 2.0},
+        "elevation": {
+            "min_elevation_m": 0,
+            "max_elevation_m": 100,
+            "height_scale": 0.03125,
+            "height_offset": 0,
+        },
+        "input": {"bbox": {"south": 0.0, "north": 4.0, "west": 0.0, "east": 4.0}},
+    }
+
+
+def _poly_feature(coords, **props):
+    return {
+        "type": "Feature",
+        "geometry": {"type": "Polygon", "coordinates": coords},
+        "properties": props,
+    }
+
+
+def _line_feature(coords, **props):
+    return {
+        "type": "Feature",
+        "geometry": {"type": "LineString", "coordinates": coords},
+        "properties": props,
+    }
+
+
+def _make_gen(**kwargs):
+    from services.enfusion_project_generator import EnfusionProjectGenerator
+    return EnfusionProjectGenerator(
+        map_name="TestMap",
+        metadata=_metadata(),
+        transformer=_IdentityTransformer(),
+        elevation_array=None,
+        **kwargs,
+    )
+
+
+_RING = [[0.5, 0.5], [1.5, 0.5], [1.5, 1.5], [0.5, 1.5], [0.5, 0.5]]
+_RIVER_LINE = [[0.5, 0.5], [1.0, 0.5], [1.5, 0.5], [2.0, 0.5]]
+_ARMA_GUID = "58D0FB3206B6F859"
+
+
+# ---------------------------------------------------------------------------
+# A3 — Forest generator child
+# ---------------------------------------------------------------------------
+
+class TestForestGeneratorChild:
+    def test_empty_catalog_emits_spline_only(self):
+        """Default behavior: catalog empty → plain spline, no child block."""
+        gen = _make_gen(forest_features={
+            "type": "FeatureCollection",
+            "features": [_poly_feature([_RING], leaf_type="needleleaved")],
+        })
+        out = gen._generate_vegetation_layer()
+        assert "SplineShapeEntity ForestArea_0 {" in out
+        assert f"${{{_ARMA_GUID}}}" not in out
+
+    def test_populated_catalog_emits_child_prefab(self):
+        """When catalog has an entry, the child block appears in the spline."""
+        fake_prefab = "Prefabs/WEGenerators/Forest/FG_PineForest_01.et"
+        with patch("config.forests.KNOWN_FOREST_PREFABS", {"coniferous": fake_prefab}):
+            gen = _make_gen(forest_features={
+                "type": "FeatureCollection",
+                "features": [_poly_feature([_RING], leaf_type="needleleaved")],
+            })
+            out = gen._generate_vegetation_layer()
+
+        assert "SplineShapeEntity ForestArea_0 {" in out
+        assert f"${{{_ARMA_GUID}}}{fake_prefab}" in out
+        assert "coords 0 0 0" in out
+
+    def test_unrecognised_leaf_type_falls_back_to_mixed_key(self):
+        """Unknown leaf_type → forest_type_from_osm returns 'mixed'."""
+        from config.forests import forest_type_from_osm
+        assert forest_type_from_osm({"leaf_type": "exotic"}) == "mixed"
+
+    def test_needleleaved_maps_to_coniferous(self):
+        from config.forests import forest_type_from_osm
+        assert forest_type_from_osm({"leaf_type": "needleleaved"}) == "coniferous"
+
+    def test_broadleaved_maps_to_deciduous(self):
+        from config.forests import forest_type_from_osm
+        assert forest_type_from_osm({"leaf_type": "broadleaved"}) == "deciduous"
+
+    def test_scrub_type_maps_to_scrub(self):
+        from config.forests import forest_type_from_osm
+        assert forest_type_from_osm({"type": "scrub"}) == "scrub"
+
+    def test_validate_forest_prefab_none_for_empty_catalog(self):
+        from config.forests import validate_forest_prefab
+        assert validate_forest_prefab("coniferous") is None
+
+    def test_validate_forest_prefab_returns_path_when_configured(self):
+        fake = "Prefabs/WEGenerators/Forest/FG_PineForest_01.et"
+        with patch("config.forests.KNOWN_FOREST_PREFABS", {"coniferous": fake}):
+            from config.forests import validate_forest_prefab
+            assert validate_forest_prefab("coniferous") == fake
+
+    def test_mixed_forest_types_only_attach_when_catalog_has_matching_entry(self):
+        """Coniferous polygon gets child; deciduous polygon stays spline-only."""
+        pine_prefab = "Prefabs/WEGenerators/Forest/FG_PineForest_01.et"
+        with patch("config.forests.KNOWN_FOREST_PREFABS", {"coniferous": pine_prefab}):
+            gen = _make_gen(forest_features={
+                "type": "FeatureCollection",
+                "features": [
+                    _poly_feature([_RING], leaf_type="needleleaved"),
+                    _poly_feature(
+                        [[[2.0, 2.0], [2.5, 2.0], [2.5, 2.5], [2.0, 2.5], [2.0, 2.0]]],
+                        leaf_type="broadleaved",
+                    ),
+                ],
+            })
+            out = gen._generate_vegetation_layer()
+
+        assert f"${{{_ARMA_GUID}}}{pine_prefab}" in out
+        assert out.count(f"${{{_ARMA_GUID}}}") == 1  # only the coniferous one
+
+
+# ---------------------------------------------------------------------------
+# A4 — Lake generator child
+# ---------------------------------------------------------------------------
+
+class TestLakeGeneratorChild:
+    def test_empty_catalog_emits_spline_only(self):
+        gen = _make_gen(water_features={
+            "type": "FeatureCollection",
+            "features": [_poly_feature([_RING], water_type="lake")],
+        })
+        out = gen._generate_water_layer()
+        assert "SplineShapeEntity Water_0 {" in out
+        assert f"${{{_ARMA_GUID}}}" not in out
+
+    def test_populated_catalog_emits_child_prefab(self):
+        fake_prefab = "Prefabs/WEGenerators/Water/Lake/LG_Lake_01.et"
+        with patch("config.lakes.KNOWN_LAKE_PREFABS", {"lake": fake_prefab}):
+            gen = _make_gen(water_features={
+                "type": "FeatureCollection",
+                "features": [_poly_feature([_RING], water_type="lake")],
+            })
+            out = gen._generate_water_layer()
+
+        assert "SplineShapeEntity Water_0 {" in out
+        assert f"${{{_ARMA_GUID}}}{fake_prefab}" in out
+        assert "coords 0 0 0" in out
+
+    def test_pond_and_reservoir_both_get_child_when_catalogued(self):
+        lake_pf = "Prefabs/WEGenerators/Water/Lake/LG_Lake_01.et"
+        pond_pf = "Prefabs/WEGenerators/Water/Lake/LG_Lake_Small_01.et"
+        catalog = {"lake": lake_pf, "pond": pond_pf}
+        pond_ring = [[2.0, 2.0], [2.5, 2.0], [2.5, 2.5], [2.0, 2.5], [2.0, 2.0]]
+        with patch("config.lakes.KNOWN_LAKE_PREFABS", catalog):
+            gen = _make_gen(water_features={
+                "type": "FeatureCollection",
+                "features": [
+                    _poly_feature([_RING], water_type="lake"),
+                    _poly_feature([pond_ring], water_type="pond"),
+                ],
+            })
+            out = gen._generate_water_layer()
+
+        assert f"${{{_ARMA_GUID}}}{lake_pf}" in out
+        assert f"${{{_ARMA_GUID}}}{pond_pf}" in out
+
+    def test_validate_lake_prefab_none_for_empty_catalog(self):
+        from config.lakes import validate_lake_prefab
+        assert validate_lake_prefab("lake") is None
+
+    def test_validate_lake_prefab_returns_path_when_configured(self):
+        fake = "Prefabs/WEGenerators/Water/Lake/LG_Lake_01.et"
+        with patch("config.lakes.KNOWN_LAKE_PREFABS", {"lake": fake}):
+            from config.lakes import validate_lake_prefab
+            assert validate_lake_prefab("lake") == fake
+
+    def test_river_polygon_still_filtered_out(self):
+        """water_type=river polygon must not get a lake generator child."""
+        gen = _make_gen(water_features={
+            "type": "FeatureCollection",
+            "features": [_poly_feature([_RING], water_type="river")],
+        })
+        out = gen._generate_water_layer()
+        assert "SplineShapeEntity" not in out.split("// River")[0]
+
+
+# ---------------------------------------------------------------------------
+# A5 — River / stream open splines
+# ---------------------------------------------------------------------------
+
+class TestRiverSplines:
+    def test_river_linestring_emits_open_spline(self):
+        gen = _make_gen(water_features={
+            "type": "FeatureCollection",
+            "features": [_line_feature(_RIVER_LINE, water_type="river", name="Test River")],
+        })
+        out = gen._generate_water_layer()
+        assert "SplineShapeEntity River_0 {" in out
+        assert "Test River" in out
+        assert "~15m" in out  # river default width
+
+    def test_stream_uses_3m_width_estimate(self):
+        gen = _make_gen(water_features={
+            "type": "FeatureCollection",
+            "features": [_line_feature(_RIVER_LINE, water_type="stream")],
+        })
+        out = gen._generate_water_layer()
+        assert "~3m" in out
+
+    def test_canal_uses_8m_width_estimate(self):
+        gen = _make_gen(water_features={
+            "type": "FeatureCollection",
+            "features": [_line_feature(_RIVER_LINE, water_type="canal")],
+        })
+        out = gen._generate_water_layer()
+        assert "~8m" in out
+
+    def test_river_spline_has_no_closing_repeat(self):
+        """Open spline: first and last ShapePoint positions must differ."""
+        gen = _make_gen(water_features={
+            "type": "FeatureCollection",
+            "features": [_line_feature(_RIVER_LINE, water_type="river")],
+        })
+        out = gen._generate_water_layer()
+        # The first point is always Position 0 0 0. If the spline were closed,
+        # there would be at least 2 occurrences of "Position 0.000 0.000 0.000".
+        # For an open spline with a moving river, the last point differs → only 1.
+        assert out.count("Position 0.000 0.000 0.000") == 1
+
+    def test_river_and_lake_coexist_in_water_layer(self):
+        gen = _make_gen(water_features={
+            "type": "FeatureCollection",
+            "features": [
+                _poly_feature([_RING], water_type="lake"),
+                _line_feature(_RIVER_LINE, water_type="river", name="Ör River"),
+            ],
+        })
+        out = gen._generate_water_layer()
+        assert "SplineShapeEntity Water_0 {" in out
+        assert "SplineShapeEntity River_0 {" in out
+        assert "Ör River" in out
+
+    def test_non_water_linestring_not_emitted(self):
+        """Only river/stream/canal LineStrings are emitted."""
+        gen = _make_gen(water_features={
+            "type": "FeatureCollection",
+            "features": [_line_feature(_RIVER_LINE, water_type="coastline")],
+        })
+        out = gen._generate_water_layer()
+        assert "SplineShapeEntity River_" not in out
+
+    def test_river_out_of_bounds_is_skipped(self):
+        far_line = [[10.0, 10.0], [11.0, 10.0], [12.0, 10.0]]
+        gen = _make_gen(water_features={
+            "type": "FeatureCollection",
+            "features": [_line_feature(far_line, water_type="river")],
+        })
+        out = gen._generate_water_layer()
+        assert "SplineShapeEntity River_" not in out
+
+    def test_degenerate_single_point_river_skipped(self):
+        gen = _make_gen(water_features={
+            "type": "FeatureCollection",
+            "features": [_line_feature([[1.0, 1.0]], water_type="river")],
+        })
+        out = gen._generate_water_layer()
+        assert "SplineShapeEntity River_" not in out
+
+    def test_no_water_features_river_section_absent(self):
+        gen = _make_gen(water_features=None)
+        out = gen._generate_water_layer()
+        assert "River_" not in out
+        assert "// River / stream" not in out
+
+
+# ---------------------------------------------------------------------------
+# Setup guide — §6.1 / §6.2 updated text
+# ---------------------------------------------------------------------------
+
+class TestSetupGuidePhase3:
+    def _make_guide(self):
+        from services.setup_guide_generator import SetupGuideGenerator
+        metadata = {
+            **_metadata(),
+            "surface_masks": {"coverage": {"per_surface": {}}},
+            "roads": {},
+            "features": {"lakes": 3, "rivers": 2, "forest_areas": 5, "buildings": 10},
+            "satellite": {},
+            "coordinate_transform": {},
+            "enfusion_import": {"recommended_settings": {}},
+        }
+        return SetupGuideGenerator("TestMap", metadata)
+
+    def test_forest_auto_attach_instructions_present(self):
+        guide = self._make_guide()
+        out = guide._phase_vegetation_water()
+        assert "KNOWN_FOREST_PREFABS" in out
+        assert "config/forests.py" in out
+
+    def test_lake_auto_attach_instructions_present(self):
+        guide = self._make_guide()
+        out = guide._phase_vegetation_water()
+        assert "KNOWN_LAKE_PREFABS" in out
+        assert "config/lakes.py" in out
+
+    def test_river_open_splines_mentioned(self):
+        guide = self._make_guide()
+        out = guide._phase_vegetation_water()
+        assert "open" in out.lower()
+        assert "river" in out.lower()
+
+    def test_feature_counts_interpolated(self):
+        guide = self._make_guide()
+        out = guide._phase_vegetation_water()
+        assert "**5** forest" in out
+        assert "**3** lake" in out
+        assert "**2** river" in out


### PR DESCRIPTION
## Summary

- A3: ForestGeneratorEntity child auto-attached to each forest SplineShapeEntity in vegetation.layer when config/forests.py::KNOWN_FOREST_PREFABS has a confirmed FG_*.et path for the polygon forest type. New forest_type_from_osm() maps raw OSM leaf_type/type to catalog keys (coniferous, deciduous, mixed, scrub, heath).
- A4: LakeGeneratorEntity child auto-attached to each lake/pond/reservoir SplineShapeEntity in water.layer when config/lakes.py::KNOWN_LAKE_PREFABS has a confirmed LG_*.et path for the water_type.
- A5: River/stream/canal LineString features now emitted as open SplineShapeEntity in water.layer (previously dropped). Width estimate from OSM type shown in entity comment.
- Both catalogs ship empty by default (same safe pattern as KNOWN_BUILDING_PREFABS in v1.2.0). Populate with confirmed prefab paths from a stock Reforger install; no code change needed.
- Uses the same ${guid}path.et { coords 0 0 0 } child syntax as roads (v1.1.0) and buildings (v1.2.0).
- setup_guide_generator.py sections 6.1 and 6.2 updated: auto-attach/fallback instructions + how to expand the catalog.
- APP_VERSION bumped to 1.2.1.

## Test plan

- [x] 28 new tests in test_phase3_generators.py - all pass (59 passed, 3 skipped shapely-only)
- [x] All 10 existing vegetation/water layer tests still pass
- [x] All buildings, roads, and setup guide tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)