### PR TITLE
fix(ui): Sentinel-2 layer renders at high zoom + default to satellite (#2)

### DIFF
--- a/webapp/static/js/app.js
+++ b/webapp/static/js/app.js
@@ -21,19 +21,26 @@ const osmLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png
     maxZoom: 19,
 });
 
+// Sentinel-2 cloudless mosaic via EOX. Native pixel resolution is ~10 m
+// (≈ z14), but EOX serves overzoom tiles up to z21, so we let Leaflet
+// render up to maxZoom and only stop fetching new tiles past
+// maxNativeZoom — past that point tiles are upscaled rather than blank.
+// Without this, switching to satellite while zoomed in (the common case
+// for picking a small bbox) shows nothing. (Issue #2.)
 const satelliteLayer = L.tileLayer(
-    'https://tiles.maps.eox.at/wmts/1.0.0/s2cloudless-2021_3857/default/GoogleMapsCompatible/{z}/{y}/{x}.jpg', {
-    attribution: '&copy; <a href="https://s2maps.eu">Sentinel-2 cloudless by EOX</a>',
-    maxZoom: 15,
+    'https://tiles.maps.eox.at/wmts/1.0.0/s2cloudless-2024_3857/default/GoogleMapsCompatible/{z}/{y}/{x}.jpg', {
+    attribution: '&copy; <a href="https://s2maps.eu">Sentinel-2 cloudless 2024 by EOX</a>',
+    maxZoom: 19,
+    maxNativeZoom: 18,
 });
 
-// Add default layer
-osmLayer.addTo(map);
+// Default to satellite — most users are picking a real-world area to map.
+satelliteLayer.addTo(map);
 
 // Layer control
 L.control.layers({
-    'OpenStreetMap': osmLayer,
     'Satellite (Sentinel-2)': satelliteLayer,
+    'OpenStreetMap': osmLayer,
 }, null, { position: 'topright' }).addTo(map);
 
 // ===========================================================================


### PR DESCRIPTION
## Summary

Closes #2.

The bbox-picker map's **Satellite (Sentinel-2)** base layer rendered blank because of a single-line oversight in [`webapp/static/js/app.js`](webapp/static/js/app.js): the layer was declared with `maxZoom: 15`, while the OSM layer (and the typical user zoom level) goes to 19. Workflow:

1. User opens the picker, zooms in past z15 on OSM to find their target area.
2. Switches base layer to Satellite (Sentinel-2).
3. Leaflet stops requesting tiles for that layer (current zoom > layer.maxZoom) → **blank gray map**.

EOX actually serves the s2cloudless `GoogleMapsCompatible` tile matrix all the way to z21 — confirmed against the WMTS capabilities document.

While in there I also addressed the user's "make satellite the default" ask and freshened the imagery year.

## Changes

- **Raise satellite `maxZoom` to 19** (matches OSM) so tiles keep loading.
- **Add `maxNativeZoom: 18`** so above true native resolution, Leaflet upscales the last real tile rather than dropping it. (Sentinel-2 is ~10 m / ≈ z14 native; EOX serves overzoom tiles beyond that.)
- **Make Satellite the default** base layer.
- **Bump the s2cloudless mosaic 2021 → 2024** (freshest available year on the EOX endpoint).
- Reorder the layer control so Satellite is listed first.

## Verification

Spun up a static preview server and inspected the live DOM at z17 (the case that used to render blank):

```
{ zoom: 17, totalTiles: 4, loaded: 4, errored: 0,
  sample: 'https://tiles.maps.eox.at/wmts/1.0.0/s2cloudless-2024_3857/default/GoogleMapsCompatible/17/38546/72114.jpg' }
```

All four visible tiles loaded as valid 256×256 JPEGs from the new endpoint. With the old `maxZoom: 15`, Leaflet would have requested zero tiles at z17.

## Test plan
- [x] Confirmed satellite tiles load at z17 over Stockholm in headless preview
- [ ] After merge, open the web UI, confirm the satellite imagery shows by default and remains visible at deep zoom (z17–19)
- [ ] Confirm switching back to OpenStreetMap still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)