### PR TITLE
v1.4.5: labels & borders overlay over Sentinel-2 satellite basemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ The application is published to GitHub Container Registry and automatically buil
 docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:latest
 
 # Or use a specific version tag
-docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.4.4
+docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.4.5
 ```
 
 The `docker-compose.yml` is pre-configured to use the GHCR.io image. See the [Quick Start Guide](#quick-start-guide) for setup instructions.

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -47,7 +47,7 @@ configure_gdal_threading()
 # Application version (for cache busting)
 # ===========================================================================
 
-APP_VERSION = "1.4.4"  # Increment when static files change OR a new release ships
+APP_VERSION = "1.4.5"  # Increment when static files change OR a new release ships
 
 # ===========================================================================
 # FastAPI app

--- a/webapp/static/js/app.js
+++ b/webapp/static/js/app.js
@@ -34,14 +34,40 @@ const satelliteLayer = L.tileLayer(
     maxNativeZoom: 18,
 });
 
+// Transparent labels + drawn admin borders overlay (Esri Reference). This is
+// the purpose-built companion to Esri's World Imagery — it ships place names
+// AND actual country/state border lines in a single tile, so users can orient
+// themselves over Sentinel-2 imagery. CARTO's voyager_only_labels was tried
+// first but turned out to be labels-only with no drawn lines.
+const labelsLayer = L.tileLayer(
+    'https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}', {
+    attribution: 'Boundaries &copy; <a href="https://www.esri.com/">Esri</a>',
+    maxZoom: 19,
+    maxNativeZoom: 16,
+});
+
 // Default to satellite — most users are picking a real-world area to map.
 satelliteLayer.addTo(map);
+labelsLayer.addTo(map);
 
 // Layer control
 L.control.layers({
     'Satellite (Sentinel-2)': satelliteLayer,
     'OpenStreetMap': osmLayer,
-}, null, { position: 'topright' }).addTo(map);
+}, {
+    'Labels & borders': labelsLayer,
+}, { position: 'topright' }).addTo(map);
+
+// Auto-hide labels on OSM (already has its own); auto-show on Satellite.
+// Manual toggles via the overlay checkbox still work — this only fires on
+// basemap switches.
+map.on('baselayerchange', (e) => {
+    if (e.layer === satelliteLayer && !map.hasLayer(labelsLayer)) {
+        labelsLayer.addTo(map);
+    } else if (e.layer === osmLayer && map.hasLayer(labelsLayer)) {
+        map.removeLayer(labelsLayer);
+    }
+});
 
 // ===========================================================================
 // Area drawing


### PR DESCRIPTION
## Summary

- Sentinel-2 cloudless is pure imagery — adding the Esri `World_Boundaries_and_Places` reference tileset on top so country/state borders + place labels overlay the satellite view.
- Auto-toggles: visible on Satellite basemap, hidden on OSM (which already has its own labels). Manual override via the new "Labels & borders" overlay checkbox in the layer control.
- No CSP change needed — `server.arcgisonline.com` was already whitelisted from earlier work.

Follow-up to #2.

## Why Esri Reference (not CARTO labels)

CARTO `voyager_only_labels` was tried first but turned out to be labels-only with no drawn borders — just floating country names. Esri's `Reference/World_Boundaries_and_Places` is the purpose-built companion to Esri's World Imagery: place labels **plus** actual drawn admin lines, single tile, worldwide, free, no API key.

## Test plan

- [x] Verified via uvicorn shim with the real `SecurityHeadersMiddleware` (not `python -m http.server` — that was the v1.4.3 CSP regression lesson)
- [x] Zero CSP violations; all Esri tiles return 200
- [x] Screenshot at z3 over Europe + North Africa shows drawn borders between France/Germany/Italy, Spain/Portugal, Poland/Ukraine/Belarus, Greece/Turkey, Algeria/Libya/Egypt
- [x] Auto-toggle: switching basemap Satellite→OSM removes Esri tiles (0); switching back adds them (6)
- [x] Manual overlay checkbox still works independently while on Satellite
- [ ] After merge: tag `v1.4.5`, verify GHCR image builds, confirm in prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)