### PR TITLE
v1.3.9: progress heartbeat during STAC Bild COG merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ The application is published to GitHub Container Registry and automatically buil
 docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:latest
 
 # Or use a specific version tag
-docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.3.8
+docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.3.9
 ```
 
 The `docker-compose.yml` is pre-configured to use the GHCR.io image. See the [Quick Start Guide](#quick-start-guide) for setup instructions.

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -47,7 +47,7 @@ configure_gdal_threading()
 # Application version (for cache busting)
 # ===========================================================================
 
-APP_VERSION = "1.3.8"  # Increment when static files change OR a new release ships
+APP_VERSION = "1.3.9"  # Increment when static files change OR a new release ships
 
 # ===========================================================================
 # FastAPI app

--- a/webapp/services/lantmateriet/stac_orthophoto_service.py
+++ b/webapp/services/lantmateriet/stac_orthophoto_service.py
@@ -120,6 +120,7 @@ def _cog_merge_rgb(
         (merged_rgb_array, affine_transform) where the array has shape
         (3, H, W) in uint8. Returns (None, None) on failure.
     """
+    import threading
     import time
 
     import rasterio
@@ -177,8 +178,36 @@ def _cog_merge_rgb(
             f"{int(x_max - x_min)}×{int(y_max - y_min)} m "
             f"→ target {target_width}×{target_height} px"
         )
+        if job:
+            # rasterio.merge is a single blocking call with no progress hook —
+            # warn the user up front so the UI doesn't look frozen.
+            job.add_log(
+                f"Merging {len(datasets)} orthophoto tiles into final image — "
+                f"this can take 30–120 seconds and the activity log will look "
+                f"idle while it runs. Please stand by..."
+            )
 
         merge_start = time.monotonic()
+
+        # Heartbeat thread: emit a progress line every 5s so docker logs and the
+        # web UI activity log show forward motion during the blocking merge.
+        heartbeat_stop = threading.Event()
+
+        def _heartbeat():
+            elapsed = 0
+            while not heartbeat_stop.wait(5.0):
+                elapsed += 5
+                logger.info(
+                    f"STAC Bild: merge in progress... {elapsed}s elapsed"
+                )
+                if job:
+                    job.add_log(
+                        f"...still merging orthophoto tiles ({elapsed}s elapsed)"
+                    )
+
+        heartbeat_thread = threading.Thread(target=_heartbeat, daemon=True)
+        heartbeat_thread.start()
+
         try:
             # indexes=[1, 2, 3] selects the RGB bands (band 4 is NIR — skip it).
             # target_aligned_pixels=True snaps the output extent so pixels are
@@ -200,6 +229,8 @@ def _cog_merge_rgb(
             logger.error(f"rasterio.merge failed for STAC Bild COGs: {exc}")
             return None, None
         finally:
+            heartbeat_stop.set()
+            heartbeat_thread.join(timeout=1.0)
             for ds in datasets:
                 try:
                     ds.close()


### PR DESCRIPTION
## Summary
- `rasterio.merge()` is a single blocking call with no progress hook — during the 30–120s merge phase both docker logs and the web UI activity log went silent, so users thought the job had crashed.
- Adds a pre-merge "this can take 30–120s, please stand by" notice to the job activity log so the UI sets expectations before the pause.
- Spawns a 5-second heartbeat thread that emits elapsed-time progress lines to both the python logger and `job.add_log` while the merge runs; stopped cleanly in `finally`.
- Bumps APP_VERSION → 1.3.9 (main.py + README).

## Test plan
- [ ] Generate a Swedish map; confirm the "please stand by" line appears in the web UI activity log immediately before the merge.
- [ ] Confirm `...still merging orthophoto tiles (Xs elapsed)` lines appear every ~5s in both `docker compose logs` and the UI activity log.
- [ ] Confirm heartbeat stops cleanly when the merge finishes (no stray progress lines after "range-merge complete").
- [ ] Verify the UI footer shows v1.3.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)