### PR TITLE
v1.3.5: bathymetry gradient + rivers/wetlands/sea coverage (#66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ The application is published to GitHub Container Registry and automatically buil
 docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:latest
 
 # Or use a specific version tag
-docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.3.4
+docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.3.5
 ```
 
 The `docker-compose.yml` is pre-configured to use the GHCR.io image. See the [Quick Start Guide](#quick-start-guide) for setup instructions.

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -47,7 +47,7 @@ configure_gdal_threading()
 # Application version (for cache busting)
 # ===========================================================================
 
-APP_VERSION = "1.3.4"  # Increment when static files change OR a new release ships
+APP_VERSION = "1.3.5"  # Increment when static files change OR a new release ships
 
 # ===========================================================================
 # FastAPI app

--- a/webapp/services/heightmap_generator.py
+++ b/webapp/services/heightmap_generator.py
@@ -330,6 +330,95 @@ def flatten_roads_in_heightmap(
     return result
 
 
+_RIVER_WATER_TYPES = ("river", "stream", "canal", "ditch", "drain")
+
+
+def _rasterize_river_mask(
+    water_features: dict,
+    width: int,
+    height: int,
+    bbox_wgs84: tuple[float, float, float, float],
+    pixel_size_m: float,
+) -> np.ndarray:
+    """Rasterize OSM river/stream/canal LineStrings as a buffered band mask."""
+    from services.feature_extractor import _estimate_river_width
+    from services.utils.rasterize import rasterize_lines_per_feature_width
+
+    def _half_width_px(feature: dict) -> int:
+        water_type = (feature.get("properties", {}) or {}).get("water_type", "")
+        width_m = _estimate_river_width(water_type)
+        return max(1, int(round(width_m / (2.0 * pixel_size_m))))
+
+    def _is_river(feature: dict) -> bool:
+        water_type = (feature.get("properties", {}) or {}).get("water_type", "")
+        return water_type in _RIVER_WATER_TYPES
+
+    return rasterize_lines_per_feature_width(
+        water_features,
+        width,
+        height,
+        bbox_wgs84,
+        buffer_px_fn=_half_width_px,
+        filter_fn=_is_river,
+    )
+
+
+def _synthesize_sea_mask(
+    water_features: dict,
+    elevation: np.ndarray,
+    bbox_wgs84: tuple[float, float, float, float],
+    pixel_size_m: float,
+    sea_level_threshold: float = 0.5,
+    coast_proximity_px: int = 50,
+) -> np.ndarray:
+    """
+    Build a sea polygon mask from OSM `natural=coastline` LineStrings + DEM.
+
+    OSM ships the coast as a LineString (with the sea conventionally on the
+    right), not as a polygon — there is no offshore feature we can rasterize
+    directly. We synthesize one by flood-filling low-elevation pixels from
+    bbox-edge seed pixels that are near the coastline. Returns an empty mask
+    for inland maps (no `coastline` features) or maps with no low-elevation
+    pixels at the bbox edge near a coast.
+    """
+    from services.utils.rasterize import rasterize_lines_per_feature_width
+
+    height, width = elevation.shape
+
+    def _is_coastline(feature: dict) -> bool:
+        return (feature.get("properties", {}) or {}).get("water_type") == "coastline"
+
+    coast = rasterize_lines_per_feature_width(
+        water_features,
+        width,
+        height,
+        bbox_wgs84,
+        buffer_px_fn=lambda _f: 0,  # 1-px stroke (line_width = 2*0+1 = 1)
+        filter_fn=_is_coastline,
+    )
+    if coast.sum() == 0:
+        return np.zeros((height, width), dtype=np.uint8)
+
+    low = elevation <= sea_level_threshold
+    edge = np.zeros_like(low, dtype=bool)
+    edge[0, :] = True
+    edge[-1, :] = True
+    edge[:, 0] = True
+    edge[:, -1] = True
+
+    near_coast = ndimage.binary_dilation(
+        coast.astype(bool), iterations=coast_proximity_px,
+    )
+    seed = low & edge & near_coast
+    if not seed.any():
+        seed = low & edge
+        if not seed.any():
+            return np.zeros((height, width), dtype=np.uint8)
+
+    sea = ndimage.binary_propagation(seed, mask=low)
+    return sea.astype(np.uint8)
+
+
 def flatten_water_in_heightmap(
     elevation: np.ndarray,
     water_mask: np.ndarray,
@@ -337,6 +426,7 @@ def flatten_water_in_heightmap(
     pixel_size_m: float = 2.0,
     max_depth_m: float = 8.0,
     shore_slope_m_per_m: float = 0.3,
+    region_depth_map: dict[int, float] | None = None,
 ) -> np.ndarray:
     """
     Set water-surface level per region and carve a depth bowl below it.
@@ -345,14 +435,21 @@ def flatten_water_in_heightmap(
     (10th percentile of the region's source-DEM elevations — robust against
     DEM/OSM misalignment that leaves the odd peak inside a lake polygon). The
     Lake Generator prefab in Enfusion later draws the water surface at this
-    level. To stop the bed being walkable (#66) we lower the terrain inside
-    the polygon as a function of distance to shore:
+    level. The terrain inside the polygon is lowered with a *linear gradient*
+    that runs from 0 at the shore to `region_max_depth` at the deepest
+    interior point:
 
-        depth_m(pixel) = min(max_depth_m, dist_to_shore_m × shore_slope_m_per_m)
+        region_max_depth = min(max_depth_m, max_dist_m × shore_slope_m_per_m)
+        depth(pixel)     = region_max_depth × dist_to_shore(pixel) / max_dist
 
-    Shore pixels sit exactly at the water surface (depth = 0), so the
-    transition with surrounding land stays smooth, while interior pixels of a
-    sufficiently large lake reach `max_depth_m` below the surface.
+    Pre-v1.3.5 every pixel further than `max_depth_m / shore_slope_m_per_m`
+    from any shore hit `max_depth_m` and the whole interior was a flat
+    plateau. The new shape ramps continuously across the region, so the bowl
+    is visible in the heightmap PNG for any region size, while small ponds
+    still stay shallow (their `max_dist_m × slope` cap fires before
+    `max_depth_m`). `region_depth_map`, if given, overrides `max_depth_m`
+    per labelled region so different water types (lakes/rivers/sea) can be
+    carved with different ceilings in a single call.
     """
     if water_mask.sum() == 0:
         return elevation
@@ -362,6 +459,8 @@ def flatten_water_in_heightmap(
 
     water_mask_bool = water_mask.astype(bool)
     labeled, n_features = ndimage.label(water_mask_bool)
+    if n_features == 0:
+        return elevation
 
     region_levels: dict[int, float] = {}
     for i in range(1, n_features + 1):
@@ -373,17 +472,31 @@ def flatten_water_in_heightmap(
         region_levels[i] = water_level
         water_surface_field[region_mask] = water_level
 
-    # Depth bowl: 0 at the shore, growing linearly with distance until clamped.
+    # Single global EDT, then scale per region by that region's maximum
+    # shore distance so every region reaches its full `max_depth_m` at its
+    # deepest interior point — small ponds get a shallow bowl, large lakes
+    # a deep one, both with a continuous gradient.
     dist_px = ndimage.distance_transform_edt(water_mask_bool)
-    depth_m = np.clip(
-        dist_px * pixel_size_m * shore_slope_m_per_m,
-        0.0,
-        max_depth_m,
-    )
+    region_ids = np.arange(1, n_features + 1)
+    max_dist_per_region = ndimage.maximum(dist_px, labeled, index=region_ids)
+
+    region_depth_map = region_depth_map or {}
 
     for region_id, water_level in region_levels.items():
         region_mask = labeled == region_id
-        result[region_mask] = water_level - depth_m[region_mask]
+        max_d_px = float(max_dist_per_region[region_id - 1])
+        if max_d_px <= 0:
+            continue
+        ceiling = float(region_depth_map.get(region_id, max_depth_m))
+        # Per-region cap: small ponds stay shallow (slope × radius caps depth
+        # below max_depth_m), large lakes hit `ceiling` at their deepest
+        # point. Either way the depth ramps linearly to that maximum.
+        region_max_depth = min(
+            ceiling,
+            max_d_px * pixel_size_m * shore_slope_m_per_m,
+        )
+        norm = dist_px[region_mask] / max_d_px  # 0 at shore, 1 at deepest pt
+        result[region_mask] = water_level - region_max_depth * norm
 
     # Shore blending: smooth land just outside water toward the water *surface*
     # level — not the carved bed — so the bowl doesn't bleed into the terrain.
@@ -578,7 +691,9 @@ def generate_heightmap(
                 elevation, road_mask, road_width_px=3, smooth_radius=5,
             )
 
-    # 4. Level water bodies
+    # 4. Level water bodies — four passes, one per water type, so each
+    # gets its own depth ceiling and rivers don't get merged into adjacent
+    # lakes by the connected-component labelling.
     if water_features and water_features.get("features"):
         logger.info("Leveling water bodies...")
         if job:
@@ -586,18 +701,49 @@ def generate_heightmap(
             job.progress = 53
         bbox = metadata.get("bounds")
         if bbox:
-            water_mask = rasterize_features_to_mask(
-                water_features,
-                elevation.shape[1], elevation.shape[0],
-                (bbox.left, bbox.bottom, bbox.right, bbox.top),
-                filter_tags={"natural": ["water"], "water_type": ["lake", "pond", "reservoir"]},
+            bbox_tuple = (bbox.left, bbox.bottom, bbox.right, bbox.top)
+            arr_h, arr_w = elevation.shape
+
+            lake_mask = rasterize_features_to_mask(
+                water_features, arr_w, arr_h, bbox_tuple,
+                filter_tags={
+                    "natural": ["water"],
+                    "water_type": ["lake", "pond", "reservoir", "water", "basin"],
+                },
             )
-            elevation = flatten_water_in_heightmap(
-                elevation,
-                water_mask,
-                transition_px=3,
-                pixel_size_m=target_resolution_m,
+            river_mask = _rasterize_river_mask(
+                water_features, arr_w, arr_h, bbox_tuple, target_resolution_m,
             )
+            wetland_mask = rasterize_features_to_mask(
+                water_features, arr_w, arr_h, bbox_tuple,
+                filter_tags={"water_type": ["wetland"]},
+            )
+            sea_mask = _synthesize_sea_mask(
+                water_features, elevation, bbox_tuple, target_resolution_m,
+            )
+
+            # Carve each type with its own depth ceiling. Order matters only
+            # where masks overlap (a river crossing a lake gets overwritten
+            # by the lake pass — desirable).
+            for mask, max_depth, label in (
+                (river_mask, 2.0, "river/stream"),
+                (wetland_mask, 1.0, "wetland"),
+                (sea_mask, 30.0, "sea"),
+                (lake_mask, 8.0, "lake/pond/reservoir"),
+            ):
+                if mask.sum() == 0:
+                    continue
+                logger.info(
+                    f"Carving bathymetry for {label} mask: "
+                    f"{int(mask.sum())} px, max_depth={max_depth} m"
+                )
+                elevation = flatten_water_in_heightmap(
+                    elevation,
+                    mask,
+                    transition_px=3,
+                    pixel_size_m=target_resolution_m,
+                    max_depth_m=max_depth,
+                )
 
     # 5. Light smoothing pass
     logger.info("Applying final smoothing...")

--- a/webapp/tests/test_heightmap_water_bathymetry.py
+++ b/webapp/tests/test_heightmap_water_bathymetry.py
@@ -22,7 +22,11 @@ if str(WEBAPP_DIR) not in sys.path:
 # scipy is a hard dep of heightmap_generator; skip the module if it's missing
 pytest.importorskip("scipy", reason="scipy is required for heightmap tests")
 
-from services.heightmap_generator import flatten_water_in_heightmap  # noqa: E402
+from services.heightmap_generator import (  # noqa: E402
+    _rasterize_river_mask,
+    _synthesize_sea_mask,
+    flatten_water_in_heightmap,
+)
 
 
 def _flat_terrain(size: int, elev: float = 100.0) -> np.ndarray:
@@ -135,6 +139,72 @@ class TestBathymetry:
         assert left_surface == pytest.approx(20.0, abs=1.0)
         assert right_surface == pytest.approx(50.0, abs=1.0)
 
+    def test_large_lake_has_gradient_not_plateau(self):
+        """A lake big enough that the old constant-slope formula would have
+        flattened most of its interior into a uniform plateau must now show
+        a continuous depth gradient. ≥50 % of the interior pixels must lie
+        strictly between the floor and the water surface."""
+        size = 200
+        elevation = _flat_terrain(size, elev=100.0)
+        mask = _disk_mask(size, radius=90)  # ~180-px diameter — old slope = 0.3 m/m
+                                            #   would plateau anything >54 px wide
+
+        out = flatten_water_in_heightmap(
+            elevation,
+            mask,
+            transition_px=0,
+            pixel_size_m=2.0,
+            max_depth_m=8.0,
+            shore_slope_m_per_m=0.3,
+        )
+
+        interior = out[mask.astype(bool)]
+        surface = 100.0
+        floor = surface - 8.0
+        strictly_between = (interior > floor + 1e-3) & (interior < surface - 1e-3)
+        fraction = float(np.mean(strictly_between))
+        assert fraction >= 0.5, (
+            f"only {fraction:.0%} of interior pixels lie strictly between "
+            f"floor={floor} and surface={surface} — plateau is back"
+        )
+
+    def test_region_depth_map_dispatch(self):
+        """`region_depth_map` overrides `max_depth_m` per labelled region."""
+        from scipy import ndimage as _ndi
+
+        size = 100
+        elevation = _flat_terrain(size, elev=50.0)
+        mask = np.zeros_like(elevation, dtype=np.uint8)
+        yy, xx = np.ogrid[:size, :size]
+        mask[(yy - 50) ** 2 + (xx - 25) ** 2 <= 100] = 1
+        mask[(yy - 50) ** 2 + (xx - 75) ** 2 <= 100] = 1
+
+        labeled, _ = _ndi.label(mask)
+        left_id = int(labeled[50, 25])
+        right_id = int(labeled[50, 75])
+        region_depth_map = {left_id: 1.0, right_id: 8.0}
+
+        out = flatten_water_in_heightmap(
+            elevation,
+            mask,
+            transition_px=0,
+            pixel_size_m=2.0,
+            max_depth_m=8.0,
+            shore_slope_m_per_m=10.0,  # huge slope → ceiling wins
+            region_depth_map=region_depth_map,
+        )
+
+        left_center = out[50, 25]
+        right_center = out[50, 75]
+        assert 48.5 < left_center < 49.5, (
+            f"left center {left_center} not within ~1 m of expected 49 "
+            f"(surface 50, ceiling 1)"
+        )
+        assert 41.5 < right_center < 42.5, (
+            f"right center {right_center} not within ~1 m of expected 42 "
+            f"(surface 50, ceiling 8)"
+        )
+
     def test_shore_blend_does_not_pull_land_down_into_bowl(self):
         """Land just outside the lake must not be dragged toward the bowl
         bottom — only toward the water surface."""
@@ -164,4 +234,90 @@ class TestBathymetry:
         assert shore_outside > midpoint, (
             f"transition pixel {shore_outside:.2f} dragged below "
             f"midpoint {midpoint:.2f} — shore blend leaked the bowl"
+        )
+
+
+def _line_feature(coords, water_type):
+    return {
+        "type": "Feature",
+        "properties": {"water_type": water_type},
+        "geometry": {"type": "LineString", "coordinates": coords},
+    }
+
+
+class TestRiverRasterization:
+    def test_river_linestring_carves_a_band(self):
+        """A horizontal river LineString must produce a band of pixels several
+        rows tall (matching its OSM-derived 15m width at 2 m/px)."""
+        bbox = (0.0, 0.0, 0.001, 0.001)  # ~111 m × 111 m tile (synthetic)
+        w_lon, s_lat, e_lon, n_lat = bbox
+        # A horizontal line across the bbox at mid-latitude
+        coords = [
+            [w_lon + 0.0001, (s_lat + n_lat) / 2],
+            [e_lon - 0.0001, (s_lat + n_lat) / 2],
+        ]
+        features = {"type": "FeatureCollection", "features": [
+            _line_feature(coords, "river"),
+        ]}
+
+        mask = _rasterize_river_mask(features, 64, 64, bbox, pixel_size_m=2.0)
+
+        # River = 15 m / (2 × 2 m) ≈ 4 px half-width → 9 px line width
+        rows_with_river = np.where(mask.sum(axis=1) > 0)[0]
+        assert rows_with_river.size >= 5, (
+            f"river carved only {rows_with_river.size} rows — expected ≥5"
+        )
+        # And rows on the edge of the bbox stay dry (river is mid-y only)
+        assert mask[0, :].sum() == 0
+        assert mask[-1, :].sum() == 0
+
+    def test_non_river_feature_is_ignored(self):
+        """A coastline LineString must not be rasterized as a river."""
+        bbox = (0.0, 0.0, 0.001, 0.001)
+        coords = [[0.0001, 0.0005], [0.0009, 0.0005]]
+        features = {"type": "FeatureCollection", "features": [
+            _line_feature(coords, "coastline"),
+        ]}
+        mask = _rasterize_river_mask(features, 64, 64, bbox, pixel_size_m=2.0)
+        assert mask.sum() == 0
+
+
+class TestSeaSynthesis:
+    def test_sea_synthesis_inland_map_returns_empty(self):
+        """No coastline features → empty mask even when low ground exists."""
+        bbox = (0.0, 0.0, 0.001, 0.001)
+        features = {"type": "FeatureCollection", "features": []}
+        elevation = np.full((64, 64), -5.0, dtype=np.float32)  # all below sea
+        mask = _synthesize_sea_mask(features, elevation, bbox, pixel_size_m=2.0)
+        assert mask.sum() == 0
+
+    def test_sea_synthesis_low_half_with_coastline(self):
+        """Left half low + right half high + coastline down the middle →
+        sea mask covers ≥90 % of the left half and 0 % of the right half."""
+        size = 100
+        bbox = (0.0, 0.0, 0.001, 0.001)
+        elevation = np.zeros((size, size), dtype=np.float32)
+        elevation[:, : size // 2] = -2.0       # left half: below sea level
+        elevation[:, size // 2 :] = 20.0       # right half: well above
+
+        # Coastline LineString runs vertically near the middle of the bbox
+        coords = [
+            [bbox[0] + (bbox[2] - bbox[0]) * 0.5, bbox[1] + 1e-6],
+            [bbox[0] + (bbox[2] - bbox[0]) * 0.5, bbox[3] - 1e-6],
+        ]
+        features = {"type": "FeatureCollection", "features": [
+            _line_feature(coords, "coastline"),
+        ]}
+
+        mask = _synthesize_sea_mask(features, elevation, bbox, pixel_size_m=2.0)
+
+        left = mask[:, : size // 2]
+        right = mask[:, size // 2 :]
+        left_fraction = float(left.mean())
+        right_fraction = float(right.mean())
+        assert left_fraction >= 0.9, (
+            f"sea mask only covers {left_fraction:.0%} of the low (left) half"
+        )
+        assert right_fraction == 0.0, (
+            f"sea mask leaked into the high (right) half ({right_fraction:.0%})"
         )


### PR DESCRIPTION
## Summary

Re-fix for #66 — v1.3.4 carved a depth bowl, but the user reported the raw heightmap PNG still shows water "all at one level". Two design gaps:

### 1. Constant-slope bowl → flat plateau on any real-world lake

The v1.3.4 formula was:
\`\`\`
depth = min(max_depth_m, dist_to_shore_m × shore_slope_m_per_m)
\`\`\`
At the defaults (\`max_depth_m=8\`, \`slope=0.3\`) anything wider than \`2 × 8 / 0.3 ≈ 54 m\` flattens to a uniform plateau at the floor. Swedish lakes are 100 m – 2 km across, so the entire interior was a single grey level — visually indistinguishable from the pre-v1.3.4 fully-flat output.

**Fix:** per-region normalised depth — every region's deepest interior pixel hits its own \`region_depth\` (capped by \`slope × radius\`), and depth ramps linearly with shore distance:

\`\`\`
region_depth = min(max_depth_m, max_dist_region × pixel × slope)
depth(pixel) = region_depth × dist_to_shore(pixel) / max_dist_region
\`\`\`

Small ponds still stay shallow (the slope × radius cap fires below \`max_depth_m\`); huge lakes get a continuous gradient across the entire interior instead of a plateau.

### 2. Coverage too narrow — only lakes were carved

Pre-v1.3.5 the call site rasterised only \`natural=water\` polygons with \`water_type ∈ {lake, pond, reservoir}\`. Rivers (LineStrings → never a polygon), wetlands (filtered out), and the **sea** (OSM has no offshore polygon, only \`natural=coastline\` LineStrings) all stayed flat. The user said "all types of water features should have a depth".

**Fix:** the call site now runs four carve passes — rivers (max 2 m), wetlands (1 m), sea (30 m), lakes (8 m). Each gets its own ceiling.

- **Rivers:** new \`_rasterize_river_mask\` wraps the existing [\`rasterize_lines_per_feature_width\`](webapp/services/utils/rasterize.py:125) using [\`_estimate_river_width\`](webapp/services/feature_extractor.py:117) so each LineString becomes a buffered band at its OSM-derived width.
- **Sea:** new \`_synthesize_sea_mask\` builds a sea polygon from coastline + DEM. Rasterises \`natural=coastline\` at 1-px, then \`scipy.ndimage.binary_propagation\` from bbox-edge low-elevation seeds gated by 50-px proximity to the coastline. Empty for inland maps; handles islands and bbox-edge coastlines correctly.

### Changes

- [heightmap_generator.py:333](webapp/services/heightmap_generator.py:333) — \`flatten_water_in_heightmap\` per-region normalised depth + new \`region_depth_map\` kwarg.
- [heightmap_generator.py](webapp/services/heightmap_generator.py) — new \`_rasterize_river_mask\`, \`_synthesize_sea_mask\` helpers.
- [heightmap_generator.py:581](webapp/services/heightmap_generator.py:581) — four-pass call site.
- [test_heightmap_water_bathymetry.py](webapp/tests/test_heightmap_water_bathymetry.py) — 6 new tests (large-lake gradient, region-depth-map dispatch, river-band, river-filter, sea-inland-empty, sea-low-half-with-coastline).
- [main.py](webapp/main.py:50), [README.md](README.md:432) — APP_VERSION + Docker tag bumped to 1.3.5.

## Test plan

- [x] \`pytest webapp/tests/\` — 247 passing (+6 new), same 7 pre-existing pyproj-env skips/failures as main.
- [ ] Generate a coastal Swedish map (archipelago) and an inland Swedish map (e.g. Småland). Open both \`heightmap.png\` — the coastal map's offshore area must show a visible gradient from shoreline to deep water; inland lakes must show a continuous bowl, not a plateau.
- [ ] Workbench import sanity-check.

Closes #66 (re-opened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)