### PR TITLE
v1.3.10: unblock event loop during STAC Bild merge/warp/encode

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ The application is published to GitHub Container Registry and automatically buil
 docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:latest
 
 # Or use a specific version tag
-docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.3.9
+docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.3.10
 ```
 
 The `docker-compose.yml` is pre-configured to use the GHCR.io image. See the [Quick Start Guide](#quick-start-guide) for setup instructions.

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -47,7 +47,7 @@ configure_gdal_threading()
 # Application version (for cache busting)
 # ===========================================================================
 
-APP_VERSION = "1.3.9"  # Increment when static files change OR a new release ships
+APP_VERSION = "1.3.10"  # Increment when static files change OR a new release ships
 
 # ===========================================================================
 # FastAPI app

--- a/webapp/services/lantmateriet/stac_orthophoto_service.py
+++ b/webapp/services/lantmateriet/stac_orthophoto_service.py
@@ -27,6 +27,7 @@ Workflow:
 
 from __future__ import annotations
 
+import asyncio
 import io
 import logging
 from typing import Optional
@@ -364,8 +365,14 @@ async def fetch_stac_orthophoto(
 
     # ------------------------------------------------------------------ #
     # 4. COG windowed merge (synchronous; rasterio issues HTTP range reqs)
+    #
+    # Run on a worker thread via asyncio.to_thread so the event loop stays
+    # responsive — otherwise the 30-300s blocking merge freezes the FastAPI
+    # /job/{id} polling endpoint and the web UI activity log can't update
+    # even though job.add_log entries are being appended in the background.
     # ------------------------------------------------------------------ #
-    merged_rgb, src_transform = _cog_merge_rgb(
+    merged_rgb, src_transform = await asyncio.to_thread(
+        _cog_merge_rgb,
         vsicurl_hrefs,
         epsg3006_bounds=(x_min, y_min, x_max, y_max),
         target_width=width,
@@ -411,9 +418,12 @@ async def fetch_stac_orthophoto(
                 f"(Lanczos, 3 bands)..."
             )
 
+        # Each band warp is ~9s blocking. Run each on a worker thread so the
+        # event loop unblocks between bands and the UI activity log can refresh.
         for band in range(3):
             band_start = _time.monotonic()
-            warp_reproject(
+            await asyncio.to_thread(
+                warp_reproject,
                 source=merged_rgb[band],
                 destination=dst_array[band],
                 src_transform=src_transform,
@@ -422,10 +432,14 @@ async def fetch_stac_orthophoto(
                 dst_crs=dst_crs,
                 resampling=Resampling.lanczos,
             )
+            band_elapsed = _time.monotonic() - band_start
             logger.info(
-                f"STAC Bild: warped band {band + 1}/3 in "
-                f"{_time.monotonic() - band_start:.1f}s"
+                f"STAC Bild: warped band {band + 1}/3 in {band_elapsed:.1f}s"
             )
+            if job:
+                job.add_log(
+                    f"Warped orthophoto band {band + 1}/3 in {band_elapsed:.1f}s"
+                )
 
         warp_elapsed = _time.monotonic() - warp_start
         logger.info(f"STAC Bild: warp complete in {warp_elapsed:.1f}s")
@@ -449,10 +463,13 @@ async def fetch_stac_orthophoto(
             job.add_log(
                 f"Encoding orthophoto to PNG ({width}×{height} px)..."
             )
-        img = Image.fromarray(dst_array.transpose(1, 2, 0))  # (H, W, 3)
-        buf = io.BytesIO()
-        img.save(buf, format="PNG")
-        png_bytes = buf.getvalue()
+        def _encode_png() -> bytes:
+            img = Image.fromarray(dst_array.transpose(1, 2, 0))  # (H, W, 3)
+            buf = io.BytesIO()
+            img.save(buf, format="PNG")
+            return buf.getvalue()
+
+        png_bytes = await asyncio.to_thread(_encode_png)
         enc_elapsed = _time.monotonic() - enc_start
 
         logger.info(


### PR DESCRIPTION
## Summary
Follow-up to #78. v1.3.9 added a heartbeat thread for the 30–300s `rasterio.merge` phase, but the merge ran synchronously inside an `async` function — it **blocked the FastAPI event loop** for the whole duration, so the `/job/{id}` polling endpoint couldn't respond and the web UI activity log appeared frozen on the last entry before the merge. The heartbeat fired in docker logs but never reached the browser.

- `_cog_merge_rgb` is now dispatched via `asyncio.to_thread`. The heartbeat thread's `job.add_log` writes now reach the UI, AND `JobLogHandler` tees the per-tile `logger.info` lines via the ContextVar that `to_thread` propagates.
- Each of the 3 band warps (≈9s each) now runs on a worker thread; per-band progress appears in the UI activity log.
- PNG encode runs on a worker thread.
- Bumps `APP_VERSION` → 1.3.10 (main.py + README).

## Test plan
- [ ] Generate a Swedish map; confirm the web UI activity log shows the pre-merge "please stand by" line and ~5s heartbeat updates while the merge runs.
- [ ] Confirm per-band warp progress (`Warped orthophoto band N/3 in Xs`) appears in the UI between merge and PNG encode.
- [ ] Confirm the UI footer shows v1.3.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)