### PR TITLE
fix(csp): whitelist tiles.maps.eox.at so Sentinel-2 base layer renders (#2 follow-up)

### DIFF
--- a/webapp/middleware/security.py
+++ b/webapp/middleware/security.py
@@ -44,7 +44,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
             "default-src 'self'; "
             "script-src 'self' https://unpkg.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com; "
             "style-src 'self' 'unsafe-inline' https://unpkg.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com; "
-            "img-src 'self' data: blob: https://*.tile.openstreetmap.org https://server.arcgisonline.com; "
+            "img-src 'self' data: blob: https://*.tile.openstreetmap.org https://server.arcgisonline.com https://tiles.maps.eox.at; "
             "connect-src 'self'; "
             "font-src 'self' https://cdn.jsdelivr.net; "
             "frame-ancestors 'self'; "


### PR DESCRIPTION
## Summary

Hotfix for v1.4.2. The Sentinel-2 base layer made it through PR [#87](https://github.com/tubalainen/arma_reforger_base_map_generator_ng/pull/87) Leaflet-correct (`maxZoom`, default layer, 2024 mosaic), but the EOX tile host was **never added to the CSP `img-src` whitelist** in [`webapp/middleware/security.py`](webapp/middleware/security.py). So in production:

- Browser loads the page → CSP header arrives, only whitelists `*.tile.openstreetmap.org` for images
- User selects "Satellite (Sentinel-2)" → browser silently blocks every `https://tiles.maps.eox.at/...jpg` request → map stays gray
- Attribution still shows "Sentinel-2 cloudless 2024 by EOX" (CSS/text isn't blocked, only the `<img>` tiles)

User reported the gray map immediately after v1.4.2 went out.

## Why my verification missed it

I verified [#87](https://github.com/tubalainen/arma_reforger_base_map_generator_ng/pull/87) against a plain `python -m http.server` static preview, which serves no CSP. The actual FastAPI backend sets a strict CSP via `SecurityHeadersMiddleware`, and the OSM whitelist there hadn't been generalised when EOX was first introduced. Lesson noted: static-asset changes that hit a new origin need to be verified through the backend, not a static server.

## Change

Single-line edit to [`webapp/middleware/security.py`](webapp/middleware/security.py): add `https://tiles.maps.eox.at` to the existing `img-src` directive.

## Test plan
- [ ] After deploy, open the bbox-picker, confirm Sentinel-2 imagery shows by default and tiles load at every zoom (5–19)
- [ ] DevTools → Network: confirm `tiles.maps.eox.at/...jpg` returns 200 and renders, no `Refused to load the image ... violates ... Content Security Policy` console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)