### PR TITLE
v1.4.2: hydrografi log noise + Sentinel-2 base layer fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ The application is published to GitHub Container Registry and automatically buil
 docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:latest
 
 # Or use a specific version tag
-docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.4.1
+docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.4.2
 ```
 
 The `docker-compose.yml` is pre-configured to use the GHCR.io image. See the [Quick Start Guide](#quick-start-guide) for setup instructions.

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -47,7 +47,7 @@ configure_gdal_threading()
 # Application version (for cache busting)
 # ===========================================================================
 
-APP_VERSION = "1.4.1"  # Increment when static files change OR a new release ships
+APP_VERSION = "1.4.2"  # Increment when static files change OR a new release ships
 
 # ===========================================================================
 # FastAPI app


### PR DESCRIPTION
## Summary

Patch release that bumps `APP_VERSION` and the README docker-pull tag to **v1.4.2**, bundling two bug fixes that already merged to `main`:

- **[#86](https://github.com/tubalainen/arma_reforger_base_map_generator_ng/pull/86)** (closes [#83](https://github.com/tubalainen/arma_reforger_base_map_generator_ng/issues/83)) — Align hydrografi `localType` maps with the documented Lantmäteriet enum (lowercase Swedish: `sjö`, `vattendrag`, `stomlinje`, …). Canals are now detected via `origin="manMade"` instead of a non-existent `localType="Kanal"`. Synthetic centre lines (`stomlinje`) are recognised so they no longer trigger the "unknown localType values" log spam.
- **[#87](https://github.com/tubalainen/arma_reforger_base_map_generator_ng/pull/87)** (closes [#2](https://github.com/tubalainen/arma_reforger_base_map_generator_ng/issues/2)) — Sentinel-2 base layer in the bbox-picker now renders at high zoom (`maxNativeZoom: 18`, `maxZoom: 19` — was capped at 15). Satellite is the default base layer. Cloudless mosaic bumped 2021 → 2024.

## Test plan
- [x] `pytest tests/test_lantmateriet.py -k Hydrografi` — 15 passed
- [x] At z17 over Stockholm, all four visible Sentinel-2 tiles load as valid 256×256 imagery from the EOX 2024 endpoint
- [ ] After merge + image build, smoke-test a Swedish-bbox job and confirm:
  - The "unknown localType values" INFO log no longer appears
  - The web UI opens with Sentinel-2 imagery visible by default and remains visible at deep zoom

🤖 Generated with [Claude Code](https://claude.com/claude-code)