### PR TITLE
fix: align hydrografi localType maps with real Lantmäteriet enums (#83)

### DIFF
--- a/webapp/services/lantmateriet/hydrografi_service.py
+++ b/webapp/services/lantmateriet/hydrografi_service.py
@@ -31,36 +31,35 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # localType → water_type mapping
 # ---------------------------------------------------------------------------
-# These are INSPIRE localType values used by Lantmäteriet.
-# Unknown values are logged at INFO and assigned a default.
+# These are the localType values documented in the Lantmäteriet Hydrografi
+# product description (e_pb_hydrografi_nedladdning v1.1, 2023-03-03).
+# The API emits Swedish terms in lowercase; lookups are normalised via
+# .lower() so any future casing drift still matches.
+#
+# Canal detection is NOT done via localType — Lantmäteriet exposes a separate
+# `origin: "natural" | "manMade"` field on watercourses for that. See
+# _watercourse_water_type() below.
 
 _STANDING_WATER_TYPE_MAP: dict[str, str] = {
-    # Swedish localType values (may appear in Swedish or English)
-    "Sjö": "lake",
-    "Lake": "lake",
-    "Damm": "pond",
-    "Pond": "pond",
-    "Reservoar": "reservoir",
-    "Reservoir": "reservoir",
-    "Magasin": "reservoir",
-    "Bassäng": "pond",
+    "sjö": "lake",
 }
 
 _WATERCOURSE_TYPE_MAP: dict[str, str] = {
-    # Rivers (larger watercourses)
-    "Flod": "river",
-    "River": "river",
-    "Å": "river",
-    "Älv": "river",
-    # Canals
-    "Kanal": "canal",
-    "Canal": "canal",
-    # Streams (smaller watercourses) — default
-    "Bäck": "stream",
-    "Stream": "stream",
-    "Dike": "ditch",
-    "Ditch": "ditch",
+    "vattendrag": "stream",
+    # Synthetic centre lines drawn through lake/watercourse polygons. Mapped
+    # so they don't trigger the "unknown" log; downstream filtering is a
+    # separate concern (they duplicate the polygon geometry).
+    "stomlinje": "stream",
+    "stomlinje, otydlig": "stream",
 }
+
+
+def _watercourse_water_type(props: dict) -> str:
+    """Pick a water_type for a WatercourseLine, honouring origin=manMade."""
+    if (props.get("origin") or "").strip().lower() == "manmade":
+        return "canal"
+    local_type = (props.get("localType") or "").strip().lower()
+    return _WATERCOURSE_TYPE_MAP.get(local_type, "stream")
 
 
 def _extract_name(feature: dict) -> str:
@@ -140,9 +139,9 @@ def _translate_standing_water(features: list[dict]) -> list[dict]:
 
     for f in features:
         props = f.get("properties", {})
-        local_type = props.get("localType", "")
+        local_type = (props.get("localType") or "").strip().lower()
 
-        water_type = _STANDING_WATER_TYPE_MAP.get(local_type, None)
+        water_type = _STANDING_WATER_TYPE_MAP.get(local_type)
         if water_type is None:
             water_type = "lake"  # Default for standing water
             if local_type:
@@ -177,13 +176,11 @@ def _translate_watercourse_line(features: list[dict]) -> list[dict]:
 
     for f in features:
         props = f.get("properties", {})
-        local_type = props.get("localType", "")
+        local_type = (props.get("localType") or "").strip().lower()
+        water_type = _watercourse_water_type(props)
 
-        water_type = _WATERCOURSE_TYPE_MAP.get(local_type, None)
-        if water_type is None:
-            water_type = "stream"  # Default for watercourse lines
-            if local_type:
-                unknown_types[local_type] = unknown_types.get(local_type, 0) + 1
+        if water_type == "stream" and local_type and local_type not in _WATERCOURSE_TYPE_MAP:
+            unknown_types[local_type] = unknown_types.get(local_type, 0) + 1
 
         translated.append({
             "type": "Feature",

--- a/webapp/tests/test_lantmateriet.py
+++ b/webapp/tests/test_lantmateriet.py
@@ -355,8 +355,8 @@ class TestHydrografiTranslation:
         assert result[0]["properties"]["natural"] == "water"
         assert result[0]["properties"]["intermittent"] == "no"
 
-    def test_standing_water_pond(self):
-        """StandingWater with localType=Damm maps to pond."""
+    def test_standing_water_sjo(self):
+        """StandingWater with localType='sjö' (the only documented value) maps to lake."""
         from services.lantmateriet.hydrografi_service import (
             _translate_standing_water,
         )
@@ -365,14 +365,30 @@ class TestHydrografiTranslation:
             {
                 "id": 2,
                 "geometry": {"type": "Polygon", "coordinates": [[[11, 57], [12, 57], [12, 58], [11, 57]]]},
-                "properties": {"localType": "Damm"},
+                "properties": {"localType": "sjö"},
             }
         ]
         result = _translate_standing_water(features)
-        assert result[0]["properties"]["water_type"] == "pond"
+        assert result[0]["properties"]["water_type"] == "lake"
 
-    def test_watercourse_line_to_river(self):
-        """WatercourseLine with localType=Älv maps to river."""
+    def test_standing_water_lookup_is_case_insensitive(self):
+        """Casing drift in the API ('Sjö' vs 'sjö') still resolves to lake."""
+        from services.lantmateriet.hydrografi_service import (
+            _translate_standing_water,
+        )
+
+        features = [
+            {
+                "id": 3,
+                "geometry": {"type": "Polygon", "coordinates": [[[11, 57], [12, 57], [12, 58], [11, 57]]]},
+                "properties": {"localType": "Sjö"},
+            }
+        ]
+        result = _translate_standing_water(features)
+        assert result[0]["properties"]["water_type"] == "lake"
+
+    def test_watercourse_line_vattendrag_to_stream(self):
+        """WatercourseLine with localType='vattendrag' maps to stream (default natural watercourse)."""
         from services.lantmateriet.hydrografi_service import (
             _translate_watercourse_line,
         )
@@ -381,14 +397,14 @@ class TestHydrografiTranslation:
             {
                 "id": 10,
                 "geometry": {"type": "LineString", "coordinates": [[11, 57], [12, 58]]},
-                "properties": {"localType": "Älv", "persistence": "Perennial"},
+                "properties": {"localType": "vattendrag", "origin": "natural", "persistence": "Perennial"},
             }
         ]
         result = _translate_watercourse_line(features)
 
         assert len(result) == 1
-        assert result[0]["properties"]["water_type"] == "river"
-        assert result[0]["properties"]["waterway"] == "river"
+        assert result[0]["properties"]["water_type"] == "stream"
+        assert result[0]["properties"]["waterway"] == "stream"
         assert result[0]["properties"]["natural"] == ""
 
     def test_watercourse_line_to_stream_default(self):
@@ -401,14 +417,14 @@ class TestHydrografiTranslation:
             {
                 "id": 11,
                 "geometry": {"type": "LineString", "coordinates": [[11, 57], [12, 58]]},
-                "properties": {"localType": "OkändTyp"},
+                "properties": {"localType": "okändtyp"},
             }
         ]
         result = _translate_watercourse_line(features)
         assert result[0]["properties"]["water_type"] == "stream"
 
-    def test_watercourse_line_canal(self):
-        """WatercourseLine with localType=Kanal maps to canal."""
+    def test_watercourse_line_canal_via_origin(self):
+        """Canals are detected via origin='manMade', not localType (per Lantmäteriet spec)."""
         from services.lantmateriet.hydrografi_service import (
             _translate_watercourse_line,
         )
@@ -417,12 +433,28 @@ class TestHydrografiTranslation:
             {
                 "id": 12,
                 "geometry": {"type": "LineString", "coordinates": [[11, 57], [12, 58]]},
-                "properties": {"localType": "Kanal"},
+                "properties": {"localType": "vattendrag", "origin": "manMade"},
             }
         ]
         result = _translate_watercourse_line(features)
         assert result[0]["properties"]["water_type"] == "canal"
         assert result[0]["properties"]["waterway"] == "canal"
+
+    def test_watercourse_line_stomlinje_is_known(self):
+        """Synthetic centre lines ('stomlinje') are mapped without warning."""
+        from services.lantmateriet.hydrografi_service import (
+            _translate_watercourse_line,
+        )
+
+        features = [
+            {
+                "id": 13,
+                "geometry": {"type": "LineString", "coordinates": [[11, 57], [12, 58]]},
+                "properties": {"localType": "stomlinje, otydlig"},
+            }
+        ]
+        result = _translate_watercourse_line(features)
+        assert result[0]["properties"]["water_type"] == "stream"
 
     def test_wetland_translation(self):
         """Wetland features map to water_type=wetland."""


### PR DESCRIPTION
## Summary

Closes #83.

The previous `localType` maps in [`hydrografi_service.py`](webapp/services/lantmateriet/hydrografi_service.py) were title-cased fantasy values (`Damm`, `Älv`, `Bäck`, `Kanal`, `Flod`, `Lake`, `Pond`, …) that the Lantmäteriet OGC Hydrografi API **never emits**. The real values, per the official product description PDF (`e_pb_hydrografi_nedladdning v1.1, 2023-03-03`), are a small lowercase Swedish enum:

| Collection | Real `localType` values |
|---|---|
| `StandingWater` | `"sjö"` |
| `WatercourseLine` | `"vattendrag"`, `"stomlinje"`, `"stomlinje, otydlig"` |
| `WatercoursePolygon` | `"vattendragsyta"` |
| `Wetland` | `"sankmark, fast"`, `"sankmark, våt"` |

Canals are flagged via a separate `origin: "natural" \| "manMade"` attribute — not `localType`.

The mismatch was harmless functionally (defaults applied), but spammed misleading INFO logs every run:
```
StandingWater: unknown localType values (defaulted to 'lake'): {'sjö': 2}
WatercourseLine: unknown localType values (defaulted to 'stream'): {'vattendrag': 3}
```

## Changes

- Replace the fantasy maps with the documented enum (lowercase Swedish).
- Normalise lookups via `.lower()` so any future casing drift still matches.
- Detect canals from `origin == "manMade"` instead of a `localType="Kanal"` that never arrives.
- Recognise synthetic centre lines (`"stomlinje"`, `"stomlinje, otydlig"`) so they don't trigger the unknown-type log.
- Rewrite the affected unit tests to use values the API actually returns.

## Out of scope (filed mentally as follow-ups)

- `"stomlinje"` features are synthetic centre lines drawn through lake / wide-river polygons — they likely produce thin streams rendered across lake surfaces. Worth filtering, but it's a separate bug.
- The pre-existing `TestLantmaterietAuth::test_basic_auth_header_missing_credentials` flake on `main` (env var pollution from earlier tests) is unrelated to this change.

## Test plan
- [x] `pytest tests/test_lantmateriet.py -k Hydrografi` — 15 passed
- [ ] After merge, watch a Swedish-bbox job and confirm the "unknown localType values" log line no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)