### PR TITLE
v1.4.4: dedup, simplify and de-spiral natural splines (#93, #88)

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ The application is published to GitHub Container Registry and automatically buil
 docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:latest
 
 # Or use a specific version tag
-docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.4.3
+docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.4.4
 ```
 
 The `docker-compose.yml` is pre-configured to use the GHCR.io image. See the [Quick Start Guide](#quick-start-guide) for setup instructions.

--- a/webapp/config/enfusion.py
+++ b/webapp/config/enfusion.py
@@ -262,6 +262,13 @@ MAX_SURFACES_PER_BLOCK = 5
 # exceeds this limit is simplified with Ramer-Douglas-Peucker before emission.
 MAX_SPLINE_POINTS = 200
 
+# Tighter cap for "natural" splines (forests, lakes, rivers, wetlands).
+# Atlas 2's manual workflow shows humans hand-clicking ~5–20 vertices for
+# typical features — over-detailed splines look unnatural and make the World
+# Editor sluggish.  Roads keep the looser MAX_SPLINE_POINTS because their
+# shapes are dictated by real-world geometry and tested at that cap.
+MAX_SPLINE_POINTS_NATURAL = 120
+
 # Recommended max externally-generated masks (leave room for manual refinement)
 RECOMMENDED_MAX_EXTERNAL_MASKS = 3
 

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -47,7 +47,7 @@ configure_gdal_threading()
 # Application version (for cache busting)
 # ===========================================================================
 
-APP_VERSION = "1.4.3"  # Increment when static files change OR a new release ships
+APP_VERSION = "1.4.4"  # Increment when static files change OR a new release ships
 
 # ===========================================================================
 # FastAPI app

--- a/webapp/services/enfusion_project_generator.py
+++ b/webapp/services/enfusion_project_generator.py
@@ -33,6 +33,7 @@ from config.enfusion import (
     PROJECT_NAME_ALLOWED_CHARS,
     PROJECT_NAME_MAX_LENGTH,
     MAX_SPLINE_POINTS,
+    MAX_SPLINE_POINTS_NATURAL,
     MANDATORY_BOOTSTRAP_KEYS,
     resolve_ambient_prefab,
     compute_height_scale,
@@ -41,6 +42,11 @@ from config.roads import validate_road_prefab, fully_qualified_road_prefab
 from config.forests import validate_forest_prefab, forest_type_from_osm
 from config.lakes import validate_lake_prefab
 from services.entity_naming import EntityNamer, expected_surface
+from services.spline_cleanup import (
+    normalize_polygons,
+    normalize_polylines,
+    adaptive_tolerance,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -667,8 +673,12 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['env_probe']} {{
                 continue
 
             # Cap spline length so long OSM ways don't hang the Workbench
-            # loader. Same MAX_SPLINE_POINTS budget the closed-spline path uses.
-            local_points = self._simplify_local_polyline(in_bounds)
+            # loader. Roads keep the looser MAX_SPLINE_POINTS budget because
+            # their geometry is dictated by real-world surveys (natural
+            # forest/lake/river splines use the tighter NATURAL cap — v1.4.4).
+            local_points = self._simplify_local_polyline(
+                in_bounds, max_pts=MAX_SPLINE_POINTS
+            )
 
             # First point is the entity origin
             origin = local_points[0]
@@ -782,8 +792,16 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['env_probe']} {{
             if "forest_type" not in props:
                 props["forest_type"] = forest_type_from_osm(props)
 
+        # v1.4.4 — collapse duplicate / overlapping forests via shapely
+        # unary_union BEFORE projection (issues #93, #88). Way+relation
+        # versions of the same wood merge; adjacent touching forests
+        # become one continuous spline.
+        cleaned_forests = self._normalized_polygon_collection(
+            self.forest_features, "forest"
+        )
+
         body = self._polygon_features_to_splines(
-            self.forest_features,
+            cleaned_forests,
             entity_prefix="ForestArea",
             empty_message="// No forest polygons found in this area.\n",
             child_prefab_fn=_forest_child,
@@ -819,8 +837,15 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['env_probe']} {{
             water_type = (feature.get("properties", {}) or {}).get("water_type", "")
             return validate_lake_prefab(water_type)  # None → spline-only fallback
 
+        # v1.4.4 — dedup/union lake polygons before projection (issues #93,
+        # #88). Coastlines + rivers pass through unchanged; polygon water
+        # features (lake / pond / reservoir / water) get merged.
+        cleaned_water = self._normalized_polygon_collection(
+            self.water_features, "lake"
+        )
+
         lake_body = self._polygon_features_to_splines(
-            self.water_features,
+            cleaned_water,
             entity_prefix="Water",
             filter_property="water_type",
             filter_values=("lake", "pond", "reservoir", "water"),
@@ -848,6 +873,13 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['env_probe']} {{
             if (f.get("properties", {}) or {}).get("water_type", "") in _RIVER_WIDTH_M
             and (f.get("geometry", {}) or {}).get("type") == "LineString"
         ]
+        if not river_features:
+            return ""
+
+        # v1.4.4 — drop hairpin (>150° near-reversal in <20 m) vertices on
+        # rivers BEFORE projection. This kills the spiral / loop artefact
+        # reported in #93 (e.g. the "crazy looped spline" screenshot).
+        river_features = normalize_polylines(river_features, "river")
         if not river_features:
             return ""
 
@@ -1422,6 +1454,24 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['env_probe']} {{
             return coords[0][0]
         return None
 
+    @staticmethod
+    def _normalized_polygon_collection(
+        features: Optional[dict],
+        kind: str,
+    ) -> Optional[dict]:
+        """
+        Run :func:`spline_cleanup.normalize_polygons` over a FeatureCollection,
+        returning a new FeatureCollection with the same shape.
+
+        Non-polygon members (e.g. river LineStrings inside the water feature
+        set) pass through unchanged. ``None`` / empty input is returned as-is
+        so callers can keep their existing empty-message handling.
+        """
+        if not features or not features.get("features"):
+            return features
+        cleaned = normalize_polygons(features["features"], kind)
+        return {"type": "FeatureCollection", "features": cleaned}
+
     def _polygon_features_to_splines(
         self,
         features: Optional[dict],
@@ -1525,7 +1575,7 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['env_probe']} {{
     @staticmethod
     def _simplify_local_ring(
         pts: list[dict],
-        max_pts: int = MAX_SPLINE_POINTS,
+        max_pts: int = MAX_SPLINE_POINTS_NATURAL,
     ) -> list[dict]:
         """
         Reduce a local-coordinate ring to at most *max_pts* points using
@@ -1534,8 +1584,13 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['env_probe']} {{
 
         *pts* is a list of {"x":…, "y":…, "z":…} dicts (local metres, no
         closing duplicate).  The returned list has the same dict structure.
+
+        v1.4.4 — simplification ALWAYS runs (previously bypassed for any ring
+        ≤200 pts, which left most OSM rings over-detailed at 50–200 vertices).
+        An :func:`adaptive_tolerance` scaled to the bbox diagonal is tried
+        first; ``preserve_topology=True`` rules out self-intersecting outputs.
         """
-        if len(pts) <= max_pts:
+        if len(pts) < 4:
             return pts
 
         def _rdp(points, tol):
@@ -1561,6 +1616,14 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['env_probe']} {{
                 return _rdp(points[:idx + 1], tol)[:-1] + _rdp(points[idx:], tol)
             return [points[0], points[-1]]
 
+        # Build an adaptive tolerance schedule that starts at the size-scaled
+        # value and escalates only as a safety net for pathological rings.
+        base_tol = adaptive_tolerance(pts)
+        tol_schedule = [base_tol]
+        for extra in (1.0, 2.0, 5.0, 10.0, 20.0, 50.0):
+            if extra > base_tol:
+                tol_schedule.append(extra)
+
         # Try shapely first for best quality, then pure-Python RDP, then decimation.
         try:
             from shapely.geometry import Polygon
@@ -1568,12 +1631,12 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['env_probe']} {{
             poly = Polygon(coords_2d)
             if not poly.is_valid:
                 poly = poly.buffer(0)
-            for tol in (0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 50.0):
+            for tol in tol_schedule:
                 s = poly.simplify(tol, preserve_topology=True)
-                if s.is_empty:
-                    break
+                if s.is_empty or not hasattr(s, "exterior") or s.exterior is None:
+                    continue
                 s_coords = list(s.exterior.coords)[:-1]  # drop closing dup
-                if len(s_coords) <= max_pts:
+                if 3 <= len(s_coords) <= max_pts:
                     result = []
                     for cx, cz in s_coords:
                         nearest = min(pts, key=lambda p, cx=cx, cz=cz: (p["x"] - cx) ** 2 + (p["z"] - cz) ** 2)
@@ -1583,12 +1646,12 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['env_probe']} {{
             pass
 
         # Pure-Python RDP with escalating tolerance
-        for tol in (2.0, 5.0, 10.0, 20.0, 50.0):
+        for tol in tol_schedule:
             closed = pts + [pts[0]]
             s = _rdp(closed, tol)
             if len(s) >= 2 and s[-1]["x"] == s[0]["x"] and s[-1]["z"] == s[0]["z"]:
                 s = s[:-1]
-            if len(s) <= max_pts:
+            if 3 <= len(s) <= max_pts:
                 return s
 
         # Last resort: uniform decimation
@@ -1598,7 +1661,7 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['env_probe']} {{
     @staticmethod
     def _simplify_local_polyline(
         pts: list[dict],
-        max_pts: int = MAX_SPLINE_POINTS,
+        max_pts: int = MAX_SPLINE_POINTS_NATURAL,
     ) -> list[dict]:
         """
         Reduce a local-coordinate open polyline to at most *max_pts* points
@@ -1608,8 +1671,13 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['env_probe']} {{
         Both endpoints are always preserved (unlike :py:meth:`_simplify_local_ring`,
         which closes the loop). *pts* is a list of {"x":…, "y":…, "z":…} dicts
         in local metres.
+
+        v1.4.4 — simplification ALWAYS runs (previously bypassed for any line
+        ≤200 pts). Tolerance is :func:`adaptive_tolerance` scaled to the bbox
+        diagonal; shapely simplify uses ``preserve_topology=True`` to avoid
+        the self-intersecting "spiral" output reported in #93.
         """
-        if len(pts) <= max_pts:
+        if len(pts) < 3:
             return pts
 
         def _rdp(points, tol):
@@ -1635,29 +1703,40 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['env_probe']} {{
                 return _rdp(points[:idx + 1], tol)[:-1] + _rdp(points[idx:], tol)
             return [points[0], points[-1]]
 
+        base_tol = adaptive_tolerance(pts)
+        tol_schedule = [base_tol]
+        for extra in (1.0, 2.0, 5.0, 10.0, 20.0):
+            if extra > base_tol:
+                tol_schedule.append(extra)
+
         # Try shapely first for best quality, then pure-Python RDP, then decimation.
         try:
             from shapely.geometry import LineString
             coords_2d = [(p["x"], p["z"]) for p in pts]
             line = LineString(coords_2d)
-            for tol in (0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 50.0):
-                s = line.simplify(tol, preserve_topology=False)
+            for tol in tol_schedule:
+                s = line.simplify(tol, preserve_topology=True)
                 if s.is_empty:
-                    break
+                    continue
                 s_coords = list(s.coords)
-                if len(s_coords) <= max_pts and len(s_coords) >= 2:
+                if 2 <= len(s_coords) <= max_pts:
                     result = []
                     for cx, cz in s_coords:
                         nearest = min(pts, key=lambda p, cx=cx, cz=cz: (p["x"] - cx) ** 2 + (p["z"] - cz) ** 2)
                         result.append({"x": cx, "y": nearest["y"], "z": cz})
+                    # Always preserve true endpoints (snap-to-nearest could
+                    # have drifted the first/last vertex slightly).
+                    if result:
+                        result[0] = {"x": pts[0]["x"], "y": pts[0]["y"], "z": pts[0]["z"]}
+                        result[-1] = {"x": pts[-1]["x"], "y": pts[-1]["y"], "z": pts[-1]["z"]}
                     return result
         except Exception:
             pass
 
         # Pure-Python RDP with escalating tolerance — open polyline, do not close.
-        for tol in (2.0, 5.0, 10.0, 20.0, 50.0):
+        for tol in tol_schedule:
             s = _rdp(pts, tol)
-            if len(s) <= max_pts:
+            if 2 <= len(s) <= max_pts:
                 return s
 
         # Last resort: uniform decimation, but always keep first + last.

--- a/webapp/services/spline_cleanup.py
+++ b/webapp/services/spline_cleanup.py
@@ -1,0 +1,337 @@
+"""
+Spline cleanup helpers — dedup, union, hairpin removal, adaptive simplify.
+
+This module runs **after OSM ingest** and **before** the geometry is projected
+to local XZ metres in :mod:`enfusion_project_generator`.  It exists to fix
+three classes of artefact seen in the Enfusion World Editor (issues #93, #88):
+
+1. **Full duplicates** — OSM tags the same feature both as a ``way`` and a
+   ``relation`` (e.g. ``natural=water`` + ``natural=water`` relation).  Our
+   Overpass queries fetch both, so the feature appears twice in the layer.
+2. **Partial duplicates** — adjacent same-type polygons (two touching forests,
+   a multipolygon's separate outer rings) each become independent splines that
+   overlap visually.
+3. **Spirals / loops** — open polylines (rivers) with tight hairpin bends, or
+   simplified rings, can collapse into self-intersecting curves.
+
+The fix is to (a) ``unary_union`` same-type polygons so overlapping geometry
+collapses into one, (b) drop near-reversal vertices on polylines before
+simplification, and (c) use an adaptive simplify tolerance that scales with
+feature size so small features keep detail and large ones get sparse.
+
+Coastlines are intentionally NOT processed — they must not be unioned with
+inland water and they should keep their original shape.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------------- #
+# Public API
+# --------------------------------------------------------------------------- #
+
+
+def normalize_polygons(
+    features: list[dict],
+    kind: str,
+    *,
+    min_area_m2: float = 100.0,
+) -> list[dict]:
+    """
+    Dedup + union same-type polygon features.
+
+    *features* is a list of GeoJSON-style Feature dicts (``{"type": "Feature",
+    "geometry": {...}, "properties": {...}}``) in WGS84 lon/lat.  Polygons and
+    MultiPolygons are unioned into a single shapely geometry; the result is
+    split back into individual Polygons (one Feature per Polygon).
+
+    Non-polygon features (e.g. LineStrings, coastlines) pass through unchanged.
+
+    *kind* is a human-readable label used in log lines only
+    (``"forest"`` / ``"lake"`` / ``"wetland"``).
+
+    Properties are carried forward from the **richest** intersecting input
+    feature — preferring named features, then largest area.  Tiny slivers
+    smaller than *min_area_m2* (computed in degrees² → approximate m² via the
+    feature's centroid latitude) are dropped to prevent noise splines after
+    union.
+    """
+    if not features:
+        return features
+
+    try:
+        from shapely.geometry import Polygon, MultiPolygon, shape, mapping
+        from shapely.ops import unary_union
+    except ImportError:
+        logger.warning(
+            "shapely unavailable — skipping polygon normalisation for %s", kind
+        )
+        return features
+
+    polygonal: list[tuple[dict, "Polygon"]] = []
+    passthrough: list[dict] = []
+
+    for feat in features:
+        geom_type = (feat.get("geometry") or {}).get("type", "")
+        if geom_type not in ("Polygon", "MultiPolygon"):
+            passthrough.append(feat)
+            continue
+        try:
+            geom = shape(feat["geometry"])
+        except Exception as exc:  # malformed geometry
+            logger.debug("dropping malformed %s feature: %s", kind, exc)
+            continue
+        if not geom.is_valid:
+            geom = geom.buffer(0)
+        if geom.is_empty:
+            continue
+        if isinstance(geom, MultiPolygon):
+            for sub in geom.geoms:
+                if not sub.is_empty:
+                    polygonal.append((feat, sub))
+        else:
+            polygonal.append((feat, geom))
+
+    if not polygonal:
+        return passthrough + features  # nothing polygonal to merge
+
+    union_geom = unary_union([g for _, g in polygonal])
+    if union_geom.is_empty:
+        return passthrough
+
+    if isinstance(union_geom, Polygon):
+        union_parts = [union_geom]
+    elif hasattr(union_geom, "geoms"):
+        union_parts = [g for g in union_geom.geoms if not g.is_empty]
+    else:
+        union_parts = []
+
+    # Approx degrees² → m² at the dataset centroid latitude (good enough for
+    # filtering slivers; we are not doing accurate area accounting).
+    try:
+        centroid_lat = union_geom.centroid.y
+    except Exception:
+        centroid_lat = 0.0
+    m_per_deg_lat = 111_320.0
+    m_per_deg_lon = 111_320.0 * max(math.cos(math.radians(centroid_lat)), 1e-6)
+    deg2_to_m2 = m_per_deg_lat * m_per_deg_lon
+    min_area_deg2 = min_area_m2 / deg2_to_m2 if deg2_to_m2 > 0 else 0.0
+
+    out: list[dict] = list(passthrough)
+    dropped_slivers = 0
+    for part in union_parts:
+        if part.area < min_area_deg2:
+            dropped_slivers += 1
+            continue
+        props = _best_props([(f, g) for f, g in polygonal if g.intersects(part)])
+        out.append(
+            {
+                "type": "Feature",
+                "geometry": mapping(part),
+                "properties": props,
+            }
+        )
+
+    n_in = len(features)
+    n_out_polys = len(out) - len(passthrough)
+    n_in_polys = len(polygonal)
+    merged = n_in_polys - n_out_polys
+    if merged > 0 or dropped_slivers > 0:
+        logger.info(
+            "spline_cleanup[%s]: %d in → %d out (merged %d, dropped %d slivers)",
+            kind,
+            n_in,
+            len(out),
+            merged,
+            dropped_slivers,
+        )
+    return out
+
+
+def normalize_polylines(
+    features: list[dict],
+    kind: str,
+) -> list[dict]:
+    """
+    Drop hairpin vertices on open polyline features (rivers, streams, canals).
+
+    A *hairpin* is an interior vertex where the bearing reverses by more than
+    150° AND the neighbouring vertices are within 20 m of each other — the
+    classic signature of a single bad OSM node or an over-simplified bend that
+    will render as a spiral loop in the World Editor.
+
+    Operates in WGS84 lon/lat by converting to local metres around each
+    candidate's latitude.  Iterates up to 5 times to catch chained hairpins.
+
+    Returns a NEW list of Feature dicts.  Features whose geometry collapses to
+    fewer than 2 points are dropped.
+    """
+    if not features:
+        return features
+
+    out: list[dict] = []
+    total_dropped = 0
+    for feat in features:
+        geom = feat.get("geometry") or {}
+        gtype = geom.get("type", "")
+        if gtype != "LineString":
+            out.append(feat)
+            continue
+        coords = geom.get("coordinates") or []
+        if len(coords) < 3:
+            out.append(feat)
+            continue
+        cleaned, dropped = _drop_hairpins_lonlat(coords)
+        total_dropped += dropped
+        if len(cleaned) < 2:
+            continue  # collapsed to nothing — skip
+        new_feat = dict(feat)
+        new_feat["geometry"] = {"type": "LineString", "coordinates": cleaned}
+        out.append(new_feat)
+
+    if total_dropped > 0:
+        logger.info(
+            "spline_cleanup[%s]: dropped %d hairpin vertices across %d polylines",
+            kind,
+            total_dropped,
+            len(features),
+        )
+    return out
+
+
+def adaptive_tolerance(pts: list[dict], *, lo: float = 1.0, hi: float = 5.0) -> float:
+    """
+    Pick a simplify tolerance in metres scaled to feature size.
+
+    *pts* is a list of ``{"x", "y", "z"}`` dicts in local metres (post
+    projection).  Returns 0.5 % of the bbox diagonal, clamped to ``[lo, hi]``.
+    Small features (~50 m) get ~1 m tolerance (keeps small bays / peninsulas);
+    large features (~2 km) get ~5 m (sparse like a hand-drawn outline).
+    """
+    if not pts:
+        return lo
+    xs = [p["x"] for p in pts]
+    zs = [p["z"] for p in pts]
+    diag = math.hypot(max(xs) - min(xs), max(zs) - min(zs))
+    return max(lo, min(hi, diag * 0.005))
+
+
+# --------------------------------------------------------------------------- #
+# Internal helpers
+# --------------------------------------------------------------------------- #
+
+
+def _best_props(candidates: list[tuple[dict, "object"]]) -> dict:
+    """
+    Pick the richest property dict from the input features whose geometry
+    contributed to a unioned part.  Preference order:
+        1. Has a non-empty ``name``
+        2. Largest source geometry area
+    Falls back to the first feature's properties if no other tiebreak.
+    """
+    if not candidates:
+        return {}
+
+    def _key(item):
+        feat, geom = item
+        props = feat.get("properties") or {}
+        named = bool((props.get("name") or "").strip())
+        area = getattr(geom, "area", 0.0) or 0.0
+        return (1 if named else 0, area)
+
+    best_feat, _ = max(candidates, key=_key)
+    return dict(best_feat.get("properties") or {})
+
+
+def _drop_hairpins_lonlat(
+    coords: list[list[float]],
+    *,
+    min_turn_deg: float = 150.0,
+    min_span_m: float = 20.0,
+    max_passes: int = 5,
+) -> tuple[list[list[float]], int]:
+    """
+    Iterative hairpin-vertex removal on a WGS84 ``[lon, lat]`` polyline.
+
+    Returns ``(cleaned_coords, num_dropped)``.
+    """
+    pts = list(coords)
+    total_dropped = 0
+    for _ in range(max_passes):
+        if len(pts) < 3:
+            break
+        keep = [True] * len(pts)
+        for i in range(1, len(pts) - 1):
+            if not keep[i]:
+                continue
+            a = pts[i - 1]
+            b = pts[i]
+            c = pts[i + 1]
+            turn = _turn_angle_deg(a, b, c)
+            if turn < min_turn_deg:
+                continue
+            if _haversine_m(a, c) > min_span_m:
+                continue
+            keep[i] = False
+        if all(keep):
+            break
+        dropped = keep.count(False)
+        total_dropped += dropped
+        pts = [p for p, k in zip(pts, keep) if k]
+    return pts, total_dropped
+
+
+def _turn_angle_deg(
+    a: list[float], b: list[float], c: list[float]
+) -> float:
+    """
+    Absolute interior turn angle in degrees at vertex ``b`` of the path
+    ``a → b → c``.  0° = straight, 180° = full reversal (hairpin).
+
+    Computed in a local metres frame around ``b`` to avoid lon-distortion at
+    high latitudes.
+    """
+    lat = b[1]
+    m_per_deg_lat = 111_320.0
+    m_per_deg_lon = 111_320.0 * max(math.cos(math.radians(lat)), 1e-6)
+
+    def to_xy(p):
+        return (
+            (p[0] - b[0]) * m_per_deg_lon,
+            (p[1] - b[1]) * m_per_deg_lat,
+        )
+
+    ax, ay = to_xy(a)
+    cx, cy = to_xy(c)
+    # Incoming bearing a→b (so vector from a to b is -a in local frame)
+    inc_dx, inc_dy = -ax, -ay
+    out_dx, out_dy = cx, cy
+    inc_len = math.hypot(inc_dx, inc_dy)
+    out_len = math.hypot(out_dx, out_dy)
+    if inc_len < 1e-9 or out_len < 1e-9:
+        return 0.0
+    cos_t = (inc_dx * out_dx + inc_dy * out_dy) / (inc_len * out_len)
+    cos_t = max(-1.0, min(1.0, cos_t))
+    # Turn angle = angle between the incoming (a→b) and outgoing (b→c) vectors.
+    # cos_t = 1  → vectors aligned → 0° turn (straight)
+    # cos_t = -1 → vectors opposite → 180° turn (hairpin / full reversal)
+    return math.degrees(math.acos(cos_t))
+
+
+def _haversine_m(a: list[float], b: list[float]) -> float:
+    """Great-circle distance between two ``[lon, lat]`` points in metres."""
+    lon1, lat1 = math.radians(a[0]), math.radians(a[1])
+    lon2, lat2 = math.radians(b[0]), math.radians(b[1])
+    dlon = lon2 - lon1
+    dlat = lat2 - lat1
+    h = (
+        math.sin(dlat / 2.0) ** 2
+        + math.cos(lat1) * math.cos(lat2) * math.sin(dlon / 2.0) ** 2
+    )
+    return 2.0 * 6_371_000.0 * math.asin(min(1.0, math.sqrt(h)))

--- a/webapp/tests/test_enfusion_roads_layer.py
+++ b/webapp/tests/test_enfusion_roads_layer.py
@@ -185,7 +185,19 @@ class TestRoadsLayerVertexCap:
         assert sp_count >= 2
 
     def test_short_road_passes_through_unchanged(self, make_generator):
-        gen = make_generator([_road(0, "RG_Road_Asphalt_E_01")])
+        # v1.4.4 — simplification now ALWAYS runs (previously gated on
+        # len > MAX_SPLINE_POINTS), so collinear points get collapsed.
+        # The default fixture has 3 collinear points → use a road with a
+        # genuine corner to confirm meaningful geometry survives.
+        road = _road(0, "RG_Road_Asphalt_E_01")
+        road["spline_points"] = [
+            {"x": 1.0, "y": 1.0, "z": 0},
+            {"x": 2.0, "y": 1.0, "z": 0},  # corner — 90° turn
+            {"x": 2.0, "y": 2.0, "z": 0},
+        ]
+        road["point_count"] = 3
+        gen = make_generator([road])
         out = gen._generate_roads_layer()
-        # Fixture has 3 points, well under the cap.
+        # All 3 points survive because the middle vertex is a true corner,
+        # not a collinear filler. Confirms simplification doesn't over-cull.
         assert out.count("ShapePoint sp_") == 3

--- a/webapp/tests/test_enfusion_vegetation_water_layers.py
+++ b/webapp/tests/test_enfusion_vegetation_water_layers.py
@@ -229,3 +229,56 @@ class TestWaterLayer:
         assert "// Water layer" in out
         assert "// No standing-water polygons" in out
         assert "SplineShapeEntity" not in out
+
+
+# ---------------------------------------------------------------------------
+# Dedup / cleanup integration (issues #93, #88 — v1.4.4)
+# ---------------------------------------------------------------------------
+
+class TestSplineCleanupIntegration:
+    """
+    End-to-end: confirm that duplicate / overlapping inputs collapse to a
+    single spline entity once they pass through the new normalize_polygons
+    step in the vegetation and water layers.
+    """
+
+    pytest.importorskip("shapely")
+
+    def test_duplicate_forests_collapse_to_one_spline(self, generator_factory):
+        # Same square submitted twice (e.g. OSM way + relation duplicate).
+        ring = [[0.5, 0.5], [1.5, 0.5], [1.5, 1.5], [0.5, 1.5], [0.5, 0.5]]
+        gen = generator_factory(forest_features={
+            "type": "FeatureCollection",
+            "features": [
+                _polygon_feature([ring], type="forest"),
+                _polygon_feature([ring], type="forest"),
+            ],
+        })
+        out = gen._generate_vegetation_layer()
+        # Despite 2 input features, only 1 spline survives.
+        assert out.count("SplineShapeEntity Forest_") == 1
+
+    def test_touching_forests_merge_into_one_spline(self, generator_factory):
+        a = [[0.5, 0.5], [1.5, 0.5], [1.5, 1.5], [0.5, 1.5], [0.5, 0.5]]
+        b = [[1.5, 0.5], [2.5, 0.5], [2.5, 1.5], [1.5, 1.5], [1.5, 0.5]]
+        gen = generator_factory(forest_features={
+            "type": "FeatureCollection",
+            "features": [
+                _polygon_feature([a], type="forest"),
+                _polygon_feature([b], type="forest"),
+            ],
+        })
+        out = gen._generate_vegetation_layer()
+        assert out.count("SplineShapeEntity Forest_") == 1
+
+    def test_duplicate_lakes_collapse_to_one_spline(self, generator_factory):
+        ring = [[0.5, 0.5], [1.5, 0.5], [1.5, 1.5], [0.5, 1.5], [0.5, 0.5]]
+        gen = generator_factory(water_features={
+            "type": "FeatureCollection",
+            "features": [
+                _polygon_feature([ring], water_type="lake"),
+                _polygon_feature([ring], water_type="lake"),
+            ],
+        })
+        out = gen._generate_water_layer()
+        assert out.count("SplineShapeEntity Lake_") == 1

--- a/webapp/tests/test_spline_cleanup.py
+++ b/webapp/tests/test_spline_cleanup.py
@@ -1,0 +1,302 @@
+"""
+Tests for :mod:`services.spline_cleanup` — the dedup / union / hairpin /
+adaptive-tolerance helpers added in v1.4.4 to fix issues #93 and #88
+(duplicate, over-detailed, and spiralling splines in the World Editor).
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+WEBAPP_DIR = Path(__file__).parent.parent
+if str(WEBAPP_DIR) not in sys.path:
+    sys.path.insert(0, str(WEBAPP_DIR))
+
+shapely = pytest.importorskip("shapely")  # noqa: F841 — cleanup needs shapely
+
+from services.spline_cleanup import (  # noqa: E402
+    adaptive_tolerance,
+    normalize_polygons,
+    normalize_polylines,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _square(cx: float, cy: float, half: float) -> list[list[list[float]]]:
+    """Return a closed-ring Polygon coordinate set centred at ``(cx, cy)``."""
+    return [
+        [
+            [cx - half, cy - half],
+            [cx + half, cy - half],
+            [cx + half, cy + half],
+            [cx - half, cy + half],
+            [cx - half, cy - half],
+        ]
+    ]
+
+
+def _poly(coords, **props) -> dict:
+    return {
+        "type": "Feature",
+        "geometry": {"type": "Polygon", "coordinates": coords},
+        "properties": props,
+    }
+
+
+def _line(coords, **props) -> dict:
+    return {
+        "type": "Feature",
+        "geometry": {"type": "LineString", "coordinates": coords},
+        "properties": props,
+    }
+
+
+def _xz(*pairs):
+    """Build a list of {x,y,z} dicts from ``(x, z)`` pairs (y defaults to 0)."""
+    return [{"x": float(x), "y": 0.0, "z": float(z)} for x, z in pairs]
+
+
+# --------------------------------------------------------------------------- #
+# normalize_polygons
+# --------------------------------------------------------------------------- #
+
+
+class TestNormalizePolygons:
+    def test_two_identical_forests_collapse_to_one(self):
+        # Same 1×1 deg square submitted twice (e.g. way + relation).
+        feats = [_poly(_square(0.5, 0.5, 0.4)), _poly(_square(0.5, 0.5, 0.4))]
+        out = normalize_polygons(feats, "forest")
+        assert len(out) == 1
+        assert out[0]["geometry"]["type"] == "Polygon"
+
+    def test_way_plus_relation_lake_dedups(self):
+        # Same lake mapped as both a way (named) and a relation (anonymous):
+        # the named feature's name must survive — preferred by _best_props.
+        named = _poly(_square(0.5, 0.5, 0.4), name="Lake Vänern", water_type="lake")
+        anon = _poly(_square(0.5, 0.5, 0.4), water_type="lake")
+        out = normalize_polygons([named, anon], "lake")
+        assert len(out) == 1
+        assert out[0]["properties"].get("name") == "Lake Vänern"
+
+    def test_touching_forests_merge_into_one(self):
+        # Two squares sharing the edge x=1.0 between (0,0)–(1,1) and (1,0)–(2,1).
+        a = _poly([[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]])
+        b = _poly([[[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]])
+        out = normalize_polygons([a, b], "forest")
+        assert len(out) == 1
+        # The merged outline must span x=[0,2]
+        coords = out[0]["geometry"]["coordinates"][0]
+        xs = [c[0] for c in coords]
+        assert min(xs) == 0 and max(xs) == 2
+
+    def test_disjoint_forests_stay_separate(self):
+        a = _poly(_square(0.5, 0.5, 0.4))
+        b = _poly(_square(5.0, 5.0, 0.4))  # far away
+        out = normalize_polygons([a, b], "forest")
+        assert len(out) == 2
+
+    def test_linestrings_pass_through_untouched(self):
+        # Coastlines / rivers etc. mixed into a water FeatureCollection must
+        # not be unioned with polygon water.
+        coast = _line([[0, 0], [1, 0], [2, 0]], water_type="coastline")
+        lake = _poly(_square(0.5, 0.5, 0.4), water_type="lake")
+        out = normalize_polygons([coast, lake], "lake")
+        assert len(out) == 2
+        types = {f["geometry"]["type"] for f in out}
+        assert types == {"LineString", "Polygon"}
+
+    def test_named_property_wins_over_unnamed(self):
+        # Two overlapping (not identical) polygons: the one with a name
+        # should contribute its name even if it's the smaller piece.
+        small_named = _poly(_square(0.5, 0.5, 0.3), name="Tiny Pond")
+        large_anon = _poly(_square(0.5, 0.5, 0.5))
+        out = normalize_polygons([small_named, large_anon], "lake")
+        assert len(out) == 1
+        assert out[0]["properties"].get("name") == "Tiny Pond"
+
+    def test_tiny_sliver_below_min_area_is_dropped(self):
+        # 1m × 1m square in lon/lat ~= 1.1e-5 deg per side.
+        # min_area_m2 default is 100 → 1 m² sliver gets dropped.
+        sliver = _poly(_square(0.0, 0.0, 5e-6))  # ~0.5 m half-edge
+        out = normalize_polygons([sliver], "forest")
+        assert out == []
+
+    def test_empty_input_returns_empty(self):
+        assert normalize_polygons([], "forest") == []
+
+    def test_invalid_geometry_repaired_via_buffer0(self):
+        # Bowtie / self-intersecting polygon — buffer(0) should fix it
+        # rather than raise.
+        bowtie = _poly([[[0, 0], [2, 2], [0, 2], [2, 0], [0, 0]]])
+        out = normalize_polygons([bowtie], "forest")
+        # Either 1 repaired polygon or 2 triangles — both are valid outcomes.
+        assert len(out) >= 1
+        for f in out:
+            assert f["geometry"]["type"] == "Polygon"
+
+
+# --------------------------------------------------------------------------- #
+# normalize_polylines (hairpin detection)
+# --------------------------------------------------------------------------- #
+
+
+class TestNormalizePolylines:
+    def test_hairpin_vertex_is_dropped(self):
+        # A→B→A' where A' is 5 m east of A creates a near-180° reversal.
+        # Use small lon offsets at lat=0 (1° lon ≈ 111.3 km).
+        ten_m = 10.0 / 111_320.0
+        five_m = 5.0 / 111_320.0
+        coords = [
+            [0.0, 0.0],
+            [ten_m, 0.0],        # B
+            [five_m, 0.0],       # A' — back-track, 5 m from start
+            [2 * ten_m, 0.0],    # continuation
+        ]
+        out = normalize_polylines([_line(coords)], "river")
+        assert len(out) == 1
+        new_coords = out[0]["geometry"]["coordinates"]
+        # The hairpin middle vertex (B) must be dropped.
+        # Exact check: middle vertex at ten_m should no longer be present.
+        xs = [c[0] for c in new_coords]
+        assert ten_m not in xs
+
+    def test_smooth_meander_keeps_all_vertices(self):
+        # 20 vertices forming a wide sinusoidal meander: each turn is small
+        # (<<150°) so no vertex should be considered a hairpin.
+        coords = []
+        for i in range(20):
+            lon = i * 0.0005          # ~55 m spacing
+            lat = math.sin(i / 3.0) * 0.0002
+            coords.append([lon, lat])
+        out = normalize_polylines([_line(coords)], "river")
+        assert len(out) == 1
+        assert len(out[0]["geometry"]["coordinates"]) == 20
+
+    def test_straight_line_keeps_all_vertices(self):
+        coords = [[i * 0.001, 0.0] for i in range(10)]
+        out = normalize_polylines([_line(coords)], "river")
+        assert len(out[0]["geometry"]["coordinates"]) == 10
+
+    def test_polygon_features_pass_through_untouched(self):
+        poly = _poly(_square(0.5, 0.5, 0.4))
+        out = normalize_polylines([poly], "river")
+        assert out == [poly]
+
+    def test_short_polyline_passes_through(self):
+        # 2 points cannot have an interior vertex → unchanged.
+        out = normalize_polylines([_line([[0, 0], [1, 1]])], "river")
+        assert out[0]["geometry"]["coordinates"] == [[0, 0], [1, 1]]
+
+    def test_collapsed_polyline_is_dropped(self):
+        # Three points where every interior is a hairpin: result < 2 pts → drop.
+        d = 5.0 / 111_320.0  # 5 m
+        coords = [[0, 0], [d, 0], [0, 0]]
+        out = normalize_polylines([_line(coords)], "river")
+        # Hairpin removal yields [0,0]→[0,0] (a single point pair) which is
+        # still ≥2 — so the feature is allowed through but degenerate. Either
+        # behaviour is acceptable; pin the exact one we ship.
+        assert len(out) <= 1
+
+
+# --------------------------------------------------------------------------- #
+# adaptive_tolerance
+# --------------------------------------------------------------------------- #
+
+
+class TestAdaptiveTolerance:
+    def test_small_feature_uses_floor(self):
+        pts = _xz((0, 0), (50, 0), (50, 50), (0, 50))  # ~71 m diagonal
+        # 71 * 0.005 = 0.35 m → clamped to floor (1.0 m)
+        assert adaptive_tolerance(pts) == pytest.approx(1.0)
+
+    def test_large_feature_uses_ceiling(self):
+        pts = _xz((0, 0), (3000, 0), (3000, 3000), (0, 3000))  # ~4.2 km diag
+        # 4243 * 0.005 = 21 m → clamped to ceiling (5.0 m)
+        assert adaptive_tolerance(pts) == pytest.approx(5.0)
+
+    def test_medium_feature_in_range(self):
+        # 600 m diagonal → 0.005 × 600 = 3.0 m, between floor and ceiling
+        pts = _xz((0, 0), (600, 0))
+        # Adjust to actually be 600 m diagonal:
+        pts = _xz((0, 0), (424, 0), (424, 424), (0, 424))  # 600 m diag
+        tol = adaptive_tolerance(pts)
+        assert 1.0 < tol < 5.0
+
+    def test_empty_returns_floor(self):
+        assert adaptive_tolerance([]) == pytest.approx(1.0)
+
+    def test_custom_bounds_respected(self):
+        pts = _xz((0, 0), (1000, 0), (1000, 1000), (0, 1000))
+        tol = adaptive_tolerance(pts, lo=2.0, hi=3.0)
+        assert 2.0 <= tol <= 3.0
+
+
+# --------------------------------------------------------------------------- #
+# Integration: end-to-end "no spirals, no excess points"
+# --------------------------------------------------------------------------- #
+
+
+class TestSimplifyIntegration:
+    """
+    Round-trip a dense forest ring through ``_simplify_local_ring`` and assert
+    (a) point count drops well below 200 and (b) the result is topologically
+    simple (no self-intersections — the "spiral" symptom from #93).
+    """
+
+    def test_dense_ring_simplifies_and_stays_simple(self):
+        from services.enfusion_project_generator import EnfusionProjectGenerator
+        from shapely.geometry import Polygon
+
+        # 500 points sampled around a 2 km × 2 km square (perimeter, not
+        # circle, so there's plenty of redundant collinear detail).
+        pts = []
+        for i in range(125):
+            pts.append({"x": i * 16.0, "y": 0.0, "z": 0.0})
+        for i in range(125):
+            pts.append({"x": 2000.0, "y": 0.0, "z": i * 16.0})
+        for i in range(125):
+            pts.append({"x": 2000.0 - i * 16.0, "y": 0.0, "z": 2000.0})
+        for i in range(125):
+            pts.append({"x": 0.0, "y": 0.0, "z": 2000.0 - i * 16.0})
+        assert len(pts) == 500
+
+        simplified = EnfusionProjectGenerator._simplify_local_ring(pts)
+        assert len(simplified) <= 60, f"got {len(simplified)} pts; expected ≤60"
+        assert len(simplified) >= 4
+
+        # Topology: the closed ring must be simple (no self-intersection).
+        ring_coords = [(p["x"], p["z"]) for p in simplified]
+        ring_coords.append(ring_coords[0])
+        assert Polygon(ring_coords).is_simple
+
+    def test_dense_polyline_simplifies_and_stays_simple(self):
+        from services.enfusion_project_generator import EnfusionProjectGenerator
+        from shapely.geometry import LineString
+
+        # 400-point gentle S-curve along x with small z wobble.
+        pts = []
+        for i in range(400):
+            pts.append(
+                {
+                    "x": float(i) * 5.0,
+                    "y": 0.0,
+                    "z": math.sin(i / 20.0) * 30.0,
+                }
+            )
+        simplified = EnfusionProjectGenerator._simplify_local_polyline(pts)
+        assert len(simplified) <= 120
+        assert len(simplified) >= 2
+        # Endpoints must be preserved verbatim.
+        assert simplified[0]["x"] == pts[0]["x"] and simplified[0]["z"] == pts[0]["z"]
+        assert simplified[-1]["x"] == pts[-1]["x"] and simplified[-1]["z"] == pts[-1]["z"]
+        # No self-intersection
+        line = LineString([(p["x"], p["z"]) for p in simplified])
+        assert line.is_simple


### PR DESCRIPTION
## Summary

- New `services/spline_cleanup.py` runs after OSM ingest: `unary_union` collapses duplicate / overlapping same-type polygons (fixes #88 and the partial-duplicate variant of #93), and a hairpin filter (>150° near-reversal in <20 m) strips the worst spiral-producing river vertices before projection.
- `_simplify_local_ring` / `_simplify_local_polyline` always run now (previously bypassed under the 200-point cap), use an **adaptive tolerance** scaled to bbox diagonal (1–5 m clamp), and use `preserve_topology=True` for both rings and lines — kills the self-intersecting "spiral" output reported in #93.
- New `MAX_SPLINE_POINTS_NATURAL = 120` for forests / lakes / rivers; roads still use `MAX_SPLINE_POINTS = 200` so the existing road tests pin a stable budget.

## Issues addressed

- Closes #88 — duplicated water-feature splines
- Closes #93 — strange splines, too many spline points, partial-coverage duplicates, spiral / loop artefacts

## Test plan

- [x] `pytest tests/test_spline_cleanup.py` — 22 new tests (dedup, union, hairpin, meanders, adaptive tolerance, topology after simplify on a dense ring + polyline)
- [x] `pytest tests/test_enfusion_vegetation_water_layers.py` — existing tests + 3 new integration tests confirming way+relation duplicates and touching forests collapse to one spline
- [x] `pytest tests/test_enfusion_roads_layer.py` — roads still pinned at the 200-point cap; the "short road" test now uses a real corner instead of collinear filler since simplification is no longer bypassed
- [x] Full suite: 330 passed, 6 pre-existing `pyproj`-env failures unrelated to this change
- [ ] **Manual end-to-end** — generate a terrain that previously exhibited the artefacts, open the resulting `.layer` files in the Reforger World Editor, and compare against the screenshots in #93 / #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)