### PR TITLE
v1.3.11: force no-store on /status/{job_id} to defeat CDN caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ The application is published to GitHub Container Registry and automatically buil
 docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:latest
 
 # Or use a specific version tag
-docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.3.10
+docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.3.11
 ```
 
 The `docker-compose.yml` is pre-configured to use the GHCR.io image. See the [Quick Start Guide](#quick-start-guide) for setup instructions.

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -47,7 +47,7 @@ configure_gdal_threading()
 # Application version (for cache busting)
 # ===========================================================================
 
-APP_VERSION = "1.3.10"  # Increment when static files change OR a new release ships
+APP_VERSION = "1.3.11"  # Increment when static files change OR a new release ships
 
 # ===========================================================================
 # FastAPI app
@@ -463,6 +463,13 @@ async def get_job_status_public(job_id: str, since: int = 0):
     the client wants. The response slices `logs` to entries from that index
     forward and reports `logs_total` so the client can advance its cursor.
     This keeps poll payloads small under fast polling and long log streams.
+
+    Cache-Control: no-store is critical. Without it, Cloudflare/CDN/browser
+    layers can cache the JSON response per (job_id, since) tuple. When the
+    cursor stops advancing because no new logs arrived yet, every subsequent
+    poll hits the same URL and gets a cached "no new logs" response — the
+    cursor never advances, and the activity log appears frozen even though
+    job.logs is growing in memory. Forcing no-store guarantees fresh polls.
     """
     from services.map_generator import get_job
 
@@ -496,7 +503,17 @@ async def get_job_status_public(job_id: str, since: int = 0):
                 "minutes_remaining": max(0, int(time_remaining)),
             }
 
-    return job_data
+    return JSONResponse(
+        content=job_data,
+        headers={
+            "Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
+            "Pragma": "no-cache",
+            "Expires": "0",
+            # Cloudflare-specific bypass: skip the edge cache entirely.
+            "CDN-Cache-Control": "no-store",
+            "Cloudflare-CDN-Cache-Control": "no-store",
+        },
+    )
 
 
 @app.get("/api/job/{job_id}")


### PR DESCRIPTION
## Summary
Follow-up to [#79](https://github.com/tubalainen/arma_reforger_base_map_generator_ng/pull/79). v1.3.10 unblocked the event loop so `job.add_log` writes during the STAC Bild merge could be served, but the UI activity log was *still* frozen on \"Searching Lantmäteriet STAC Bild...\" even though `docker compose logs` showed the heartbeat firing.

Root cause: `/status/{job_id}` returned the JSON snapshot with no `Cache-Control` header. Cloudflare tunnel (and any intermediary or the browser HTTP cache) can cache the response per `(job_id, since)` tuple. When no new logs arrive between polls and the cursor stops advancing, every subsequent poll hits the same URL and gets the cached \"no new logs\" payload back — the cursor never advances, and the activity log appears frozen even though `job.logs` is growing in memory.

- Return `JSONResponse` with `Cache-Control: no-store, no-cache, must-revalidate, max-age=0`, `Pragma: no-cache`, `Expires: 0`.
- Add `CDN-Cache-Control: no-store` + `Cloudflare-CDN-Cache-Control: no-store` to bypass any \"Cache Everything\" Cloudflare rule explicitly.
- Bumps `APP_VERSION` → 1.3.11.

## Test plan
- [ ] Generate a Swedish map; confirm the activity log fills with heartbeat \"...still merging orthophoto tiles (Xs elapsed)\" lines during the 30–300s merge.
- [ ] In browser DevTools → Network, confirm `/status/...` responses now have `Cache-Control: no-store` and that `cf-cache-status` is `BYPASS` or `DYNAMIC`.
- [ ] Confirm the UI footer shows v1.3.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)