### PR TITLE
v1.3.2: fix duplicate GUID Workbench crash + surface-violation warning (closes #61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ The application is published to GitHub Container Registry and automatically buil
 docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:latest
 
 # Or use a specific version tag
-docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.3.1
+docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.3.2
 ```
 
 The `docker-compose.yml` is pre-configured to use the GHCR.io image. See the [Quick Start Guide](#quick-start-guide) for setup instructions.

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -47,7 +47,7 @@ configure_gdal_threading()
 # Application version (for cache busting)
 # ===========================================================================
 
-APP_VERSION = "1.3.1"  # Increment when static files change OR a new release ships
+APP_VERSION = "1.3.2"  # Increment when static files change OR a new release ships
 
 # ===========================================================================
 # FastAPI app

--- a/webapp/services/enfusion_project_generator.py
+++ b/webapp/services/enfusion_project_generator.py
@@ -167,8 +167,13 @@ class EnfusionProjectGenerator:
         self.water_features = water_features
         self.building_data = building_data
 
-        # Generate a deterministic GUID from the map name
+        # Addon GUID — identifies this project in addon.gproj and dependency lists
         self.project_guid = generate_guid(self.map_name)
+        # Per-resource GUIDs — each file registered in Enfusion's resource system
+        # must have its own unique GUID; reusing project_guid for both .ent and .conf
+        # caused "duplicate GUID" registration errors in Workbench (issue #61).
+        self.world_ent_guid = generate_guid(self.map_name + ":world.ent")
+        self.mission_conf_guid = generate_guid(self.map_name + ":mission.conf")
 
         # Extract key values from metadata
         self._extract_terrain_params()
@@ -264,7 +269,7 @@ class EnfusionProjectGenerator:
         # World metadata
         files["world.ent.meta"] = self._write_file(
             worlds_dir / f"{self.map_name}.ent.meta",
-            self._generate_meta("ent", f"Worlds/{self.map_name}.ent")
+            self._generate_meta("ent", f"Worlds/{self.map_name}.ent", self.world_ent_guid)
         )
 
         # Layer files
@@ -314,7 +319,7 @@ class EnfusionProjectGenerator:
 
         files["mission.conf.meta"] = self._write_file(
             missions_dir / f"{self.map_name}.conf.meta",
-            self._generate_meta("conf", f"Missions/{self.map_name}.conf")
+            self._generate_meta("conf", f"Missions/{self.map_name}.conf", self.mission_conf_guid)
         )
 
         logger.info(f"Generated {len(files)} Enfusion project files in {output_dir}")
@@ -378,13 +383,14 @@ Layer buildings {{
 }}
 '''
 
-    def _generate_meta(self, resource_type: str, resource_path: str) -> str:
+    def _generate_meta(self, resource_type: str, resource_path: str, guid: str) -> str:
         """
         Generate a .meta file for a resource.
 
         Args:
             resource_type: "ent" or "conf"
             resource_path: Relative path to the resource file.
+            guid: Unique 16-char hex GUID for this specific resource.
         """
         # Determine resource class name
         if resource_type == "ent":
@@ -401,7 +407,7 @@ Layer buildings {{
         )
 
         return f'''MetaFileClass {{
- Name "{{{self.project_guid}}}{resource_path}"
+ Name "{{{guid}}}{resource_path}"
  Configurations {{
 {platforms}
  }}
@@ -1603,7 +1609,7 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['destruction']} {{
     def _generate_mission_conf(self) -> str:
         """Generate mission header .conf file."""
         return f'''SCR_MissionHeader {{
- World "{{{self.project_guid}}}Worlds/{self.map_name}.ent"
+ World "{{{self.world_ent_guid}}}Worlds/{self.map_name}.ent"
  m_sName "{self.map_name}"
  m_sGameMode "GameMaster"
  m_iPlayerCount 64

--- a/webapp/services/setup_guide_generator.py
+++ b/webapp/services/setup_guide_generator.py
@@ -745,6 +745,17 @@ webapp to get simplified layers.
   comment (or `Reference/roads_reference.csv` for the full per-road list)
 - Splines without a generator render as a thin debug line only
 
+### "resource not registered" warnings for Reference/ files
+Workbench may print warnings such as:
+```
+resource not registered: Reference/features.json
+resource not registered: Reference/metadata.json
+```
+These are **expected and harmless**. The `Reference/` folder contains helper
+files for you (building locations, road list, generation metadata) — they are
+not Enfusion resources. Workbench scans the entire addon directory and warns
+about any file it does not recognise. You can safely ignore these warnings.
+
 ### No sky/atmosphere
 - Check the **default** layer has GenericWorldEntity with sky presets
 - Verify Lighting_Default.et is present and enabled

--- a/webapp/services/surface_mask_generator.py
+++ b/webapp/services/surface_mask_generator.py
@@ -776,6 +776,14 @@ def generate_surface_masks(
             f"After {max_merge_passes} merge passes, {saturation_final['violations']} "
             f"violations remain"
         )
+        if job:
+            job.add_log(
+                f"WARNING: {saturation_final['violations']} terrain block(s) still exceed the "
+                f"5-surface-material limit after auto-merge. Workbench will show "
+                f"'Too many layers' warnings when importing the surface masks — see "
+                f"SETUP_GUIDE Step 3.5 for how to resolve this in Workbench.",
+                "warning",
+            )
 
     # =========================================================================
     # Step 7: Save mask files (only those with actual coverage)

--- a/webapp/tests/test_enfusion_project_generator.py
+++ b/webapp/tests/test_enfusion_project_generator.py
@@ -1,0 +1,109 @@
+"""
+Tests for EnfusionProjectGenerator — GUID uniqueness (issue #61).
+
+Before the fix, world.ent.meta and mission.conf.meta both used project_guid,
+causing a "duplicate GUID" registration error in Workbench.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+WEBAPP_DIR = Path(__file__).parent.parent
+if str(WEBAPP_DIR) not in sys.path:
+    sys.path.insert(0, str(WEBAPP_DIR))
+
+
+class _IdentityTransformer:
+    def transform_points(self, points, elevation_array=None):
+        return [
+            {"x": round(p["x"] * 1000, 3), "y": 0.0, "z": round(p["y"] * 1000, 3)}
+            for p in points
+        ]
+
+
+def _metadata():
+    return {
+        "heightmap": {"dimensions": "2049x2049", "grid_cell_size_m": 2.0},
+        "elevation": {
+            "min_elevation_m": 0,
+            "max_elevation_m": 100,
+            "height_scale": 0.03125,
+            "height_offset": 0,
+        },
+        "input": {"bbox": {"south": 0.0, "north": 4.0, "west": 0.0, "east": 4.0}},
+    }
+
+
+def _make_gen(**kwargs):
+    from services.enfusion_project_generator import EnfusionProjectGenerator
+    return EnfusionProjectGenerator(
+        map_name="TestMap",
+        metadata=_metadata(),
+        transformer=_IdentityTransformer(),
+        elevation_array=None,
+        **kwargs,
+    )
+
+
+class TestGuidUniqueness:
+    def test_three_guids_are_all_different(self):
+        gen = _make_gen()
+        assert gen.project_guid != gen.world_ent_guid, (
+            "project_guid and world_ent_guid must differ"
+        )
+        assert gen.project_guid != gen.mission_conf_guid, (
+            "project_guid and mission_conf_guid must differ"
+        )
+        assert gen.world_ent_guid != gen.mission_conf_guid, (
+            "world_ent_guid and mission_conf_guid must differ — "
+            "duplicate GUID causes Workbench registration errors (issue #61)"
+        )
+
+    def test_world_ent_meta_uses_world_ent_guid(self):
+        gen = _make_gen()
+        meta = gen._generate_meta("ent", "Worlds/TestMap.ent", gen.world_ent_guid)
+        assert gen.world_ent_guid in meta
+        assert gen.project_guid not in meta, (
+            "world.ent.meta must use world_ent_guid, not project_guid"
+        )
+
+    def test_mission_conf_meta_uses_mission_conf_guid(self):
+        gen = _make_gen()
+        meta = gen._generate_meta("conf", "Missions/TestMap.conf", gen.mission_conf_guid)
+        assert gen.mission_conf_guid in meta
+        assert gen.project_guid not in meta, (
+            "mission.conf.meta must use mission_conf_guid, not project_guid"
+        )
+
+    def test_mission_conf_world_reference_uses_world_ent_guid(self):
+        gen = _make_gen()
+        conf = gen._generate_mission_conf()
+        assert gen.world_ent_guid in conf, (
+            "mission.conf World field must reference world_ent_guid so Workbench "
+            "can resolve the world file"
+        )
+        assert gen.project_guid not in conf, (
+            "mission.conf must not use project_guid as a resource reference"
+        )
+
+    def test_guids_are_deterministic(self):
+        gen1 = _make_gen()
+        gen2 = _make_gen()
+        assert gen1.project_guid == gen2.project_guid
+        assert gen1.world_ent_guid == gen2.world_ent_guid
+        assert gen1.mission_conf_guid == gen2.mission_conf_guid
+
+    def test_guids_differ_across_map_names(self):
+        from services.enfusion_project_generator import EnfusionProjectGenerator
+        gen_a = EnfusionProjectGenerator(
+            map_name="MapA", metadata=_metadata(),
+            transformer=_IdentityTransformer(), elevation_array=None,
+        )
+        gen_b = EnfusionProjectGenerator(
+            map_name="MapB", metadata=_metadata(),
+            transformer=_IdentityTransformer(), elevation_array=None,
+        )
+        assert gen_a.world_ent_guid != gen_b.world_ent_guid
+        assert gen_a.mission_conf_guid != gen_b.mission_conf_guid


### PR DESCRIPTION
## Summary

Fixes the `nvtt::CubeSurface::toGamma` Workbench crash reported in #61, caused by two generator bugs:

- **Duplicate resource GUID**: `world.ent.meta` and `mission.conf.meta` both used `project_guid` as their Enfusion resource GUID. Having two resources claim the same GUID corrupts Workbench's resource registry and leads to the access violation. Fixed by generating separate per-resource GUIDs (`world_ent_guid` / `mission_conf_guid`) derived from the map name + resource path, and updating the `World` cross-reference in `mission.conf` to use `world_ent_guid`.

- **Silent surface violations**: When the 5-pass auto-merge loop left block-saturation violations unresolved, only a server-side log was written — the user had no indication and imported the violating masks into Workbench, triggering "Too many layers" errors that correlate with the same nvtt crash. Added a `job.add_log` warning (visible in the web UI) that directs the user to SETUP_GUIDE Step 3.5.

Also adds a SETUP_GUIDE troubleshooting entry explaining that `resource not registered: Reference/features.json` warnings from Workbench are benign.

## Changes

| File | Change |
|---|---|
| `webapp/services/enfusion_project_generator.py` | Add `world_ent_guid` + `mission_conf_guid`; update `_generate_meta()` signature; fix `mission.conf` World cross-reference |
| `webapp/services/surface_mask_generator.py` | Add `job.add_log` warning when surface violations remain |
| `webapp/services/setup_guide_generator.py` | Add "resource not registered" troubleshooting note |
| `webapp/tests/test_enfusion_project_generator.py` | 6 new tests asserting GUID uniqueness (new file) |
| `webapp/main.py` | Bump `APP_VERSION` → `v1.3.2` |
| `README.md` | Update Docker version tag |

## Test plan

- [x] `pytest tests/test_enfusion_project_generator.py` — 6/6 pass
- [x] Full suite — no new failures vs. baseline
- [ ] Manually verify generated ZIP: `world.ent.meta` GUID ≠ `mission.conf.meta` GUID ≠ `addon.gproj` GUID
- [ ] Confirm `mission.conf` `World` field matches `world.ent.meta` GUID
- [ ] Confirm `APP_VERSION` reads `v1.3.2` in `/health` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)