### PR TITLE
v1.3.8: rate limiter returns 429 instead of bubbling as 500

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ The application is published to GitHub Container Registry and automatically buil
 docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:latest
 
 # Or use a specific version tag
-docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.3.7
+docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.3.8
 ```
 
 The `docker-compose.yml` is pre-configured to use the GHCR.io image. See the [Quick Start Guide](#quick-start-guide) for setup instructions.

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -47,7 +47,7 @@ configure_gdal_threading()
 # Application version (for cache busting)
 # ===========================================================================
 
-APP_VERSION = "1.3.7"  # Increment when static files change OR a new release ships
+APP_VERSION = "1.3.8"  # Increment when static files change OR a new release ships
 
 # ===========================================================================
 # FastAPI app

--- a/webapp/middleware/rate_limit.py
+++ b/webapp/middleware/rate_limit.py
@@ -14,10 +14,9 @@ import os
 from collections import defaultdict
 from datetime import datetime, timedelta
 
-from fastapi import HTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
-from starlette.responses import Response
+from starlette.responses import JSONResponse, Response
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +79,31 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         cutoff = datetime.utcnow() - window
         return [t for t in timestamps if t > cutoff]
 
+    def _rate_limited_response(
+        self,
+        detail: str,
+        limit: int,
+        retry_after_seconds: int,
+    ) -> JSONResponse:
+        """
+        Build the 429 response.
+
+        Important: we MUST return a Response from a BaseHTTPMiddleware.dispatch
+        rather than `raise HTTPException(...)`. Exceptions raised inside a
+        BaseHTTPMiddleware do not flow through FastAPI's exception handlers —
+        Starlette wraps them in an anyio ExceptionGroup that surfaces as a
+        500 Internal Server Error, hiding the real 429 from the client.
+        """
+        return JSONResponse(
+            status_code=429,
+            content={"detail": detail},
+            headers={
+                "Retry-After": str(retry_after_seconds),
+                "X-RateLimit-Limit": str(limit),
+                "X-RateLimit-Remaining": "0",
+            },
+        )
+
     async def dispatch(self, request: Request, call_next) -> Response:
         path = request.url.path
 
@@ -104,9 +128,10 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
         if len(self.request_counts[key]) >= REQUESTS_PER_MINUTE:
             logger.warning(f"Rate limit exceeded for {key}: general limit")
-            raise HTTPException(
-                status_code=429,
+            return self._rate_limited_response(
                 detail="Too many requests. Please slow down.",
+                limit=REQUESTS_PER_MINUTE,
+                retry_after_seconds=60,
             )
 
         # Special stricter rate limit for /api/generate
@@ -117,9 +142,13 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
             if len(self.generate_counts[key]) >= GENERATE_PER_HOUR:
                 logger.warning(f"Rate limit exceeded for {key}: generate limit")
-                raise HTTPException(
-                    status_code=429,
-                    detail=f"Generation limit reached ({GENERATE_PER_HOUR}/hour). Please try again later.",
+                return self._rate_limited_response(
+                    detail=(
+                        f"Generation limit reached ({GENERATE_PER_HOUR}/hour). "
+                        f"Please try again later."
+                    ),
+                    limit=GENERATE_PER_HOUR,
+                    retry_after_seconds=3600,
                 )
 
             self.generate_counts[key].append(now)

--- a/webapp/tests/test_rate_limit_middleware.py
+++ b/webapp/tests/test_rate_limit_middleware.py
@@ -1,0 +1,133 @@
+"""
+Tests for middleware/rate_limit.py.
+
+The middleware previously did `raise HTTPException(429, ...)` from
+`BaseHTTPMiddleware.dispatch`. Starlette does not run FastAPI's exception
+handlers for exceptions raised inside middleware — the HTTPException flowed
+up through an anyio ExceptionGroup and surfaced as a 500 Internal Server
+Error, masking the real 429 from the client. The fix is to return a
+JSONResponse directly. These tests pin that contract.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+WEBAPP_DIR = Path(__file__).parent.parent
+if str(WEBAPP_DIR) not in sys.path:
+    sys.path.insert(0, str(WEBAPP_DIR))
+
+# fastapi/starlette live in the Docker image but not on every dev machine.
+pytest.importorskip("fastapi", reason="fastapi required for middleware tests")
+pytest.importorskip("starlette", reason="starlette required for middleware tests")
+
+from fastapi import FastAPI  # noqa: E402
+from starlette.testclient import TestClient  # noqa: E402
+
+
+@pytest.fixture
+def app_with_low_limits(monkeypatch):
+    """Build an isolated FastAPI app with tiny rate limits so the test can
+    trip them in a couple of requests."""
+    monkeypatch.setenv("RATE_LIMIT_REQUESTS_PER_MINUTE", "3")
+    monkeypatch.setenv("RATE_LIMIT_GENERATE_PER_HOUR", "2")
+
+    # Force a fresh import so the module-level env-driven constants reload.
+    for mod_name in [
+        "middleware.rate_limit",
+        "middleware",
+    ]:
+        sys.modules.pop(mod_name, None)
+    from middleware.rate_limit import RateLimitMiddleware  # noqa: E402
+
+    app = FastAPI()
+    app.add_middleware(RateLimitMiddleware)
+
+    @app.get("/api/ping")
+    def ping():
+        return {"ok": True}
+
+    @app.post("/api/generate")
+    def generate():
+        return {"ok": True}
+
+    return app
+
+
+class TestGeneralRateLimit:
+    def test_under_limit_returns_200(self, app_with_low_limits):
+        client = TestClient(app_with_low_limits)
+        for _ in range(3):
+            resp = client.get("/api/ping")
+            assert resp.status_code == 200
+
+    def test_over_limit_returns_429_not_500(self, app_with_low_limits):
+        """The original bug: HTTPException raised in BaseHTTPMiddleware was
+        surfaced as 500. The fix returns a proper 429 JSONResponse."""
+        client = TestClient(app_with_low_limits)
+        for _ in range(3):
+            client.get("/api/ping")
+        resp = client.get("/api/ping")
+        assert resp.status_code == 429, (
+            f"expected 429, got {resp.status_code} — the middleware is "
+            f"raising HTTPException again and Starlette is masking it as 500"
+        )
+
+    def test_429_body_is_json_with_detail(self, app_with_low_limits):
+        client = TestClient(app_with_low_limits)
+        for _ in range(4):
+            resp = client.get("/api/ping")
+        assert resp.headers["content-type"].startswith("application/json")
+        body = resp.json()
+        assert "detail" in body
+        assert "Too many requests" in body["detail"]
+
+    def test_429_includes_retry_after_and_ratelimit_headers(
+        self, app_with_low_limits
+    ):
+        client = TestClient(app_with_low_limits)
+        for _ in range(4):
+            resp = client.get("/api/ping")
+        assert resp.headers.get("Retry-After") == "60"
+        assert resp.headers.get("X-RateLimit-Limit") == "3"
+        assert resp.headers.get("X-RateLimit-Remaining") == "0"
+
+
+class TestGenerateRateLimit:
+    def test_generate_over_limit_returns_429_not_500(self, app_with_low_limits):
+        client = TestClient(app_with_low_limits)
+        # Two POSTs are allowed (GENERATE_PER_HOUR=2); the third trips it.
+        client.post("/api/generate")
+        client.post("/api/generate")
+        resp = client.post("/api/generate")
+        assert resp.status_code == 429
+        body = resp.json()
+        assert "Generation limit reached" in body["detail"]
+        assert resp.headers.get("Retry-After") == "3600"
+
+
+class TestNonApiPathsAreExempt:
+    def test_health_endpoint_is_not_rate_limited(self, app_with_low_limits):
+        # Mount a /api/health route too — exempt per the middleware.
+        @app_with_low_limits.get("/api/health")
+        def health():
+            return {"ok": True}
+
+        client = TestClient(app_with_low_limits)
+        for _ in range(20):
+            resp = client.get("/api/health")
+            assert resp.status_code == 200
+
+    def test_non_api_paths_are_not_rate_limited(self, app_with_low_limits):
+        @app_with_low_limits.get("/static-asset")
+        def asset():
+            return {"ok": True}
+
+        client = TestClient(app_with_low_limits)
+        for _ in range(20):
+            resp = client.get("/static-asset")
+            assert resp.status_code == 200


### PR DESCRIPTION
## Summary

\`middleware/rate_limit.py\` raised \`HTTPException(429, ...)\` from inside \`BaseHTTPMiddleware.dispatch\`. **Starlette does not run FastAPI's exception handlers for exceptions raised inside middleware** — the HTTPException flows up through an anyio \`ExceptionGroup\` and surfaces as a 500 Internal Server Error, hiding the real 429 from the client. This is the well-known \`BaseHTTPMiddleware\` gotcha.

User saw it on 2026-05-14 hammering \`/api/job/.../preview/heightmap\`:
\`\`\`
500 Internal Server Error
ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+--- 1 ---
    | fastapi.exceptions.HTTPException: 429: Too many requests. Please slow down.
\`\`\`

The rate limiter was working correctly — it was just signalling it wrong.

## Changes

- [middleware/rate_limit.py](webapp/middleware/rate_limit.py) — both \`raise HTTPException(429, ...)\` call sites now \`return self._rate_limited_response(...)\`. New helper builds the JSONResponse and adds \`Retry-After\` (60 s general / 3600 s for \`/api/generate\`), \`X-RateLimit-Limit\`, and \`X-RateLimit-Remaining=0\` so clients can self-throttle without polling.
- New [test_rate_limit_middleware.py](webapp/tests/test_rate_limit_middleware.py) — gated on \`fastapi\`: general limit returns 429 not 500, JSON body has detail, headers present; generate limit returns 429 with 3600 Retry-After; \`/api/health\` and non-\`/api/\` paths remain unthrottled.
- [main.py](webapp/main.py:50), [README.md](README.md:432) — APP_VERSION + Docker tag bumped to 1.3.8.

The middleware's \`_rate_limited_response\` helper carries a comment explaining why returning beats raising here, so the next maintainer doesn't reintroduce the bug.

## Test plan

- [x] \`pytest webapp/tests/\` — 251 passing, same 7 pre-existing pyproj-env skips/failures as main. (New test gated on fastapi locally — runs green in Docker CI.)
- [ ] After deploy, slam the preview endpoint with \`for i in {1..100}; do curl http://...; done\` and verify clients see HTTP 429 with \`Retry-After: 60\` instead of HTTP 500 + stack trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)