### PR TITLE
v1.3.6: render satellite at 4× heightmap resolution, switch to Lanczos (#67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ The application is published to GitHub Container Registry and automatically buil
 docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:latest
 
 # Or use a specific version tag
-docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.3.5
+docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.3.6
 ```
 
 The `docker-compose.yml` is pre-configured to use the GHCR.io image. See the [Quick Start Guide](#quick-start-guide) for setup instructions.

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -47,7 +47,7 @@ configure_gdal_threading()
 # Application version (for cache busting)
 # ===========================================================================
 
-APP_VERSION = "1.3.5"  # Increment when static files change OR a new release ships
+APP_VERSION = "1.3.6"  # Increment when static files change OR a new release ships
 
 # ===========================================================================
 # FastAPI app

--- a/webapp/services/lantmateriet/stac_orthophoto_service.py
+++ b/webapp/services/lantmateriet/stac_orthophoto_service.py
@@ -333,7 +333,7 @@ async def fetch_stac_orthophoto(
                 src_crs=src_crs,
                 dst_transform=dst_transform,
                 dst_crs=dst_crs,
-                resampling=Resampling.bilinear,
+                resampling=Resampling.lanczos,
             )
 
     except Exception as exc:

--- a/webapp/services/map_generator.py
+++ b/webapp/services/map_generator.py
@@ -963,13 +963,27 @@ async def run_generation(job: MapGenerationJob):
             terrain_size_m=terrain_size_m,
         )
 
+        # Render the satellite texture at higher resolution than the heightmap.
+        # The diffuse texture imported via Terrain Tool > Import Satellite Map
+        # is independent of the heightmap vertex grid, so we can preserve much
+        # more of the source detail (Lantmäteriet STAC Bild is 0.16 m/px, vs
+        # the heightmap's ~2.4 m/px at 2049 vertices on a 5 km map — fixes #67).
+        from services.satellite_service import (
+            SATELLITE_MAX_DIM,
+            compute_satellite_target_dims,
+        )
+
+        sat_target_x, sat_target_z = compute_satellite_target_dims(
+            target_size_x, target_size_z,
+        )
+
         # If the transformer uses a projected CRS, expand the WGS84 fetch box to
         # the envelope of the projected rectangle and scale the fetch dimensions
         # proportionally to keep the same pixel density. This fixes the diagonal
         # tilt / corner crop caused by source-extent mismatch in reprojection.
         sat_fetch_bbox = bbox
-        sat_fetch_w = target_size_x
-        sat_fetch_h = target_size_z
+        sat_fetch_w = sat_target_x
+        sat_fetch_h = sat_target_z
         if transformer._use_pyproj:
             env_w, env_s, env_e, env_n = transformer.wgs84_envelope_of_projected_extent()
             sat_fetch_bbox = {
@@ -983,8 +997,8 @@ async def run_generation(job: MapGenerationJob):
             if orig_lon_span > 0 and orig_lat_span > 0:
                 ratio_x = (env_e - env_w) / orig_lon_span
                 ratio_y = (env_n - env_s) / orig_lat_span
-                sat_fetch_w = int(math.ceil(target_size_x * ratio_x))
-                sat_fetch_h = int(math.ceil(target_size_z * ratio_y))
+                sat_fetch_w = min(SATELLITE_MAX_DIM, int(math.ceil(sat_target_x * ratio_x)))
+                sat_fetch_h = min(SATELLITE_MAX_DIM, int(math.ceil(sat_target_z * ratio_y)))
 
         job.current_step = "Downloading satellite imagery..."
         job.progress = 75
@@ -1068,7 +1082,7 @@ async def run_generation(job: MapGenerationJob):
                     ),
                     dst_crs=country_info["crs"],
                     dst_bounds=dst_bounds,
-                    target_size=(target_size_x, target_size_z),
+                    target_size=(sat_target_x, sat_target_z),
                 )
                 if reproject_ok:
                     job.add_log(

--- a/webapp/services/satellite_service.py
+++ b/webapp/services/satellite_service.py
@@ -316,6 +316,42 @@ async def fetch_satellite_imagery(
 
 
 # ---------------------------------------------------------------------------
+# Satellite texture dimensions
+# ---------------------------------------------------------------------------
+
+# How many times larger the satellite texture is than the heightmap, per axis.
+# The diffuse texture is imported via the Terrain Tool > Import Satellite Map
+# step, independent of the heightmap vertex grid, so it can carry far more
+# detail. With high-resolution sources (e.g. Lantmäteriet STAC Bild at
+# 0.16 m/px) the previous heightmap-matched dimensions threw away ~15× the
+# source detail (#67).
+SATELLITE_RESOLUTION_MULTIPLIER = 4
+
+# Hard cap on satellite texture dimensions. 8192 is a safe modern texture
+# size; larger values risk Workbench import problems and big RAM/disk costs.
+SATELLITE_MAX_DIM = 8192
+
+
+def compute_satellite_target_dims(
+    heightmap_x: int, heightmap_z: int,
+) -> tuple[int, int]:
+    """
+    Compute the target satellite texture dimensions given the heightmap size.
+
+    Multiplies each axis by ``SATELLITE_RESOLUTION_MULTIPLIER`` and caps at
+    ``SATELLITE_MAX_DIM`` so we don't exceed the engine's texture limit or
+    blow up the export size.
+    """
+    # Never let the satellite be smaller than the heightmap, even at the
+    # 8193 vertex max where multiplier × dim exceeds the cap by a lot.
+    sat_x = min(SATELLITE_MAX_DIM, heightmap_x * SATELLITE_RESOLUTION_MULTIPLIER)
+    sat_z = min(SATELLITE_MAX_DIM, heightmap_z * SATELLITE_RESOLUTION_MULTIPLIER)
+    sat_x = max(sat_x, heightmap_x)
+    sat_z = max(sat_z, heightmap_z)
+    return int(sat_x), int(sat_z)
+
+
+# ---------------------------------------------------------------------------
 # Satellite reprojection (WGS84 → terrain CRS)
 # ---------------------------------------------------------------------------
 
@@ -392,7 +428,10 @@ def reproject_satellite_to_terrain_crs(
         # Allocate destination (rasterio expects bands × H × W)
         dst_raster = np.zeros((3, target_h, target_w), dtype=np.uint8)
 
-        # Reproject all three bands
+        # Reproject all three bands. Lanczos preserves more high-frequency
+        # detail than bilinear — important when the source is sub-metre
+        # imagery (Lantmäteriet STAC Bild at 0.16 m/px) being warped to a
+        # sub-metre output texture (see #67).
         for band in range(3):
             reproject(
                 source=src_raster[band],
@@ -401,7 +440,7 @@ def reproject_satellite_to_terrain_crs(
                 src_crs=src_crs,
                 dst_transform=dst_transform,
                 dst_crs=dst_crs_obj,
-                resampling=Resampling.bilinear,
+                resampling=Resampling.lanczos,
             )
 
         # Save reprojected image back to the same path

--- a/webapp/tests/test_satellite_dims.py
+++ b/webapp/tests/test_satellite_dims.py
@@ -1,0 +1,55 @@
+"""
+Tests for the satellite texture dimension helper (issue #67 — blurry imagery).
+
+The satellite texture is rendered at a higher resolution than the heightmap
+so we don't throw away source detail. These tests pin the multiplier and the
+SATELLITE_MAX_DIM cap. Pure Python — no rasterio/pyproj required, so they
+run on every dev environment.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+WEBAPP_DIR = Path(__file__).parent.parent
+if str(WEBAPP_DIR) not in sys.path:
+    sys.path.insert(0, str(WEBAPP_DIR))
+
+from services.satellite_service import (  # noqa: E402
+    SATELLITE_MAX_DIM,
+    SATELLITE_RESOLUTION_MULTIPLIER,
+    compute_satellite_target_dims,
+)
+
+
+class TestComputeSatelliteTargetDims:
+    def test_default_2049_heightmap_scales_up_capped_at_max(self):
+        """A 2049 heightmap × multiplier=4 = 8196 → capped to 8192."""
+        x, z = compute_satellite_target_dims(2049, 2049)
+        assert x == SATELLITE_MAX_DIM
+        assert z == SATELLITE_MAX_DIM
+
+    def test_small_heightmap_scales_up_uncapped(self):
+        """1025 × 4 = 4100, well below the 8192 cap, so no clamping."""
+        x, z = compute_satellite_target_dims(1025, 1025)
+        assert x == 1025 * SATELLITE_RESOLUTION_MULTIPLIER
+        assert z == 1025 * SATELLITE_RESOLUTION_MULTIPLIER
+
+    def test_rectangular_axes_capped_independently(self):
+        """Non-square heightmap: the larger axis caps first, the smaller one
+        scales freely."""
+        x, z = compute_satellite_target_dims(2049, 513)
+        # x = min(8192, 8196) = 8192
+        # z = min(8192, 2052) = 2052
+        assert x == SATELLITE_MAX_DIM
+        assert z == 513 * SATELLITE_RESOLUTION_MULTIPLIER
+
+    def test_satellite_strictly_larger_than_heightmap(self):
+        """For every valid Enfusion heightmap size, the satellite dim must be
+        strictly larger (or equal at the cap) — never smaller."""
+        for size in (129, 257, 513, 1025, 2049, 4097, 8193):
+            x, _ = compute_satellite_target_dims(size, size)
+            assert x >= size, (
+                f"satellite dim {x} smaller than heightmap dim {size}"
+            )


### PR DESCRIPTION
## Summary

Closes #67 — the satellite texture rendered at the heightmap's vertex resolution (e.g. 2049×2049 for a 5 km map → ~2.4 m/px output) while the Lantmäteriet STAC Bild source is 0.16 m/px — a ~15× downsample, which is exactly the visible blurriness the user reported on zoom-in.

The diffuse texture imported via Terrain Tool > Import Satellite Map is **independent** of the heightmap vertex grid, so we can render it at far higher resolution.

## Changes

### 1. Decouple satellite dims from heightmap dims

New `compute_satellite_target_dims(heightmap_x, heightmap_z)` in [satellite_service.py](webapp/services/satellite_service.py):
- Multiplies each axis by `SATELLITE_RESOLUTION_MULTIPLIER = 4`.
- Caps at `SATELLITE_MAX_DIM = 8192` (safe modern texture limit).
- Floors at the heightmap dim so the satellite is never smaller than the heightmap even at the 8193 vertex maximum.

For the default 2049 heightmap: satellite is now 8192×8192 (~0.61 m/px on a 5 km map) — **4× more detail per axis, 16× more pixels overall**.

### 2. Lanczos resampling

Both `reproject_satellite_to_terrain_crs` (WGS84 → terrain CRS, [satellite_service.py:397](webapp/services/satellite_service.py:397)) and the EPSG:3006 → WGS84 warp in the Lantmäteriet COG pipeline ([stac_orthophoto_service.py](webapp/services/lantmateriet/stac_orthophoto_service.py)) switched from `Resampling.bilinear` to `Resampling.lanczos`. Lanczos preserves edges and fine detail much better than bilinear, important when the source is sub-metre imagery.

### 3. Tests

New [test_satellite_dims.py](webapp/tests/test_satellite_dims.py) — 4 pure-Python tests (no rasterio/pyproj needed):

- Default 2049 heightmap caps at 8192.
- Small 1025 heightmap scales freely to 4100.
- Rectangular axes capped independently.
- Property test: satellite ≥ heightmap for every valid Enfusion size (129/257/.../8193).

## Test plan

- [x] `pytest webapp/tests/` — 251 passing (+4 new), same 7 pre-existing pyproj-env skips/failures as main.
- [ ] Generate a Swedish map with Lantmäteriet credentials; verify `satellite_map.png` is 8192×8192 (or 4× heightmap up to the cap) and looks crisp when zoomed in instead of bilinear-blurry.
- [ ] Workbench import sanity-check — confirm the higher-res texture imports without complaints.
- [ ] Disk-size sanity-check — 8192×8192 RGB PNG is ~50–150 MB compressed; well within reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)