### PR TITLE
v1.3.1: fix asphalt mask (#55) + satellite alignment for rectangular maps (#58)

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ The application is published to GitHub Container Registry and automatically buil
 docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:latest
 
 # Or use a specific version tag
-docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.3.0
+docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.3.1
 ```
 
 The `docker-compose.yml` is pre-configured to use the GHCR.io image. See the [Quick Start Guide](#quick-start-guide) for setup instructions.

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -47,7 +47,7 @@ configure_gdal_threading()
 # Application version (for cache busting)
 # ===========================================================================
 
-APP_VERSION = "1.3.0"  # Increment when static files change OR a new release ships
+APP_VERSION = "1.3.1"  # Increment when static files change OR a new release ships
 
 # ===========================================================================
 # FastAPI app

--- a/webapp/services/map_generator.py
+++ b/webapp/services/map_generator.py
@@ -1033,7 +1033,7 @@ async def run_generation(job: MapGenerationJob):
                     src_bbox=(bbox["west"], bbox["south"], bbox["east"], bbox["north"]),
                     dst_crs=country_info["crs"],
                     dst_bounds=dst_bounds,
-                    target_size=target_size_x,
+                    target_size=(target_size_x, target_size_z),
                 )
                 if reproject_ok:
                     job.add_log(

--- a/webapp/services/satellite_service.py
+++ b/webapp/services/satellite_service.py
@@ -325,7 +325,7 @@ def reproject_satellite_to_terrain_crs(
     src_bbox: tuple[float, float, float, float],
     dst_crs: str,
     dst_bounds: tuple[float, float, float, float],
-    target_size: int,
+    target_size: tuple[int, int] | int,
 ) -> bool:
     """
     Reproject satellite_map.png from WGS84 to the terrain's native projected CRS.
@@ -347,7 +347,8 @@ def reproject_satellite_to_terrain_crs(
         dst_bounds: Bounding box in dst_crs (min_x, min_y, max_x, max_y).
             These are the _sw_projected and _ne_projected values from
             CoordinateTransformer.
-        target_size: Output pixel dimensions (target_size × target_size).
+        target_size: Output pixel dimensions as (width, height). For backwards
+            compatibility a scalar is also accepted and produces a square output.
 
     Returns:
         True on success, False on failure (original file left unchanged on error).
@@ -360,6 +361,11 @@ def reproject_satellite_to_terrain_crs(
         from rasterio.crs import CRS
         from rasterio.transform import from_bounds
         from rasterio.warp import Resampling, reproject
+
+        if isinstance(target_size, int):
+            target_w, target_h = target_size, target_size
+        else:
+            target_w, target_h = int(target_size[0]), int(target_size[1])
 
         satellite_path = Path(satellite_path)
 
@@ -381,10 +387,10 @@ def reproject_satellite_to_terrain_crs(
         # Destination affine: projected CRS, north-up
         min_x, min_y, max_x, max_y = dst_bounds
         dst_crs_obj = CRS.from_string(dst_crs)
-        dst_transform = from_bounds(min_x, min_y, max_x, max_y, target_size, target_size)
+        dst_transform = from_bounds(min_x, min_y, max_x, max_y, target_w, target_h)
 
-        # Allocate destination
-        dst_raster = np.zeros((3, target_size, target_size), dtype=np.uint8)
+        # Allocate destination (rasterio expects bands × H × W)
+        dst_raster = np.zeros((3, target_h, target_w), dtype=np.uint8)
 
         # Reproject all three bands
         for band in range(3):
@@ -404,7 +410,7 @@ def reproject_satellite_to_terrain_crs(
 
         logger.info(
             f"Reprojected satellite image EPSG:4326 → {dst_crs} "
-            f"({target_size}×{target_size}px, "
+            f"({target_w}×{target_h}px, "
             f"bounds: {min_x:.0f},{min_y:.0f} → {max_x:.0f},{max_y:.0f})"
         )
         return True

--- a/webapp/services/surface_mask_generator.py
+++ b/webapp/services/surface_mask_generator.py
@@ -35,7 +35,9 @@ from config.enfusion import (
     SURFACE_IMPORT_ORDER,
 )
 from services.heightmap_generator import rasterize_features_to_mask
+from services.road_processor import infer_road_surface, infer_road_width
 from services.utils.parallel import parallel_gaussian_filter, parallel_edt
+from services.utils.rasterize import rasterize_lines_per_feature_width
 
 logger = logging.getLogger(__name__)
 
@@ -359,7 +361,7 @@ def generate_surface_masks(
     1. Grass (default complement — fills wherever no other surface claims)
     2. Forest floor (deciduous forest areas)
     3. Pine floor (coniferous forest areas)
-    4. Asphalt (paved roads + urban areas)
+    4. Asphalt (paved roads, per-feature width — matches road splines)
     5. Gravel (gravel/unpaved roads)
     6. Dirt (farmland, dirt paths)
     7. Rock (steep slopes + above treeline)
@@ -407,15 +409,15 @@ def generate_surface_masks(
     if job:
         job.add_log(f"Generating surface masks for {w}x{h} terrain (cell size: {cell_size_m}m)...")
 
-    # Resolution-scaled parameters
+    # Resolution-scaled parameters. Asphalt no longer uses a fixed buffer —
+    # each paved road feature is rasterized at its own OSM-derived width.
     sigma = max(1.0, 2.0 * (cell_size_m / 2.0))
-    road_buffer_px = max(2, int(6.0 / cell_size_m))    # ~6m paved road half-width
     gravel_buffer_px = max(1, int(3.0 / cell_size_m))   # ~3m gravel road half-width
     forest_transition_px = max(3, int(20.0 / cell_size_m))  # ~20m forest edge transition
     sand_transition_px = max(2, int(10.0 / cell_size_m))    # ~10m shoreline transition
 
     logger.debug(
-        f"Resolution-scaled params: sigma={sigma:.1f}, road_buf={road_buffer_px}px, "
+        f"Resolution-scaled params: sigma={sigma:.1f}, "
         f"gravel_buf={gravel_buffer_px}px, forest_edge={forest_transition_px}px"
     )
 
@@ -463,21 +465,10 @@ def generate_surface_masks(
     # Deciduous = all forest minus coniferous
     deciduous_binary = forest_binary & ~coniferous_binary
 
-    # Paved roads
-    logger.debug("Rasterizing road network...")
-    if job:
-        job.progress = 64
-    asphalt_types = [
-        "motorway", "trunk", "primary", "secondary", "tertiary",
-        "residential", "unclassified", "service", "motorway_link",
-        "trunk_link", "primary_link", "secondary_link", "tertiary_link",
-        "living_street", "cycleway",
-    ]
-    asphalt_binary = _rasterize_lines(
-        osm_data.get("roads"), bounds, w, h,
-        buffer_px=road_buffer_px,
-        filter_tags={"highway": asphalt_types},
-    )
+    # Paved roads — built later, after `urban_binary` is rasterized, so that
+    # the per-feature surface classification can consult the urban polygons to
+    # decide whether context-dependent highway types (residential / service /
+    # cycleway / unclassified) end up as asphalt vs gravel. See below.
 
     # Gravel/dirt roads
     gravel_types = ["track", "path", "footway", "bridleway"]
@@ -501,13 +492,78 @@ def generate_surface_masks(
         filter_tags={"type": ["farmland", "farmyard", "allotments", "orchard"]},
     )
 
-    # Urban areas + buildings
+    # Urban polygons — used solely as context input to the road-surface
+    # classifier so the asphalt mask agrees with road_processor's spline
+    # classification (residential/service/cycleway → asphalt inside urban
+    # polygons, gravel outside). Pre-v1.2.5 the urban polygons themselves
+    # (plus all building footprints) were painted as ~50% asphalt, which
+    # produced large rectangular asphalt patches in residential areas with
+    # no actual roads (issue #55). They are no longer painted directly.
     urban_binary = _rasterize_polygons(
         osm_data.get("land_use"), bounds, w, h,
         filter_tags={"type": ["residential", "industrial", "commercial", "retail"]},
     )
-    building_binary = _rasterize_polygons(osm_data.get("buildings"), bounds, w, h)
-    urban_combined = urban_binary | building_binary
+
+    # Paved roads — rasterize each feature at its own width (matching the
+    # per-feature width used by road_processor when emitting splines) and
+    # classify surface using the same infer_road_surface() helper so the
+    # asphalt mask follows exactly the same road set as the splines.
+    logger.debug("Rasterizing road network (per-feature widths)...")
+    if job:
+        job.progress = 64
+
+    def _line_midpoint_in_urban(coords: list) -> bool:
+        if not coords or len(coords) < 2:
+            return False
+        mid_lng, mid_lat = coords[len(coords) // 2]
+        west, south, east, north = bounds
+        if not (west <= mid_lng <= east and south <= mid_lat <= north):
+            return False
+        px = int((mid_lng - west) / (east - west) * w)
+        py = int((north - mid_lat) / (north - south) * h)
+        px = max(0, min(w - 1, px))
+        py = max(0, min(h - 1, py))
+        return bool(urban_binary[py, px])
+
+    def _is_asphalt_feature(feature: dict) -> bool:
+        geom = feature.get("geometry", {})
+        if geom.get("type") not in ("LineString", "MultiLineString"):
+            return False
+        props = feature.get("properties", {})
+        highway = props.get("highway", "")
+        if not highway:
+            return False
+        coords = geom.get("coordinates", [])
+        if geom.get("type") == "MultiLineString":
+            coords = coords[0] if coords else []
+        is_urban = _line_midpoint_in_urban(coords)
+        surface = infer_road_surface(
+            highway_type=highway,
+            osm_surface=props.get("surface", ""),
+            country_code=country_code,
+            is_in_forest=False,
+            is_in_urban=is_urban,
+        )
+        return surface == "asphalt"
+
+    def _feature_buffer_px(feature: dict) -> int:
+        props = feature.get("properties", {})
+        width_m = infer_road_width(
+            highway_type=props.get("highway", ""),
+            osm_width=props.get("width", ""),
+            osm_lanes=props.get("lanes", ""),
+            surface="asphalt",
+        )
+        return max(1, int(round((width_m / 2.0) / cell_size_m)))
+
+    asphalt_binary = rasterize_lines_per_feature_width(
+        osm_data.get("roads") or {"features": []},
+        width=w,
+        height=h,
+        bbox_wgs84=bounds,
+        buffer_px_fn=_feature_buffer_px,
+        filter_fn=_is_asphalt_feature,
+    ).astype(bool)
 
     # =========================================================================
     # Step 3: Compute soft-edge float masks [0.0, 1.0]
@@ -543,9 +599,7 @@ def generate_surface_masks(
         return pine
 
     def _compute_asphalt():
-        asphalt_soft = soft_edge_mask(asphalt_binary, transition_px=2)
-        urban_soft = soft_edge_mask(urban_combined, transition_px=3) * 0.5
-        return np.maximum(asphalt_soft, urban_soft)
+        return soft_edge_mask(asphalt_binary, transition_px=2)
 
     def _compute_gravel():
         """Gravel/unpaved roads."""

--- a/webapp/services/utils/rasterize.py
+++ b/webapp/services/utils/rasterize.py
@@ -19,6 +19,8 @@ Polygon-with-holes handling:
 
 from __future__ import annotations
 
+from typing import Callable
+
 import numpy as np
 from PIL import Image, ImageChops, ImageDraw
 from scipy import ndimage
@@ -118,6 +120,72 @@ def rasterize_features_to_mask(
 
     # Convert 0/255 to 0/1
     return (mask > 0).astype(np.uint8)
+
+
+def rasterize_lines_per_feature_width(
+    geojson: dict,
+    width: int,
+    height: int,
+    bbox_wgs84: tuple[float, float, float, float],
+    buffer_px_fn: Callable[[dict], int],
+    filter_fn: Callable[[dict], bool] | None = None,
+) -> np.ndarray:
+    """
+    Rasterize LineString / MultiLineString features with a per-feature buffer.
+
+    Unlike rasterize_features_to_mask which applies one global buffer to every
+    line, this variant calls `buffer_px_fn(feature)` for each feature so that
+    e.g. a 4m residential street and a 14m motorway are rendered at different
+    pixel widths — which lets the asphalt surface mask match the per-feature
+    widths used to generate the road splines.
+
+    Args:
+        geojson: GeoJSON FeatureCollection.
+        width:   Output raster width in pixels.
+        height:  Output raster height in pixels.
+        bbox_wgs84: (west, south, east, north) bounding box.
+        buffer_px_fn: Callable receiving a feature dict and returning the
+            per-feature half-width in pixels. Drawn line width = 2*half+1.
+        filter_fn: Optional callable receiving a feature dict and returning
+            True if the feature should be drawn. Use this to reproduce the
+            road-surface classification logic (so the mask matches the spline).
+
+    Returns:
+        Binary uint8 mask (0 or 1).
+    """
+    west, south, east, north = bbox_wgs84
+    lng_range = east - west
+    lat_range = north - south
+    if lng_range <= 0 or lat_range <= 0:
+        return np.zeros((height, width), dtype=np.uint8)
+
+    line_img = Image.new("L", (width, height), 0)
+    line_draw = ImageDraw.Draw(line_img)
+
+    for feature in geojson.get("features", []):
+        if filter_fn is not None and not filter_fn(feature):
+            continue
+
+        geom = feature.get("geometry", {})
+        geom_type = geom.get("type", "")
+        coords = geom.get("coordinates", [])
+        if not coords:
+            continue
+
+        half = max(0, int(buffer_px_fn(feature)))
+        line_width = max(1, half * 2 + 1)
+
+        if geom_type == "LineString":
+            pixels = _coords_to_pixels(coords, west, north, lng_range, lat_range, width, height)
+            if len(pixels) >= 2:
+                line_draw.line(pixels, fill=255, width=line_width)
+        elif geom_type == "MultiLineString":
+            for line_coords in coords:
+                pixels = _coords_to_pixels(line_coords, west, north, lng_range, lat_range, width, height)
+                if len(pixels) >= 2:
+                    line_draw.line(pixels, fill=255, width=line_width)
+
+    return (np.array(line_img) > 0).astype(np.uint8)
 
 
 def _composite_polygon_with_holes(

--- a/webapp/tests/test_rasterize.py
+++ b/webapp/tests/test_rasterize.py
@@ -18,7 +18,10 @@ WEBAPP_DIR = Path(__file__).parent.parent
 if str(WEBAPP_DIR) not in sys.path:
     sys.path.insert(0, str(WEBAPP_DIR))
 
-from services.utils.rasterize import rasterize_features_to_mask  # noqa: E402
+from services.utils.rasterize import (  # noqa: E402
+    rasterize_features_to_mask,
+    rasterize_lines_per_feature_width,
+)
 
 
 # A 1°×1° bbox with width/height = 100 px → 1 pixel ≈ 0.01° on each side.
@@ -178,6 +181,91 @@ class TestLines:
         mask = rasterize_features_to_mask(gj, W, H, BBOX, buffer_px=1)
         # The horizontal centre row should have at least one painted pixel
         assert mask[H // 2].sum() > 0
+
+    def test_per_feature_width_renders_wider_for_wider_roads(self):
+        # Two horizontal LineStrings; one labelled width=4, the other width=14.
+        # The buffer_px_fn translates each to a different pixel half-width and
+        # the resulting mask must have a thicker stripe for the wider road.
+        gj = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "LineString",
+                        "coordinates": [[0.0, 0.25], [1.0, 0.25]],
+                    },
+                    "properties": {"width_m": 4},
+                },
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "LineString",
+                        "coordinates": [[0.0, 0.75], [1.0, 0.75]],
+                    },
+                    "properties": {"width_m": 14},
+                },
+            ],
+        }
+        # Width 14 → half=7 → pixel width 15; width 4 → half=2 → pixel width 5.
+        buffer_fn = lambda f: f["properties"]["width_m"] // 2
+        mask = rasterize_lines_per_feature_width(
+            gj, W, H, BBOX, buffer_px_fn=buffer_fn,
+        )
+
+        # Find the painted-stripe height around each road.
+        # narrow stripe: roughly centered at y = H * (1 - 0.25) = 75
+        # wide stripe:   roughly centered at y = H * (1 - 0.75) = 25
+        narrow_col = mask[:, W // 2]
+        narrow_stripe_y = np.where(narrow_col > 0)[0]
+        wide_col = mask[:, W // 2]
+        # Both stripes share the same column; split by centre y
+        narrow_band = narrow_stripe_y[narrow_stripe_y > H // 2]
+        wide_band = narrow_stripe_y[narrow_stripe_y < H // 2]
+
+        assert len(narrow_band) >= 1
+        assert len(wide_band) >= 1
+        # Wider road must paint strictly more pixels per column.
+        assert len(wide_band) > len(narrow_band), (
+            f"Wider road must produce a thicker stripe; got narrow={len(narrow_band)}, "
+            f"wide={len(wide_band)} — per-feature buffer_px_fn likely ignored."
+        )
+
+    def test_per_feature_filter_excludes_unwanted_features(self):
+        gj = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "LineString",
+                        "coordinates": [[0.0, 0.5], [1.0, 0.5]],
+                    },
+                    "properties": {"surface": "asphalt"},
+                },
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "LineString",
+                        "coordinates": [[0.5, 0.0], [0.5, 1.0]],
+                    },
+                    "properties": {"surface": "gravel"},
+                },
+            ],
+        }
+        mask = rasterize_lines_per_feature_width(
+            gj, W, H, BBOX,
+            buffer_px_fn=lambda f: 1,
+            filter_fn=lambda f: f["properties"]["surface"] == "asphalt",
+        )
+        # Horizontal asphalt line is drawn (centre row has pixels).
+        assert mask[H // 2].sum() > 0
+        # Vertical gravel line is filtered out (centre column has only the
+        # one painted pixel from the asphalt row).
+        col_pixels = mask[:, W // 2].sum()
+        assert col_pixels <= 3, (
+            f"Filtered-out gravel line should not be drawn; column sum={col_pixels}"
+        )
 
     def test_polygon_holes_dont_erase_lines(self):
         # Polygon with hole AND a line crossing the hole

--- a/webapp/tests/test_satellite_service.py
+++ b/webapp/tests/test_satellite_service.py
@@ -1,0 +1,135 @@
+"""
+Tests for services/satellite_service.py.
+
+Focuses on reproject_satellite_to_terrain_crs and its handling of rectangular
+(non-square) terrain outputs. Pre-v1.2.5 the function hardcoded a square output
+grid, which corrupted rectangular maps (issue #58).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+WEBAPP_DIR = Path(__file__).parent.parent
+if str(WEBAPP_DIR) not in sys.path:
+    sys.path.insert(0, str(WEBAPP_DIR))
+
+# rasterio lives in the Docker image but not in dev environments without GDAL.
+pytest.importorskip("rasterio", reason="rasterio is required for satellite reprojection tests")
+
+from services.satellite_service import reproject_satellite_to_terrain_crs  # noqa: E402
+
+
+# A small synthetic WGS84 bbox at mid-Sweden latitude (where EPSG:3006 is meaningful).
+# Use a roughly 1° wide × 0.5° tall rectangle so the aspect is genuinely non-square.
+SRC_BBOX = (15.0, 58.0, 16.0, 58.5)
+
+# Projected destination bounds (SWEREF99 TM, EPSG:3006). The exact numbers don't
+# matter for these tests — only that the aspect is the same as the requested
+# pixel dimensions.
+DST_CRS = "EPSG:3006"
+DST_BOUNDS_2_TO_1 = (500_000.0, 6_400_000.0, 560_000.0, 6_430_000.0)  # 60 km × 30 km
+DST_BOUNDS_SQUARE = (500_000.0, 6_400_000.0, 540_000.0, 6_440_000.0)  # 40 km × 40 km
+
+
+def _write_synthetic_png(path: Path, width: int, height: int) -> None:
+    """Write a colorful gradient PNG so reprojection produces non-zero output."""
+    arr = np.zeros((height, width, 3), dtype=np.uint8)
+    arr[..., 0] = np.linspace(0, 255, width, dtype=np.uint8)[None, :]
+    arr[..., 1] = np.linspace(0, 255, height, dtype=np.uint8)[:, None]
+    arr[..., 2] = 128
+    Image.fromarray(arr).save(str(path), format="PNG")
+
+
+class TestReprojectRectangular:
+    def test_reproject_preserves_rectangular_dimensions(self, tmp_path: Path):
+        """Rectangular target (800×400) must produce a rectangular PNG, not a square one."""
+        png = tmp_path / "satellite_map.png"
+        _write_synthetic_png(png, width=1000, height=500)
+
+        ok = reproject_satellite_to_terrain_crs(
+            satellite_path=png,
+            src_bbox=SRC_BBOX,
+            dst_crs=DST_CRS,
+            dst_bounds=DST_BOUNDS_2_TO_1,
+            target_size=(800, 400),
+        )
+        assert ok is True
+
+        with Image.open(png) as out:
+            assert out.size == (800, 400), (
+                f"Reprojection must honour the requested (width, height) tuple; "
+                f"pre-v1.2.5 it produced a square output, corrupting rectangular maps. "
+                f"Got {out.size}."
+            )
+
+    def test_reproject_preserves_square_dimensions(self, tmp_path: Path):
+        """Regression: square targets must still work (this is the v1.2.4 behaviour)."""
+        png = tmp_path / "satellite_map.png"
+        _write_synthetic_png(png, width=512, height=512)
+
+        ok = reproject_satellite_to_terrain_crs(
+            satellite_path=png,
+            src_bbox=SRC_BBOX,
+            dst_crs=DST_CRS,
+            dst_bounds=DST_BOUNDS_SQUARE,
+            target_size=(512, 512),
+        )
+        assert ok is True
+
+        with Image.open(png) as out:
+            assert out.size == (512, 512)
+
+    def test_reproject_accepts_scalar_target_size(self, tmp_path: Path):
+        """Backwards-compatibility: a scalar target_size should still produce a square output."""
+        png = tmp_path / "satellite_map.png"
+        _write_synthetic_png(png, width=512, height=512)
+
+        ok = reproject_satellite_to_terrain_crs(
+            satellite_path=png,
+            src_bbox=SRC_BBOX,
+            dst_crs=DST_CRS,
+            dst_bounds=DST_BOUNDS_SQUARE,
+            target_size=256,
+        )
+        assert ok is True
+
+        with Image.open(png) as out:
+            assert out.size == (256, 256)
+
+    def test_reproject_tall_rectangle(self, tmp_path: Path):
+        """Aspect must be respected when height > width too."""
+        png = tmp_path / "satellite_map.png"
+        _write_synthetic_png(png, width=400, height=800)
+
+        # 30 km × 60 km — tall in the projected CRS
+        dst_bounds_tall = (500_000.0, 6_400_000.0, 530_000.0, 6_460_000.0)
+        ok = reproject_satellite_to_terrain_crs(
+            satellite_path=png,
+            src_bbox=(15.0, 58.0, 15.5, 59.0),
+            dst_crs=DST_CRS,
+            dst_bounds=dst_bounds_tall,
+            target_size=(400, 800),
+        )
+        assert ok is True
+
+        with Image.open(png) as out:
+            assert out.size == (400, 800)
+
+
+class TestReprojectFailure:
+    def test_missing_file_returns_false(self, tmp_path: Path):
+        """A missing source file must yield False so callers can warn instead of crashing."""
+        ok = reproject_satellite_to_terrain_crs(
+            satellite_path=tmp_path / "does_not_exist.png",
+            src_bbox=SRC_BBOX,
+            dst_crs=DST_CRS,
+            dst_bounds=DST_BOUNDS_2_TO_1,
+            target_size=(800, 400),
+        )
+        assert ok is False

--- a/webapp/tests/test_surface_mask_generator.py
+++ b/webapp/tests/test_surface_mask_generator.py
@@ -1,0 +1,254 @@
+"""
+Tests for services/surface_mask_generator.py.
+
+Focuses on the asphalt mask, which was rewritten in v1.2.5 to fix issue #55:
+- Per-feature OSM widths drive per-feature pixel widths (so the mask matches
+  the road splines emitted by road_processor).
+- Urban landuse polygons and building footprints no longer paint asphalt
+  outside actual roads.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+WEBAPP_DIR = Path(__file__).parent.parent
+if str(WEBAPP_DIR) not in sys.path:
+    sys.path.insert(0, str(WEBAPP_DIR))
+
+from services.surface_mask_generator import generate_surface_masks  # noqa: E402
+
+
+# Small Swedish bbox at ~1m/pixel — 512×512 is enough for the rasterization
+# logic without blowing up runtime.
+BBOX = (15.0, 58.0, 15.005, 58.003)  # roughly 300m × 333m at this latitude
+W, H = 512, 384
+
+
+def _flat_elevation() -> np.ndarray:
+    return np.full((H, W), 100.0, dtype=np.float32)
+
+
+def _road_feature(lng_start: float, lat: float, lng_end: float, highway: str,
+                  width: str | None = None, lanes: str | None = None) -> dict:
+    props = {"highway": highway}
+    if width is not None:
+        props["width"] = width
+    if lanes is not None:
+        props["lanes"] = lanes
+    return {
+        "type": "Feature",
+        "geometry": {
+            "type": "LineString",
+            "coordinates": [[lng_start, lat], [lng_end, lat]],
+        },
+        "properties": props,
+    }
+
+
+def _landuse_polygon(lng_min: float, lat_min: float, lng_max: float, lat_max: float,
+                     landuse_type: str) -> dict:
+    return {
+        "type": "Feature",
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [[
+                [lng_min, lat_min], [lng_max, lat_min],
+                [lng_max, lat_max], [lng_min, lat_max], [lng_min, lat_min],
+            ]],
+        },
+        "properties": {"type": landuse_type},
+    }
+
+
+def _building_polygon(lng_min: float, lat_min: float, lng_max: float, lat_max: float) -> dict:
+    return {
+        "type": "Feature",
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [[
+                [lng_min, lat_min], [lng_max, lat_min],
+                [lng_max, lat_max], [lng_min, lat_max], [lng_min, lat_min],
+            ]],
+        },
+        "properties": {},
+    }
+
+
+def _empty_collection() -> dict:
+    return {"type": "FeatureCollection", "features": []}
+
+
+def _run_with(osm_data: dict, tmp_path: Path) -> np.ndarray:
+    """Run generate_surface_masks and return the asphalt mask as a 2-D uint8 array."""
+    result = generate_surface_masks(
+        elevation=_flat_elevation(),
+        osm_data=osm_data,
+        bounds=BBOX,
+        cell_size_m=1.0,
+        output_dir=tmp_path,
+        country_code="SE",
+        heightmap_dimensions=(W, H),
+    )
+    assert result is not None
+    asphalt_path = tmp_path / "surface_asphalt.png"
+    if not asphalt_path.exists():
+        # The generator skips empty masks; return a zero array.
+        return np.zeros((H, W), dtype=np.uint8)
+    return np.array(Image.open(asphalt_path).convert("L"))
+
+
+class TestAsphaltUrbanPolygonsNoLongerPainted:
+    def test_residential_landuse_alone_produces_no_asphalt(self, tmp_path: Path):
+        """Pre-v1.2.5: a residential polygon painted ~50% asphalt over its whole area.
+        Post-v1.2.5: no roads → no asphalt mask file (or fully zero)."""
+        osm_data = {
+            "roads": _empty_collection(),
+            "water": _empty_collection(),
+            "forests": _empty_collection(),
+            "buildings": _empty_collection(),
+            "land_use": {
+                "type": "FeatureCollection",
+                "features": [
+                    _landuse_polygon(15.001, 58.0005, 15.004, 58.0025, "residential"),
+                ],
+            },
+        }
+        mask = _run_with(osm_data, tmp_path)
+        # Inside the residential polygon there must be zero asphalt.
+        assert mask.sum() == 0, (
+            f"Residential landuse with no roads must produce no asphalt; "
+            f"got {mask.sum()} non-zero pixels."
+        )
+
+    def test_buildings_alone_produce_no_asphalt(self, tmp_path: Path):
+        osm_data = {
+            "roads": _empty_collection(),
+            "water": _empty_collection(),
+            "forests": _empty_collection(),
+            "buildings": {
+                "type": "FeatureCollection",
+                "features": [
+                    _building_polygon(15.002, 58.001, 15.003, 58.002),
+                ],
+            },
+            "land_use": _empty_collection(),
+        }
+        mask = _run_with(osm_data, tmp_path)
+        assert mask.sum() == 0, (
+            f"Building footprints with no roads must produce no asphalt; "
+            f"got {mask.sum()} non-zero pixels."
+        )
+
+
+class TestAsphaltMatchesRoadProcessorClassification:
+    def test_service_road_outside_urban_is_not_asphalt(self, tmp_path: Path):
+        """Per road_processor.infer_road_surface, 'service' outside urban → gravel."""
+        osm_data = {
+            "roads": {
+                "type": "FeatureCollection",
+                "features": [
+                    _road_feature(15.001, 58.0015, 15.004, "service"),
+                ],
+            },
+            "water": _empty_collection(),
+            "forests": _empty_collection(),
+            "buildings": _empty_collection(),
+            "land_use": _empty_collection(),
+        }
+        mask = _run_with(osm_data, tmp_path)
+        assert mask.sum() == 0, (
+            "A 'service' road outside any urban polygon must be classified as "
+            "gravel (not asphalt) so the mask agrees with the spline."
+        )
+
+    def test_service_road_inside_urban_is_asphalt(self, tmp_path: Path):
+        """Same service road, but the midpoint sits inside a residential polygon."""
+        osm_data = {
+            "roads": {
+                "type": "FeatureCollection",
+                "features": [
+                    _road_feature(15.001, 58.0015, 15.004, "service"),
+                ],
+            },
+            "water": _empty_collection(),
+            "forests": _empty_collection(),
+            "buildings": _empty_collection(),
+            "land_use": {
+                "type": "FeatureCollection",
+                "features": [
+                    _landuse_polygon(15.0005, 58.0005, 15.0045, 58.0025, "residential"),
+                ],
+            },
+        }
+        mask = _run_with(osm_data, tmp_path)
+        assert mask.sum() > 0, (
+            "A 'service' road inside a residential polygon must be classified "
+            "as asphalt (matching road_processor)."
+        )
+
+    def test_motorway_is_always_asphalt(self, tmp_path: Path):
+        osm_data = {
+            "roads": {
+                "type": "FeatureCollection",
+                "features": [
+                    _road_feature(15.001, 58.0015, 15.004, "motorway"),
+                ],
+            },
+            "water": _empty_collection(),
+            "forests": _empty_collection(),
+            "buildings": _empty_collection(),
+            "land_use": _empty_collection(),
+        }
+        mask = _run_with(osm_data, tmp_path)
+        assert mask.sum() > 0
+
+
+class TestAsphaltUsesPerFeatureWidth:
+    def test_wider_road_paints_more_pixels(self, tmp_path: Path):
+        """A 14m road should paint strictly more asphalt pixels than a 4m road."""
+        # Run twice with the same road geometry but different OSM widths.
+        narrow_osm = {
+            "roads": {
+                "type": "FeatureCollection",
+                "features": [_road_feature(15.001, 58.0015, 15.004, "primary", width="4")],
+            },
+            "water": _empty_collection(),
+            "forests": _empty_collection(),
+            "buildings": _empty_collection(),
+            "land_use": _empty_collection(),
+        }
+        wide_osm = {
+            "roads": {
+                "type": "FeatureCollection",
+                "features": [_road_feature(15.001, 58.0015, 15.004, "primary", width="14")],
+            },
+            "water": _empty_collection(),
+            "forests": _empty_collection(),
+            "buildings": _empty_collection(),
+            "land_use": _empty_collection(),
+        }
+
+        narrow_dir = tmp_path / "narrow"
+        wide_dir = tmp_path / "wide"
+        narrow_dir.mkdir()
+        wide_dir.mkdir()
+
+        narrow_mask = _run_with(narrow_osm, narrow_dir)
+        wide_mask = _run_with(wide_osm, wide_dir)
+
+        narrow_count = int((narrow_mask > 0).sum())
+        wide_count = int((wide_mask > 0).sum())
+
+        assert narrow_count > 0 and wide_count > 0
+        # 14m / 4m ≈ 3.5×. Allow a generous tolerance for soft-edge blending.
+        assert wide_count >= narrow_count * 1.8, (
+            f"Wider road must produce a thicker asphalt stripe; "
+            f"narrow(4m)={narrow_count}, wide(14m)={wide_count}. "
+            f"Pre-v1.2.5 both used a fixed 6m buffer regardless of OSM width."
+        )


### PR DESCRIPTION
## Summary

Two independent alignment bugs in the imagery pipeline, fixed in a single patch release.

### Fix #55 — asphalt surface mask misaligned with road splines

`surface_asphalt.png` had two visual problems:
- A fixed ~6m half-width buffer was applied to every paved road regardless of OSM `width=*` / `lanes=*` tags, while the road spline side already used per-feature widths via `road_processor.infer_road_width()`. Mask and spline disagreed on stripe width.
- `landuse=residential/industrial/commercial/retail` polygons plus all building footprints were OR-merged into the asphalt mask at 50% blend. After the sum-to-255 normalization those areas dominated and painted entire neighborhoods as asphalt with no corresponding roads in the satellite image.

The asphalt mask now uses the same `infer_road_surface()` + `infer_road_width()` that drive the spline emitter, so it follows exactly the road set the splines render, at exactly the per-feature widths. Urban polygons no longer paint asphalt directly — they only inform the urban-context test for context-dependent highway types (`residential`, `service`, `cycleway`, `unclassified`).

### Fix #58 — satellite image tilted / strangely cropped on rectangular maps

`reproject_satellite_to_terrain_crs` hardcoded a square destination grid (`target_size` was used for both width and height). For rectangular terrains (made user-reachable in v1.2.4 when the polygon tool was removed) the rectangular WGS84 input got warped into a square pixel grid then displayed as a rectangle, producing the diagonal tilt and crop in the screenshot.

`target_size` now accepts a `(width, height)` tuple (scalar still works for back-compat with any external callers) and the only in-repo call site in `map_generator.py` passes both `target_size_x` and `target_size_z`.

## Test plan

- [x] New unit tests in `webapp/tests/test_surface_mask_generator.py` covering: residential landuse alone → zero asphalt, buildings alone → zero asphalt, `service` road outside vs inside urban polygon classification parity with `road_processor`, wider OSM `width=*` → strictly more painted pixels.
- [x] New unit tests in `webapp/tests/test_satellite_service.py` covering: rectangular target size honoured (800×400), square regression (512×512), scalar back-compat, tall rectangle (400×800), missing-file failure returns False.
- [x] `pytest webapp/tests/` — 229 passing (+8 new), 5 skipped (rasterio gated for the new satellite tests), 7 pre-existing environmental failures unchanged (missing pyproj on the dev machine — they run in Docker CI).
- [ ] End-to-end: generate a non-square map (e.g. 4 km × 8 km) and verify `satellite_map.png` fills the PNG without diagonal black bands, splines overlay aligns with visible roads, and `surface_asphalt.png` shows asphalt only along roads.
- [ ] Workbench import check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)