### PR TITLE
v1.4.3: hotfix — whitelist EOX tile host in CSP so Sentinel-2 actually renders

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ The application is published to GitHub Container Registry and automatically buil
 docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:latest
 
 # Or use a specific version tag
-docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.4.2
+docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.4.3
 ```
 
 The `docker-compose.yml` is pre-configured to use the GHCR.io image. See the [Quick Start Guide](#quick-start-guide) for setup instructions.

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -47,7 +47,7 @@ configure_gdal_threading()
 # Application version (for cache busting)
 # ===========================================================================
 
-APP_VERSION = "1.4.2"  # Increment when static files change OR a new release ships
+APP_VERSION = "1.4.3"  # Increment when static files change OR a new release ships
 
 # ===========================================================================
 # FastAPI app


### PR DESCRIPTION
## Summary

Hotfix release for v1.4.2. Bumps `APP_VERSION` and the README docker-pull tag to **v1.4.3**.

[#87](https://github.com/tubalainen/arma_reforger_base_map_generator_ng/pull/87) (shipped in v1.4.2) made the Sentinel-2 base layer Leaflet-correct — `maxZoom: 19`, default layer, 2024 mosaic — but the **EOX tile host was never added to the CSP `img-src` whitelist** in [`webapp/middleware/security.py`](webapp/middleware/security.py). In production the browser silently blocks every `https://tiles.maps.eox.at/...jpg` request and the bbox-picker map renders gray.

[PR #90](https://github.com/tubalainen/arma_reforger_base_map_generator_ng/pull/90) added `https://tiles.maps.eox.at` to the `img-src` directive (one-line change).

### Why v1.4.2's verification missed this

I verified [#87](https://github.com/tubalainen/arma_reforger_base_map_generator_ng/pull/87) against a plain `python -m http.server` static preview, which serves no CSP. The strict CSP only kicks in when the page is served by FastAPI. Lesson noted: future static-asset changes that hit a new origin must be verified through the actual backend, not a static file server.

## Test plan
- [ ] After deploy, open the bbox-picker, confirm Sentinel-2 imagery shows by default and tiles load at every zoom (5–19)
- [ ] DevTools → Network: `tiles.maps.eox.at/...jpg` returns 200; no `Refused to load the image ... violates ... Content Security Policy` console errors
- [ ] Layer switcher still flips back to OpenStreetMap correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)