### PR TITLE
v1.2.3: fix Workbench 4% hang regressed in v1.1.0 (revert nested road child + cap road/river splines)

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ The application is published to GitHub Container Registry and automatically buil
 docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:latest
 
 # Or use a specific version tag
-docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.2.2
+docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.2.3
 ```
 
 The `docker-compose.yml` is pre-configured to use the GHCR.io image. See the [Quick Start Guide](#quick-start-guide) for setup instructions.

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -47,7 +47,7 @@ configure_gdal_threading()
 # Application version (for cache busting)
 # ===========================================================================
 
-APP_VERSION = "1.2.2"  # Increment when static files change OR a new release ships
+APP_VERSION = "1.2.3"  # Increment when static files change OR a new release ships
 
 # ===========================================================================
 # FastAPI app

--- a/webapp/services/enfusion_project_generator.py
+++ b/webapp/services/enfusion_project_generator.py
@@ -25,7 +25,6 @@ import math
 from config.enfusion import (
     ARMA_REFORGER_GUID,
     PLATFORM_CONFIGS,
-    ROAD_PREFAB_BASE,
     FOREST_PREFAB_BASE,
     LAKE_PREFAB_BASE,
     WORLD_ENTITY_DEFAULTS,
@@ -527,28 +526,30 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['destruction']} {{
 
     def _generate_roads_layer(self) -> str:
         """
-        Generate the roads layer with one SplineShapeEntity per road and an
-        auto-attached RoadGeneratorEntity child carrying the inferred prefab.
+        Generate the roads layer with one spline-only SplineShapeEntity per road.
 
-        Each road's ``enfusion_prefab`` field is run through
-        ``validate_road_prefab`` so the emitted path always points at a known
-        prefab in a stock Reforger install. The child uses the standard
-        ``${guid}path/to/prefab.et { coords ... }`` instance syntax — the
-        same pattern the managers layer uses to instantiate world prefabs.
+        v1.1.0 attempted to auto-attach a ``RoadGeneratorEntity`` child by
+        nesting a ``${guid}path/to/prefab.et { coords 0 0 0 }`` instance line
+        inside the SplineShapeEntity body. Workbench rejects that nesting
+        form and stalls "Loading entity data..." at 4%. Reverted in v1.2.3.
+
+        The validated prefab name is still computed (via ``validate_road_prefab``)
+        and surfaced in the entity's trailing ``//`` comment so the user can
+        attach the right ``RoadGeneratorEntity`` child manually in Workbench.
+        ``Reference/roads_reference.csv`` carries the same data per road.
 
         Spline points include Y (elevation) values sampled from the heightmap
-        so roads follow the terrain surface.
+        so roads follow the terrain surface, and are simplified to at most
+        ``MAX_SPLINE_POINTS`` vertices to avoid choking the Workbench loader
+        on long OSM ways.
 
         Entity format:
-          SplineShapeEntity Road_N {
+          SplineShapeEntity Road_N { // <name> | prefab: RG_Road_<Surface>_<W>m
            coords X Y Z
            Points {
             ShapePoint sp_0 { Position 0 0 0 }
             ShapePoint sp_1 { Position relX relY relZ }
             ...
-           }
-           ${guid}Prefabs/WEGenerators/Roads/RG_Road_<Surface>_<W>m.et {
-            coords 0 0 0
            }
           }
 
@@ -594,8 +595,9 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['destruction']} {{
                 clipped += 1
                 continue
 
-            # Use clipped points
-            local_points = in_bounds
+            # Cap spline length so long OSM ways don't hang the Workbench
+            # loader. Same MAX_SPLINE_POINTS budget the closed-spline path uses.
+            local_points = self._simplify_local_polyline(in_bounds)
 
             # First point is the entity origin
             origin = local_points[0]
@@ -613,23 +615,19 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['destruction']} {{
                 )
 
             road_name = road.get("name", "").replace('"', "'")
-            comment = f' // {road_name}' if road_name else ""
-
             prefab_name = validate_road_prefab(
                 road.get("enfusion_prefab", "RG_Road_Asphalt_4m")
             )
-            prefab_ref = (
-                f'${{{ARMA_REFORGER_GUID}}}{ROAD_PREFAB_BASE}/{prefab_name}.et'
-            )
+            if road_name:
+                comment = f' // {road_name} | prefab: {prefab_name}'
+            else:
+                comment = f' // prefab: {prefab_name}'
 
             entity = (
                 f'SplineShapeEntity Road_{i} {{{comment}\n'
                 f' coords {origin["x"]:.3f} {origin["y"]:.3f} {origin["z"]:.3f}\n'
                 f' Points {{\n'
                 + "\n".join(point_defs) + "\n"
-                f' }}\n'
-                f' {prefab_ref} {{\n'
-                f'  coords 0 0 0\n'
                 f' }}\n'
                 f'}}'
             )
@@ -641,8 +639,8 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['destruction']} {{
             logger.info(f"Clipped {clipped} road segments outside terrain bounds")
 
         logger.info(
-            f"Generated {len(entities)} road entities (each with auto-attached "
-            f"RoadGeneratorEntity child) for roads layer"
+            f"Generated {len(entities)} spline-only road entities for roads "
+            f"layer (prefab name surfaced as a // comment per spline)"
         )
         return "\n".join(entities) + "\n"
 
@@ -781,6 +779,8 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['destruction']} {{
             if len(in_bounds) < 2:
                 skipped += 1
                 continue
+
+            in_bounds = self._simplify_local_polyline(in_bounds)
 
             origin = in_bounds[0]
             point_defs = []
@@ -1437,6 +1437,81 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['destruction']} {{
         step = max(1, math.ceil(len(pts) / max_pts))
         return pts[::step][:max_pts]
 
+    @staticmethod
+    def _simplify_local_polyline(
+        pts: list[dict],
+        max_pts: int = MAX_SPLINE_POINTS,
+    ) -> list[dict]:
+        """
+        Reduce a local-coordinate open polyline to at most *max_pts* points
+        using Ramer-Douglas-Peucker in the XZ plane, falling back to uniform
+        decimation if shapely is unavailable or all tolerances fail.
+
+        Both endpoints are always preserved (unlike :py:meth:`_simplify_local_ring`,
+        which closes the loop). *pts* is a list of {"x":…, "y":…, "z":…} dicts
+        in local metres.
+        """
+        if len(pts) <= max_pts:
+            return pts
+
+        def _rdp(points, tol):
+            if len(points) <= 2:
+                return list(points)
+            ax, az = points[0]["x"], points[0]["z"]
+            bx, bz = points[-1]["x"], points[-1]["z"]
+            dx, dz = bx - ax, bz - az
+            seg_len_sq = dx * dx + dz * dz
+
+            def _perp(p):
+                if seg_len_sq == 0:
+                    return math.hypot(p["x"] - ax, p["z"] - az)
+                t = max(0.0, min(1.0, ((p["x"] - ax) * dx + (p["z"] - az) * dz) / seg_len_sq))
+                return math.hypot(p["x"] - (ax + t * dx), p["z"] - (az + t * dz))
+
+            max_d, idx = 0.0, 0
+            for i in range(1, len(points) - 1):
+                d = _perp(points[i])
+                if d > max_d:
+                    max_d, idx = d, i
+            if max_d > tol:
+                return _rdp(points[:idx + 1], tol)[:-1] + _rdp(points[idx:], tol)
+            return [points[0], points[-1]]
+
+        # Try shapely first for best quality, then pure-Python RDP, then decimation.
+        try:
+            from shapely.geometry import LineString
+            coords_2d = [(p["x"], p["z"]) for p in pts]
+            line = LineString(coords_2d)
+            for tol in (0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 50.0):
+                s = line.simplify(tol, preserve_topology=False)
+                if s.is_empty:
+                    break
+                s_coords = list(s.coords)
+                if len(s_coords) <= max_pts and len(s_coords) >= 2:
+                    result = []
+                    for cx, cz in s_coords:
+                        nearest = min(pts, key=lambda p, cx=cx, cz=cz: (p["x"] - cx) ** 2 + (p["z"] - cz) ** 2)
+                        result.append({"x": cx, "y": nearest["y"], "z": cz})
+                    return result
+        except Exception:
+            pass
+
+        # Pure-Python RDP with escalating tolerance — open polyline, do not close.
+        for tol in (2.0, 5.0, 10.0, 20.0, 50.0):
+            s = _rdp(pts, tol)
+            if len(s) <= max_pts:
+                return s
+
+        # Last resort: uniform decimation, but always keep first + last.
+        step = max(1, math.ceil(len(pts) / max_pts))
+        decimated = pts[::step][:max_pts]
+        if decimated and decimated[-1] is not pts[-1]:
+            if len(decimated) >= max_pts:
+                decimated[-1] = pts[-1]
+            else:
+                decimated.append(pts[-1])
+        return decimated
+
     def _closed_spline_entity_from_ring(
         self,
         ring: list[list[float]],
@@ -1454,8 +1529,14 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['destruction']} {{
         trailing ``// ...`` comment so callers can label the spline.
 
         ``child_prefab``: when not None, a generator child block is appended
-        inside the entity using the ``${guid}path.et { coords 0 0 0 }`` syntax
-        established for roads (v1.1.0) and buildings (v1.2.0).
+        inside the entity using the ``${guid}path.et { coords 0 0 0 }`` syntax.
+
+        TODO: this nested-child syntax inside a SplineShapeEntity body is
+        unverified — the same form on roads (v1.1.0) caused Workbench to hang
+        at 4% on world load and was reverted in v1.2.3. The Phase 3 forest /
+        lake catalogues (``KNOWN_FOREST_PREFABS`` / ``KNOWN_LAKE_PREFABS``)
+        ship empty so this path stays dormant; populating either catalogue
+        may re-arm the same hang. Verify in Workbench before merging entries.
         """
         if len(ring) < 3:
             return None

--- a/webapp/services/setup_guide_generator.py
+++ b/webapp/services/setup_guide_generator.py
@@ -409,56 +409,56 @@ No roads were found in the selected area."""
         by_surface = self.roads.get("by_surface", {})
         surface_str = ", ".join(f"{k}: {v}" for k, v in by_surface.items())
 
-        return f"""## Phase 5: Roads (Auto-attached prefabs)
+        return f"""## Phase 5: Roads (manual generator attach)
 
 Your terrain has **{road_count}** road segments ({surface_str}).
 
-Both the road **splines** and their **`RoadGeneratorEntity`** prefabs have been
-pre-generated in the **roads layer** (`{self.map_name}_roads.layer`). Each
-spline follows the terrain elevation, and each spline already carries the
-correct road generator prefab as a child entity. You should see fully
-rendered roads as soon as the world finishes loading.
+The roads layer (`{self.map_name}_roads.layer`) carries one
+**SplineShapeEntity** per road segment, projected to Enfusion local
+coordinates and following terrain elevation. Each spline's `//` comment
+shows the road name and the **suggested prefab** chosen from the
+known-good Reforger road set, e.g.:
 
-### Step 5.1: Verify Roads Render
+```
+SplineShapeEntity Road_12 {{ // E18 | prefab: RG_Road_Asphalt_8m
+```
+
+Splines are emitted **without** an attached `RoadGeneratorEntity` child —
+v1.1.0 attempted to auto-attach the generator but the resulting nested
+prefab syntax hangs the World Editor at 4% on world load. v1.2.3 reverts
+that behaviour. Attach the generator manually as described below.
+
+### Step 5.1: Verify Splines Loaded
 
 1. In the World Editor hierarchy, expand the **roads** layer
 2. Make sure the layer's visibility checkbox is enabled (eye icon)
-3. You should see one **SplineShapeEntity** per road segment, each with a
-   **RoadGeneratorEntity** child showing the inferred prefab path
+3. You should see one **SplineShapeEntity** per road segment, with a `//`
+   comment listing the road name and the suggested prefab name
 4. Splines include elevation data so they follow the terrain surface
-5. If a road segment looks wrong, the per-road prefab path is in
-   `Reference/roads_reference.csv` for easy override
 
-### Step 5.2: Override a Prefab (only if you need to)
+### Step 5.2: Attach a `RoadGeneratorEntity` to Each Spline
 
-The auto-attached prefab is chosen from a **known-good** list (asphalt,
-gravel, dirt at the widths shipped with stock Reforger), so it should
-load without errors. If you want to swap one:
-
-1. Select the **RoadGeneratorEntity** child under the spline
-2. In the Object Properties panel, change the prefab reference to another
-   prefab from `Prefabs/WEGenerators/Roads/`
-3. Enable **Adjust Height Map** on the generator if you want the road to
-   carve into the terrain
-
-### Step 5.3: Manual Fallback
-
-If for some reason a road spline lost its child entity (rare — only happens
-if the .layer file was hand-edited), re-attach it the original way:
-
-1. Select the SplineShapeEntity
+1. Select the **SplineShapeEntity** in the hierarchy
 2. Right-click > **Add Child Entity** > **RoadGeneratorEntity**
-3. Set the road prefab from `Reference/roads_reference.csv`
+3. In the new child's properties, set the **Prefab** field to the value
+   shown in the spline's `// prefab: …` comment, fully qualified to
+   `Prefabs/WEGenerators/Roads/<prefab>.et`
+4. Optionally enable **Adjust Height Map** on the generator to carve the
+   road into the terrain
+5. Repeat for each road spline. `Reference/roads_reference.csv` has the
+   complete per-road prefab list if you want to script this in bulk.
 
-### Step 5.4: Reference Data
+### Step 5.3: Reference Data
 
 - `Reference/roads_reference.csv` — road index, type, surface, width, and
-  the prefab that was auto-attached
+  the suggested known-good prefab
 - `Reference/roads_enfusion.geojson` — road data with local coordinates
 - `Reference/roads_splines.csv` — spline control points in local metres
 
 > **Note**: Road prefabs are located at `Prefabs/WEGenerators/Roads/` in
-> the ArmaReforger data."""
+> the ArmaReforger data. The suggested prefab is snapped to a known-good
+> name (asphalt, gravel, dirt at the widths shipped with stock Reforger),
+> so it should load without errors."""
 
     def _phase_vegetation_water(self) -> str:
         lakes = self.features.get("lakes", 0)
@@ -739,12 +739,11 @@ webapp to get simplified layers.
 
 ### Roads not visible
 - Ensure the **roads** layer is **enabled** (eye icon checked) in the hierarchy
-- Each spline already has a `RoadGeneratorEntity` child with a prefab
-  attached — check the child is present and the prefab path resolves
-- Use `Reference/roads_reference.csv` to find which prefab was auto-attached
-  for each road, in case you want to override
-- If a child entity is missing, re-add it: right-click the SplineShapeEntity
-  > Add Child Entity > RoadGeneratorEntity
+- Road splines are emitted spline-only — they need a `RoadGeneratorEntity`
+  child to render. Right-click each SplineShapeEntity > **Add Child Entity**
+  > **RoadGeneratorEntity** and set the prefab from the spline's `// prefab: …`
+  comment (or `Reference/roads_reference.csv` for the full per-road list)
+- Splines without a generator render as a thin debug line only
 
 ### No sky/atmosphere
 - Check the **default** layer has GenericWorldEntity with sky presets

--- a/webapp/tests/test_enfusion_roads_layer.py
+++ b/webapp/tests/test_enfusion_roads_layer.py
@@ -1,13 +1,16 @@
 """
-Tests for the auto-attached RoadGeneratorEntity child in the roads layer
-(Phase 1 / task A1).
+Tests for the spline-only roads layer.
 
-Pre-Phase-1 the roads layer emitted SplineShapeEntity entries only and the
-user had to right-click each one in Workbench to add a RoadGeneratorEntity
-child. The generator now emits the child prefab inline using the same
-``${guid}path/to/prefab.et { coords ... }`` syntax the managers layer uses,
-backed by the validate_road_prefab safeguard so fabricated prefab names
-never reach the .layer file.
+v1.1.0 (Phase 1 / task A1) tried to auto-attach a ``RoadGeneratorEntity``
+child by nesting a ``${guid}path/to/prefab.et { coords ... }`` line inside
+each ``SplineShapeEntity`` body. That nesting form is unsupported and hung
+the World Editor at 4% on world load. v1.2.3 reverts to spline-only road
+entities, with the validated prefab name surfaced in the spline's ``//``
+comment so the user can attach the generator manually.
+
+These tests pin the spline-only behaviour and the new
+``_simplify_local_polyline`` vertex cap that protects the loader from
+multi-thousand-point OSM ways.
 """
 
 from __future__ import annotations
@@ -82,24 +85,16 @@ def make_generator():
     return _make
 
 
-class TestRoadsLayerAutoAttach:
-    def test_road_emits_spline_with_prefab_child(self, make_generator):
+class TestRoadsLayerSplineOnly:
+    def test_road_emits_spline_with_prefab_in_comment(self, make_generator):
         gen = make_generator([_road(0, "RG_Road_Asphalt_6m", name="E39")])
         out = gen._generate_roads_layer()
 
-        # Spline parent entity exists with the road name as a comment.
+        # Spline parent entity exists with road name + prefab in the comment.
         assert "SplineShapeEntity Road_0 {" in out
-        assert "// E39" in out
+        assert "// E39 | prefab: RG_Road_Asphalt_6m" in out
 
-        # The prefab child reference is nested inside the spline body.
-        from config.enfusion import ARMA_REFORGER_GUID, ROAD_PREFAB_BASE
-        expected_ref = (
-            f"${{{ARMA_REFORGER_GUID}}}{ROAD_PREFAB_BASE}/RG_Road_Asphalt_6m.et"
-        )
-        assert expected_ref in out
-        assert out.count(expected_ref) == 1
-
-    def test_unknown_prefab_is_normalized_before_emit(self, make_generator):
+    def test_unknown_prefab_is_normalized_in_comment(self, make_generator):
         from config.roads import KNOWN_ROAD_PREFABS
 
         gen = make_generator([_road(0, "RG_Road_Asphalt_99m")])
@@ -107,13 +102,17 @@ class TestRoadsLayerAutoAttach:
 
         # The fabricated 99m name must NOT reach the layer file.
         assert "RG_Road_Asphalt_99m" not in out
-        # Whatever prefab DID get emitted must be from the known-good set.
-        emitted = [p for p in KNOWN_ROAD_PREFABS if f"/{p}.et" in out]
-        assert len(emitted) == 1, (
-            f"Expected exactly one known prefab in output; found {emitted}"
+        # Whatever prefab name DID land in the comment must be a known-good one.
+        matched = [p for p in KNOWN_ROAD_PREFABS if f"prefab: {p}" in out]
+        assert len(matched) == 1, (
+            f"Expected exactly one known prefab in comment; found {matched}"
         )
 
-    def test_each_spline_gets_exactly_one_child_prefab(self, make_generator):
+    def test_no_nested_guid_reference_inside_splines(self, make_generator):
+        """
+        Regression guard for the v1.1.0 hang: no ``${...}`` instance line
+        may appear inside any ``SplineShapeEntity Road_*`` body.
+        """
         gen = make_generator([
             _road(0, "RG_Road_Asphalt_6m"),
             _road(1, "RG_Road_Gravel_4m"),
@@ -121,10 +120,10 @@ class TestRoadsLayerAutoAttach:
         ])
         out = gen._generate_roads_layer()
 
-        # 3 splines, 3 prefab children — one each.
         assert out.count("SplineShapeEntity Road_") == 3
-        from config.enfusion import ROAD_PREFAB_BASE
-        assert out.count(f"{ROAD_PREFAB_BASE}/") == 3
+        # Workbench rejects nested ${guid}path.et inside SplineShapeEntity —
+        # the .layer must contain zero such tokens.
+        assert "${" not in out
 
     def test_no_road_data_emits_friendly_comment(self):
         from services.enfusion_project_generator import EnfusionProjectGenerator
@@ -144,3 +143,38 @@ class TestRoadsLayerAutoAttach:
         gen = make_generator([bad])
         out = gen._generate_roads_layer()
         assert "SplineShapeEntity" not in out
+
+
+class TestRoadsLayerVertexCap:
+    """A long OSM way must be simplified to <= MAX_SPLINE_POINTS vertices
+    so the World Editor doesn't choke on 'Loading entity data...'."""
+
+    def test_long_road_capped_to_max_spline_points(self, make_generator):
+        from config.enfusion import MAX_SPLINE_POINTS
+
+        # 3000 collinear points across a 4 km terrain — RDP collapses easy.
+        n = 3000
+        long_road = _road(0, "RG_Road_Asphalt_6m", name="LongRoad")
+        long_road["spline_points"] = [
+            {"x": 0.001 + (i / (n - 1)) * 3.998, "y": 1.0, "z": 0}
+            for i in range(n)
+        ]
+        long_road["point_count"] = n
+
+        gen = make_generator([long_road])
+        out = gen._generate_roads_layer()
+
+        # Count ShapePoint sp_ entries inside the single Road_0 block.
+        sp_count = out.count("ShapePoint sp_")
+        assert sp_count <= MAX_SPLINE_POINTS, (
+            f"Road spline emitted {sp_count} points; "
+            f"expected <= MAX_SPLINE_POINTS ({MAX_SPLINE_POINTS})"
+        )
+        # Sanity: still at least 2 points so the spline is valid.
+        assert sp_count >= 2
+
+    def test_short_road_passes_through_unchanged(self, make_generator):
+        gen = make_generator([_road(0, "RG_Road_Asphalt_6m")])
+        out = gen._generate_roads_layer()
+        # Fixture has 3 points, well under the cap.
+        assert out.count("ShapePoint sp_") == 3

--- a/webapp/tests/test_setup_guide_generator.py
+++ b/webapp/tests/test_setup_guide_generator.py
@@ -117,7 +117,9 @@ class TestSurfaceCoverageFiltering:
 
 
 class TestRoadsPhaseGuide:
-    """G6 — §5 must reflect the new auto-attach behavior."""
+    """v1.2.3 — §5 documents manual generator attach (the v1.1.0 auto-attach
+    nested ``${guid}...`` syntax was reverted because Workbench rejected it
+    and hung at 4% on world load)."""
 
     def test_no_roads_skipped_message(self):
         from services.setup_guide_generator import SetupGuideGenerator
@@ -125,14 +127,17 @@ class TestRoadsPhaseGuide:
         guide = SetupGuideGenerator("TestMap", meta)._phase_roads()
         assert "Phase 5: Roads (Skipped)" in guide
 
-    def test_with_roads_says_auto_attached(self):
+    def test_with_roads_describes_manual_attach(self):
         from services.setup_guide_generator import SetupGuideGenerator
         meta = _metadata(["grass"], {"grass": {"percentage": 100.0}}, road_count=12)
         guide = SetupGuideGenerator("TestMap", meta)._phase_roads()
 
-        # Headline now describes auto-attached prefabs.
-        assert "Auto-attached" in guide
-        # Manual fallback path still documented for the rare break case.
-        assert "Manual Fallback" in guide
-        # The old "Manual Prefab Assignment Required" framing must be gone.
-        assert "Manual Prefab Assignment Required" not in guide
+        # Headline + body describe manual generator attach.
+        assert "manual generator attach" in guide
+        assert "Add Child Entity" in guide
+        assert "RoadGeneratorEntity" in guide
+        # Prefab hint format from the .layer comment is documented.
+        assert "// prefab:" in guide
+        # The auto-attach framing from v1.1.0–v1.2.2 must be gone.
+        assert "Auto-attached" not in guide
+        assert "already carries" not in guide


### PR DESCRIPTION
## Summary

- Drops the nested `${guid}path.et { coords 0 0 0 }` child from every road `SplineShapeEntity` (added in v1.1.0 / PR #47, Phase 1 task A1). That nesting form is unverified Enfusion text-format syntax — Workbench rejects it and stalls "Loading entity data…" at 4% on world load. Restores v1.0.9 spline-only output. Validated prefab name is surfaced in the spline's `// prefab: …` comment instead.
- Adds `_simplify_local_polyline` (open-polyline RDP, mirrors `_simplify_local_ring`) and applies it in `_generate_roads_layer` + `_generate_river_splines`, so long OSM ways can't deliver multi-thousand-point splines that choke the loader. v1.2.2's `MAX_SPLINE_POINTS=200` cap previously only ran on closed splines.
- Rewrites `SETUP_GUIDE.md` §5 + the "Roads not visible" troubleshooting back to the manual `Right-click → Add Child Entity → RoadGeneratorEntity` workflow with prefab guidance from the spline comment / `Reference/roads_reference.csv`. Adds a TODO on the dormant Phase 3 `child_prefab` branch in `_closed_spline_entity_from_ring` warning that populating `KNOWN_FOREST_PREFABS` / `KNOWN_LAKE_PREFABS` may re-arm the same hang. `KNOWN_ROAD_PREFABS` and `validate_road_prefab` stay (still used by `road_processor` to normalize the per-road CSV — Phase 1 task L10).

Why v1.0.9 worked and v1.1.0+ didn't: the only thing that changed about road entity bodies between those releases was the nested child injection. v1.2.2's vertex cap addressed a separate forest/lake hang but never touched the roads layer, which is why the user still hit 4% on the latest release.

`APP_VERSION` 1.2.2 → 1.2.3 and README docker pin updated to match.

## Test plan

- [x] `pytest webapp/tests/test_enfusion_roads_layer.py` — 7/7 pass (replaces 3 v1.1.0 child-asserting tests with: prefab in `//` comment, no `${` token in any spline body, vertex cap ≤ `MAX_SPLINE_POINTS` for a 3000-point road, short roads pass through unchanged)
- [x] `pytest webapp/tests/test_setup_guide_generator.py webapp/tests/test_enfusion_buildings_layer.py webapp/tests/test_enfusion_vegetation_water_layers.py webapp/tests/test_phase3_generators.py` — all green (61 passed, 3 shapely-skipped)
- [x] Full suite parity with `origin/main`: 24 pre-existing failures in both, no regressions; +2 new tests pass on this branch
- [ ] Generate a Sweden `SE_60N_19E` map (the user's reproducer for the v1.2.2 hang) and confirm Workbench passes 4% in seconds and reaches 100%
- [ ] In the World Editor: roads layer expands; splines render along terrain. Right-click one spline → Add Child Entity → RoadGeneratorEntity, set prefab from the `// prefab: …` comment hint, confirm road geometry generates
- [ ] `grep -c '\${'` on the generated `*_roads.layer` returns 0; longest road's `ShapePoint sp_` count ≤ 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)