### PR TITLE
v1.2.4: remove polygon draw tool (#50) — World Editor only supports square/rectangle

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Automate the tedious work of creating custom Arma Reforger maps.** This tool generates realistic terrain from real-world geodata, eliminating hours of manual work in the [Arma Reforger World Editor](https://community.bistudio.com/wiki/Arma_Reforger:World_Editor).
 
-Instead of manually sourcing elevation data, painting surface masks by hand, placing roads one-by-one, and sculpting terrain around features, simply draw a polygon on the interactive map and get Enfusion-ready heightmaps, surface masks, and vector data in minutes.
+Instead of manually sourcing elevation data, painting surface masks by hand, placing roads one-by-one, and sculpting terrain around features, simply draw a square or rectangle on the interactive map and get Enfusion-ready heightmaps, surface masks, and vector data in minutes.
 
 <img width="1920" height="1152" alt="image" src="https://github.com/user-attachments/assets/31b9a3de-3581-47aa-b060-ee56fbcf73f6" />
 
@@ -198,7 +198,7 @@ Docker will automatically pull the latest image from `ghcr.io/tubalainen/arma_re
 
 ### 3. Generate Your First Map
 
-1. **Draw a polygon** on the interactive map by clicking the rectangle or polygon tool in the top-left
+1. **Select an area** on the interactive map by clicking the rectangle or 1:1 square tool in the top-left (Enfusion only supports square / rectangular terrain)
 2. **Set options** in the sidebar:
    - **Map Name** — letters, numbers, underscores (used as Enfusion project folder name)
    - **Heightmap Size** — 2049x2049 is a good default (2048 terrain faces at your chosen cell size)
@@ -429,7 +429,7 @@ The application is published to GitHub Container Registry and automatically buil
 docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:latest
 
 # Or use a specific version tag
-docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.2.3
+docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.2.4
 ```
 
 The `docker-compose.yml` is pre-configured to use the GHCR.io image. See the [Quick Start Guide](#quick-start-guide) for setup instructions.

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -47,7 +47,7 @@ configure_gdal_threading()
 # Application version (for cache busting)
 # ===========================================================================
 
-APP_VERSION = "1.2.3"  # Increment when static files change OR a new release ships
+APP_VERSION = "1.2.4"  # Increment when static files change OR a new release ships
 
 # ===========================================================================
 # FastAPI app

--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -39,8 +39,9 @@
                     <h6><i class="bi bi-vector-pen"></i> Area Selection</h6>
                     <p class="small mb-2">
                         Use one of the drawing tools on the map &mdash;
-                        <strong>polygon</strong>, <strong>rectangle</strong>, or
+                        <strong>rectangle</strong> or
                         <strong>1:1 square</strong> (recommended for Enfusion).
+                        Enfusion only supports square / rectangular terrain.
                     </p>
                     <div id="selection-info" class="d-none">
                         <table class="table table-sm table-dark mb-1">

--- a/webapp/static/js/app.js
+++ b/webapp/static/js/app.js
@@ -1,7 +1,7 @@
 /**
  * Arma Reforger Base Map Generator - Frontend Application
  *
- * Interactive map with polygon drawing for area selection,
+ * Interactive map with rectangle / 1:1-square area selection,
  * generation controls, and result display.
  */
 
@@ -37,7 +37,7 @@ L.control.layers({
 }, null, { position: 'topright' }).addTo(map);
 
 // ===========================================================================
-// Polygon drawing
+// Area drawing
 // ===========================================================================
 
 const drawnItems = new L.FeatureGroup();
@@ -106,17 +106,15 @@ L.Draw.Square = L.Draw.Rectangle.extend({
 
 L.drawLocal.draw.toolbar.buttons.square = 'Draw a square area (recommended)';
 
-// Standard draw toolbar (polygon + rectangle + edit/remove). The Square
-// button is injected into the same toolbar below so all three drawing
-// tools live in one uniform control group.
+// Standard draw toolbar (rectangle + edit/remove). The Square button is
+// injected into the same toolbar below so both drawing tools live in one
+// uniform control group. The Enfusion World Editor only supports
+// square / rectangular terrain (issue #50), so the polygon tool is
+// disabled.
 const drawControl = new L.Control.Draw({
     position: 'topleft',
     draw: {
-        polygon: {
-            allowIntersection: false,
-            drawError: { color: '#f85149', timeout: 1000 },
-            shapeOptions: { ...SHAPE_STYLE },
-        },
+        polygon: false,
         rectangle: {
             shapeOptions: { ...SHAPE_STYLE },
         },
@@ -132,7 +130,7 @@ const drawControl = new L.Control.Draw({
 });
 map.addControl(drawControl);
 
-// Inject a Square button into the same toolbar row as polygon and rectangle.
+// Inject a Square button into the same toolbar row as rectangle.
 // Using the existing Leaflet.Draw toolbar gives us identical sizing, borders,
 // and hover styling — see issue #40.
 (function addSquareToolButton() {
@@ -174,30 +172,28 @@ let logsSinceCursor = 0;
 // ===========================================================================
 
 map.on(L.Draw.Event.CREATED, function (event) {
-    // Clear previous polygon
+    // Only rectangle / square selections are supported — Enfusion World Editor
+    // can only build square or rectangular terrain (issue #50).
+    if (event.layerType !== 'rectangle' && event.layerType !== 'square') {
+        return;
+    }
+
+    // Clear previous selection
     drawnItems.clearLayers();
 
     const layer = event.layer;
     drawnItems.addLayer(layer);
     currentPolygon = layer;
 
-    // Extract coordinates as [lng, lat] pairs
-    let coords;
-    if (event.layerType === 'rectangle' || event.layerType === 'square') {
-        const bounds = layer.getBounds();
-        coords = [
-            [bounds.getWest(), bounds.getSouth()],
-            [bounds.getEast(), bounds.getSouth()],
-            [bounds.getEast(), bounds.getNorth()],
-            [bounds.getWest(), bounds.getNorth()],
-            [bounds.getWest(), bounds.getSouth()],
-        ];
-    } else {
-        const latLngs = layer.getLatLngs()[0];
-        coords = latLngs.map(ll => [ll.lng, ll.lat]);
-        // Close polygon
-        coords.push([latLngs[0].lng, latLngs[0].lat]);
-    }
+    // Extract bbox corners as [lng, lat] pairs (closed ring)
+    const bounds = layer.getBounds();
+    const coords = [
+        [bounds.getWest(), bounds.getSouth()],
+        [bounds.getEast(), bounds.getSouth()],
+        [bounds.getEast(), bounds.getNorth()],
+        [bounds.getWest(), bounds.getNorth()],
+        [bounds.getWest(), bounds.getSouth()],
+    ];
 
     currentPolygonCoords = coords;
     onPolygonSelected(coords);


### PR DESCRIPTION
Closes #50.

## Summary

- `Leaflet.Draw` toolbar: `polygon: false`. Square + rectangle tools remain. The square injection logic and styling are unchanged.
- `L.Draw.Event.CREATED` handler now rejects any layerType other than `rectangle` / `square`, and the polygon-coordinate branch is removed (rectangle/square always emit a closed bbox ring).
- Sidebar help in [`webapp/static/index.html`](webapp/static/index.html) and the README intro + quick-start step rewritten to mention only rectangle + 1:1 square, with a note that Enfusion only supports square / rectangular terrain.
- Backend untouched: `country_detector.detect_countries` already takes the drawn polygon's bbox before feeding the rest of the pipeline, so removing the UI affordance is the only change required. No endpoint, validation, or test changes.

`APP_VERSION` 1.2.3 → 1.2.4 and the README Docker pin updated to match.

## Test plan

- [x] `node --check webapp/static/js/app.js` — clean parse
- [ ] Visual check in the Launch preview panel: polygon tool no longer in the top-left toolbar; rectangle + square tools both present and styled identically; sidebar copy reads "rectangle or 1:1 square"
- [ ] Draw a square → confirm `selection-info` populates and Generate runs end-to-end
- [ ] Draw a rectangle → confirm same

🤖 Generated with [Claude Code](https://claude.com/claude-code)