### PR TITLE
v1.2.5: detect USA selections (fix #48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ The application is published to GitHub Container Registry and automatically buil
 docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:latest
 
 # Or use a specific version tag
-docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.2.4
+docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.2.5
 ```
 
 The `docker-compose.yml` is pre-configured to use the GHCR.io image. See the [Quick Start Guide](#quick-start-guide) for setup instructions.

--- a/webapp/config/countries.py
+++ b/webapp/config/countries.py
@@ -36,6 +36,8 @@ COUNTRY_BOUNDS: dict[str, tuple[float, float, float, float]] = {
     "PT": (37.00, -9.50, 42.20, -6.20),
     "IE": (51.40, -10.50, 55.40, -6.00),
     "IS": (63.30, -24.50, 66.50, -13.50),
+    # North America
+    "US": (24.40, -125.00, 49.40, -66.90),  # CONUS only — Alaska/Hawaii excluded
 }
 
 # CRS recommendations per country
@@ -67,6 +69,7 @@ COUNTRY_NAMES: dict[str, str] = {
     "BE": "Belgium", "UA": "Ukraine", "RO": "Romania", "HU": "Hungary",
     "SK": "Slovakia", "HR": "Croatia", "RS": "Serbia", "BG": "Bulgaria",
     "GR": "Greece", "PT": "Portugal", "IE": "Ireland", "IS": "Iceland",
+    "US": "United States",
 }
 
 # Treeline elevations per country (metres above sea level)

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -47,7 +47,7 @@ configure_gdal_threading()
 # Application version (for cache busting)
 # ===========================================================================
 
-APP_VERSION = "1.2.4"  # Increment when static files change OR a new release ships
+APP_VERSION = "1.2.5"  # Increment when static files change OR a new release ships
 
 # ===========================================================================
 # FastAPI app


### PR DESCRIPTION
## Summary

Fixes #48. The offline polygon detector had no entry for the USA, so any U.S. selection fell through to the Nominatim reverse-geocode fallback, which on rate-limit returns nothing and leaves `primary_country = "UNKNOWN"` (the symptom in the issue: lots of retries, then UNKNOWN).

- Add CONUS bounds to `COUNTRY_BOUNDS` and `"US": "United States"` to `COUNTRY_NAMES` in [webapp/config/countries.py](webapp/config/countries.py).
- Bump `APP_VERSION` 1.2.4 → 1.2.5 + README image tag.

Detection now resolves U.S. selections offline via the existing bbox-fallback path. Elevation continues to use the OpenTopography Copernicus DEM 30 m fallback (no USGS 3DEP integration here — that's a separate feature, see the country geodata catalog).

CONUS only — Alaska/Hawaii are excluded (lon wrap and isolation make a single bbox a poor fit; can be added separately if requested).

## Test plan

- [ ] Draw a polygon over part of the U.S. mainland; verify `primary_country = "US"` in the activity log instead of `UNKNOWN`.
- [ ] Confirm no Nominatim retry storm in logs for U.S. selections.
- [ ] Generation completes with Cop30 elevation fallback.
- [ ] Existing European-country selections still detect correctly (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)