### PR TITLE
v1.4.6: buildings as point prefab instances with rotation (closes #85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Instead of manually sourcing elevation data, painting surface masks by hand, pla
 - **GeoJSON export** with structured metadata
 
 ### Building & Vegetation Data
-- **Building footprints** with height estimation and rotation
+- **Building footprints** mapped to real `Building_*.et` prefab instances (rotation-aligned to OSM longest-wall) — one positioned entity per OSM building, not a spline outline
 - **Forest areas** with species classification (coniferous/deciduous/mixed)
 - **Sweden**: Lantmäteriet Marktäcke OGC API for landcover and wetlands
 - **Auto-emitted closed splines** in `*_vegetation.layer` — one per forest polygon, ready to drop a Forest Generator prefab onto
@@ -265,6 +265,7 @@ The generated ZIP package is organized into an Enfusion-ready project structure:
 | `*_roads.layer` | Enfusion layer | Road spline entities (one `SplineShapeEntity` per road segment) |
 | `*_vegetation.layer` | Enfusion layer | One closed `SplineShapeEntity` per forest polygon — drag a Forest Generator (`FG_*`) prefab onto each |
 | `*_water.layer` | Enfusion layer | One closed `SplineShapeEntity` per lake/pond/reservoir — drag a Lake Generator (`LG_*`) prefab onto each |
+| `*_buildings.layer` | Enfusion layer | One positioned `Building_*.et` prefab instance per OSM building (rotation-aligned to longest wall) — no spline wiring needed |
 | `*.conf` | Enfusion config | Mission configuration |
 | `*.meta` | Enfusion metadata | Resource metadata for each asset |
 | `SETUP_GUIDE.md` | Markdown | Personalized step-by-step Workbench import guide |
@@ -433,7 +434,7 @@ The application is published to GitHub Container Registry and automatically buil
 docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:latest
 
 # Or use a specific version tag
-docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.4.5
+docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.4.6
 ```
 
 The `docker-compose.yml` is pre-configured to use the GHCR.io image. See the [Quick Start Guide](#quick-start-guide) for setup instructions.

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -47,7 +47,7 @@ configure_gdal_threading()
 # Application version (for cache busting)
 # ===========================================================================
 
-APP_VERSION = "1.4.5"  # Increment when static files change OR a new release ships
+APP_VERSION = "1.4.6"  # Increment when static files change OR a new release ships
 
 # ===========================================================================
 # FastAPI app

--- a/webapp/services/enfusion_project_generator.py
+++ b/webapp/services/enfusion_project_generator.py
@@ -1000,13 +1000,15 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['env_probe']} {{
         Z-fighting and block traffic.
         """
         header = (
-            "// Buildings layer — one entity per extracted OSM building.\n"
-            "// Buildings with a verified Enfusion prefab in\n"
+            "// Buildings layer — one positioned prefab instance per OSM building.\n"
+            "// Each entity references a verified Building_*.et from\n"
             "//   config/buildings.py::KNOWN_BUILDING_PREFABS\n"
-            "// are emitted as auto-positioned prefab instances. Buildings\n"
-            "// whose category has no verified prefab are emitted as closed\n"
-            "// footprint splines — drag a Building_*.et prefab from\n"
-            "// Prefabs/Structures/ onto each spline to wire it up.\n"
+            "// and is rotated by `angles 0 <yaw> 0` to align the building's\n"
+            "// longest wall with the OSM footprint orientation. Buildings\n"
+            "// with an uncatalogued category are logged and skipped (the\n"
+            "// previous spline-footprint fallback was removed in v1.4.6\n"
+            "// because nested-child syntax inside SplineShapeEntity has\n"
+            "// hung Workbench at 4% on world load — see issue #85).\n"
             "// Buildings overlapping asphalt roads are dropped (L12).\n"
             "// Source data: Reference/osm_buildings.geojson and features.json.\n"
         )
@@ -1079,44 +1081,38 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['env_probe']} {{
 
             if prefab_path:
                 prefab_ref = f"${{{ARMA_REFORGER_GUID}}}{prefab_path}"
+                rotation_deg = float(building.get("rotation_deg", 0.0) or 0.0)
+                body_lines = [
+                    f' coords {origin["x"]:.3f} {origin["y"]:.3f} {origin["z"]:.3f}',
+                ]
+                # `angles 0 <yaw> 0` form verified against shipped community
+                # building layers (DarcMods town01.layer, Overthrow, Coalition).
+                # Skip the line for cardinal-aligned buildings to match the
+                # convention in those files — keeps the output diff-friendly.
+                if abs(rotation_deg) > 0.05:
+                    body_lines.append(f' angles 0 {rotation_deg:.2f} 0')
                 entities.append(
                     f'{prefab_ref} {{{comment}\n'
-                    f' coords {origin["x"]:.3f} {origin["y"]:.3f} {origin["z"]:.3f}\n'
-                    f'}}'
+                    + '\n'.join(body_lines)
+                    + '\n}'
                 )
                 prefab_count += 1
             else:
-                # Footprint marker: emit the exterior ring as a closed spline
-                # the user can right-click → Add Child Entity → BuildingEntity.
-                geom = building.get("geometry") or {}
-                ring = self._building_exterior_ring(geom)
-                if ring is None:
-                    # Fall back to a tiny spline at the centroid so the
-                    # building still appears in the editor hierarchy.
-                    ring = [
-                        [lon - 0.00001, lat - 0.00001],
-                        [lon + 0.00001, lat - 0.00001],
-                        [lon + 0.00001, lat + 0.00001],
-                        [lon - 0.00001, lat + 0.00001],
-                        [lon - 0.00001, lat - 0.00001],
-                    ]
-                # The ring writer normally suffixes its prefix with `_<index>`.
-                # We pass our pre-allocated descriptive name as the prefix and
-                # then rewrite the `_0` suffix it adds back to the literal
-                # name. naming_kind is None here because we already allocated.
-                entity = self._closed_spline_entity_from_ring(
-                    ring, entity_name, 0, comment_suffix=comment,
+                # Should be unreachable: every category extractor produces has
+                # a KNOWN_BUILDING_PREFABS entry, and Building_Generic catches
+                # building=yes. If this fires, the catalog and extractor have
+                # diverged — fix config/buildings.py rather than emit a
+                # SplineShapeEntity. Nested-child syntax inside one caused
+                # Workbench to hang at 4% on world load in v1.1.0 (reverted
+                # in v1.2.3) so we never re-arm that footgun.
+                logger.warning(
+                    f"Building category {building.get('prefab_category')!r} "
+                    f"has no entry in KNOWN_BUILDING_PREFABS — skipping "
+                    f"osm_id={building.get('osm_id')}. Add the category to "
+                    f"config/buildings.py to fix."
                 )
-                if entity is None:
-                    skipped_out_of_bounds += 1
-                    continue
-                entity = entity.replace(
-                    f"SplineShapeEntity {entity_name}_0 ",
-                    f"SplineShapeEntity {entity_name} ",
-                    1,
-                )
-                entities.append(entity)
                 marker_count += 1
+                continue
 
         if skipped_road_overlap:
             logger.info(
@@ -1240,13 +1236,15 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['env_probe']} {{
         Z-fighting and block traffic.
         """
         header = (
-            "// Buildings layer — one entity per extracted OSM building.\n"
-            "// Buildings with a verified Enfusion prefab in\n"
+            "// Buildings layer — one positioned prefab instance per OSM building.\n"
+            "// Each entity references a verified Building_*.et from\n"
             "//   config/buildings.py::KNOWN_BUILDING_PREFABS\n"
-            "// are emitted as auto-positioned prefab instances. Buildings\n"
-            "// whose category has no verified prefab are emitted as closed\n"
-            "// footprint splines — drag a Building_*.et prefab from\n"
-            "// Prefabs/Structures/ onto each spline to wire it up.\n"
+            "// and is rotated by `angles 0 <yaw> 0` to align the building's\n"
+            "// longest wall with the OSM footprint orientation. Buildings\n"
+            "// with an uncatalogued category are logged and skipped (the\n"
+            "// previous spline-footprint fallback was removed in v1.4.6\n"
+            "// because nested-child syntax inside SplineShapeEntity has\n"
+            "// hung Workbench at 4% on world load — see issue #85).\n"
             "// Buildings overlapping asphalt roads are dropped (L12).\n"
             "// Source data: Reference/osm_buildings.geojson and features.json.\n"
         )
@@ -1319,44 +1317,38 @@ ${{58D0FB3206B6F859}}{WORLD_PREFABS['env_probe']} {{
 
             if prefab_path:
                 prefab_ref = f"${{{ARMA_REFORGER_GUID}}}{prefab_path}"
+                rotation_deg = float(building.get("rotation_deg", 0.0) or 0.0)
+                body_lines = [
+                    f' coords {origin["x"]:.3f} {origin["y"]:.3f} {origin["z"]:.3f}',
+                ]
+                # `angles 0 <yaw> 0` form verified against shipped community
+                # building layers (DarcMods town01.layer, Overthrow, Coalition).
+                # Skip the line for cardinal-aligned buildings to match the
+                # convention in those files — keeps the output diff-friendly.
+                if abs(rotation_deg) > 0.05:
+                    body_lines.append(f' angles 0 {rotation_deg:.2f} 0')
                 entities.append(
                     f'{prefab_ref} {{{comment}\n'
-                    f' coords {origin["x"]:.3f} {origin["y"]:.3f} {origin["z"]:.3f}\n'
-                    f'}}'
+                    + '\n'.join(body_lines)
+                    + '\n}'
                 )
                 prefab_count += 1
             else:
-                # Footprint marker: emit the exterior ring as a closed spline
-                # the user can right-click → Add Child Entity → BuildingEntity.
-                geom = building.get("geometry") or {}
-                ring = self._building_exterior_ring(geom)
-                if ring is None:
-                    # Fall back to a tiny spline at the centroid so the
-                    # building still appears in the editor hierarchy.
-                    ring = [
-                        [lon - 0.00001, lat - 0.00001],
-                        [lon + 0.00001, lat - 0.00001],
-                        [lon + 0.00001, lat + 0.00001],
-                        [lon - 0.00001, lat + 0.00001],
-                        [lon - 0.00001, lat - 0.00001],
-                    ]
-                # The ring writer normally suffixes its prefix with `_<index>`.
-                # We pass our pre-allocated descriptive name as the prefix and
-                # then rewrite the `_0` suffix it adds back to the literal
-                # name. naming_kind is None here because we already allocated.
-                entity = self._closed_spline_entity_from_ring(
-                    ring, entity_name, 0, comment_suffix=comment,
+                # Should be unreachable: every category extractor produces has
+                # a KNOWN_BUILDING_PREFABS entry, and Building_Generic catches
+                # building=yes. If this fires, the catalog and extractor have
+                # diverged — fix config/buildings.py rather than emit a
+                # SplineShapeEntity. Nested-child syntax inside one caused
+                # Workbench to hang at 4% on world load in v1.1.0 (reverted
+                # in v1.2.3) so we never re-arm that footgun.
+                logger.warning(
+                    f"Building category {building.get('prefab_category')!r} "
+                    f"has no entry in KNOWN_BUILDING_PREFABS — skipping "
+                    f"osm_id={building.get('osm_id')}. Add the category to "
+                    f"config/buildings.py to fix."
                 )
-                if entity is None:
-                    skipped_out_of_bounds += 1
-                    continue
-                entity = entity.replace(
-                    f"SplineShapeEntity {entity_name}_0 ",
-                    f"SplineShapeEntity {entity_name} ",
-                    1,
-                )
-                entities.append(entity)
                 marker_count += 1
+                continue
 
         if skipped_road_overlap:
             logger.info(

--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -166,6 +166,7 @@
                         <div><i class="bi bi-check-circle"></i> Biome-matched ambient sound</div>
                         <div><i class="bi bi-check-circle"></i> OSM-named splines (no more <code>Road_1, Road_2</code>)</div>
                         <div><i class="bi bi-check-circle"></i> Canonical <code>RG_Road_*_E_01..03</code> prefabs</div>
+                        <div><i class="bi bi-check-circle"></i> Real <code>Building_*.et</code> prefab instances, rotation-aligned to OSM footprint</div>
                         <div><i class="bi bi-check-circle"></i> <code>surface_assignments.json</code> sidecar</div>
                     </div>
                 </div>

--- a/webapp/tests/test_enfusion_buildings_layer.py
+++ b/webapp/tests/test_enfusion_buildings_layer.py
@@ -1,14 +1,20 @@
 """
 Tests for the Phase 2 buildings layer (audit task A2 + L12).
 
-The buildings layer emits one entity per OSM building, in one of two modes:
+The buildings layer emits one entity per OSM building as a positioned
+prefab instance:
 
-* **Auto-placed prefab instance** when ``config.buildings.KNOWN_BUILDING_PREFABS``
-  has a verified path for the building's category. Uses the
-  ``${guid}path/to/prefab.et { coords X Y Z }`` syntax.
-* **Footprint-spline marker** when the catalog has no entry — emits a closed
-  ``SplineShapeEntity`` over the exterior ring so the user can manually wire
-  a building prefab as a child entity.
+    ${guid}path/to/Building_*.et { coords X Y Z; angles 0 yaw 0 }
+
+The ``angles`` line is omitted for cardinal-aligned buildings (yaw ≈ 0)
+to match shipped community convention.
+
+Buildings whose category isn't in ``config.buildings.KNOWN_BUILDING_PREFABS``
+are logged-and-skipped (v1.4.6, closes #85). The catalog now covers every
+category the feature_extractor produces, so this path is a regression guard
+rather than a runtime fallback — the previous spline-footprint fallback
+was removed because nested-child syntax inside SplineShapeEntity has
+hung Workbench at 4% on world load (the v1.1.0 → v1.2.3 incident).
 
 Buildings whose centroid falls inside an asphalt-road exclusion zone (half
 road width + 1.5 m safety) are dropped (L12).
@@ -49,7 +55,17 @@ def _metadata_for_4km_terrain() -> dict:
     }
 
 
-def _building(idx, lon, lat, building_type="house", prefab=None, name=""):
+# Default catalog path used when callers don't supply one — matches
+# Building_Generic in config.buildings.KNOWN_BUILDING_PREFABS. Tests that
+# want the skip-with-warning path pass prefab=None explicitly.
+_DEFAULT_TEST_PREFAB = (
+    "Prefabs/Structures/Houses/Village/"
+    "House_Village_E_1I01/House_Village_E_1I01.et"
+)
+
+
+def _building(idx, lon, lat, building_type="house",
+              prefab=_DEFAULT_TEST_PREFAB, name="", rotation_deg=0):
     """Synthetic building dict matching extract_building_features output."""
     # Tiny 0.0001-degree square footprint around (lon, lat)
     d = 0.0001
@@ -59,7 +75,7 @@ def _building(idx, lon, lat, building_type="house", prefab=None, name=""):
         "building_type": building_type,
         "height_m": 6,
         "center": [lon, lat],
-        "rotation_deg": 0,
+        "rotation_deg": rotation_deg,
         "footprint_area_m2": 100,
         "prefab_category": f"Building_{building_type.capitalize()}",
         "enfusion_prefab": prefab,
@@ -200,29 +216,38 @@ class TestBuildingsLayerEmission:
         out = gen._generate_buildings_layer()
         assert "// Buildings layer" in out
         assert "No building data available" in out
-        assert "SplineShapeEntity" not in out
+        # No actual SplineShapeEntity emission. The header's explanatory
+        # text *mentions* the term, so we check for the emitted form
+        # `SplineShapeEntity Building_` rather than the bare word.
+        assert "SplineShapeEntity Building_" not in out
 
     def test_empty_building_list_emits_friendly_comment(self, make_generator):
         gen = make_generator(buildings=[])
         out = gen._generate_buildings_layer()
         assert "No buildings found" in out
-        assert "SplineShapeEntity" not in out
+        assert "SplineShapeEntity Building_" not in out
 
-    def test_unvalidated_building_emits_footprint_spline(self, make_generator):
+    def test_uncatalogued_category_is_skipped_with_warning(self, make_generator, caplog):
+        """v1.4.6 (closes #85): the spline-footprint fallback was removed.
+        Categories without a KNOWN_BUILDING_PREFABS entry now warn-and-skip
+        rather than emit a dangerous nested-child SplineShapeEntity."""
+        import logging
         gen = make_generator(buildings=[
             _building(0, lon=1.0, lat=1.0, building_type="house", prefab=None,
-                      name="Test House")
+                      name="Uncatalogued")
         ])
-        out = gen._generate_buildings_layer()
+        with caplog.at_level(logging.WARNING):
+            out = gen._generate_buildings_layer()
 
-        # v1.4.0 — footprint markers now use descriptive names derived from OSM
-        # tags (Building_House_TestHouse), no longer Building_<index>.
-        assert "SplineShapeEntity Building_House_TestHouse {" in out
-        # Comment carries the human-readable name + type
-        assert "Test House" in out
-        # No actual ${guid}prefab.et reference was emitted for this building.
+        # No spline emission for the skipped building.
+        assert "SplineShapeEntity Building_" not in out
+        # No prefab reference either — building was dropped.
         from config.enfusion import ARMA_REFORGER_GUID
         assert f"${{{ARMA_REFORGER_GUID}}}" not in out
+        # Warning was logged pointing at the catalog.
+        assert any(
+            "KNOWN_BUILDING_PREFABS" in r.message for r in caplog.records
+        ), "Expected a catalog-divergence warning."
 
     def test_validated_building_emits_prefab_instance(self, make_generator):
         from config.enfusion import ARMA_REFORGER_GUID
@@ -240,30 +265,53 @@ class TestBuildingsLayerEmission:
         # for this building (no Building_* spline header).
         assert "SplineShapeEntity Building_" not in out
 
+    def test_rotated_building_emits_angles_line(self, make_generator):
+        """Y-axis rotation from _estimate_building_rotation flows through to
+        an `angles 0 <yaw> 0` line — verified against community .layer
+        files (DarcMods town01.layer, Overthrow). #85."""
+        b = _building(0, lon=1.0, lat=1.0, building_type="house",
+                      rotation_deg=42.5)
+        gen = make_generator(buildings=[b])
+        out = gen._generate_buildings_layer()
+
+        # Three-component form, not bare `angleY`.
+        assert "angles 0 42.50 0" in out
+
+    def test_cardinal_aligned_building_omits_angles_line(self, make_generator):
+        """rotation_deg ≈ 0 → no `angles` line, matching community .layer
+        convention (keeps the file diff-friendly and less noisy)."""
+        b = _building(0, lon=1.0, lat=1.0, building_type="house",
+                      rotation_deg=0.0)
+        gen = make_generator(buildings=[b])
+        out = gen._generate_buildings_layer()
+
+        # The header explains the `angles 0 <yaw> 0` convention, so check
+        # only the emission body after the last header line.
+        body = out.split("// Source data:")[-1]
+        assert "coords " in body
+        assert "angles" not in body
+
     def test_building_outside_terrain_skipped(self, make_generator):
         # Identity ×1000: lon=10 → x=10000m, terrain only 4096m wide.
         gen = make_generator(buildings=[
             _building(0, lon=10.0, lat=10.0, building_type="house"),
         ])
         out = gen._generate_buildings_layer()
-        # The header text mentions `Building_*.et` — strip that before
-        # checking that no real entity was emitted.
-        body = out.split("// Source data:")[-1]
-        assert "SplineShapeEntity" not in body
-        # Counter is empty: no entity carrying a Building_<something> name.
-        assert "SplineShapeEntity Building_" not in out
+        # No prefab reference was emitted for the out-of-bounds building.
+        from config.enfusion import ARMA_REFORGER_GUID
+        assert f"${{{ARMA_REFORGER_GUID}}}" not in out
 
     def test_each_building_gets_one_entity(self, make_generator):
+        from config.enfusion import ARMA_REFORGER_GUID
         gen = make_generator(buildings=[
             _building(0, lon=0.5, lat=0.5),
             _building(1, lon=1.0, lat=1.0),
             _building(2, lon=1.5, lat=1.5),
         ])
         out = gen._generate_buildings_layer()
-        # Three footprint markers (none have validated prefabs). Names are now
-        # descriptive (Building_<category>_<quadrant>_NNN) rather than
-        # Building_<idx> — count by the SplineShapeEntity Building_ prefix.
-        assert out.count("SplineShapeEntity Building_") == 3
+        # Three positioned prefab instances. Count by the GUID reference
+        # since each building emits one ${guid}path { ... } block.
+        assert out.count(f"${{{ARMA_REFORGER_GUID}}}") == 3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

[Issue #85](https://github.com/tubalainen/arma_reforger_base_map_generator_ng/issues/85) asked "Buildings are created as splines, is that correct?" — the honest answer is no. Buildings in Enfusion/World Editor are positioned prefab instances referencing a `Building_*.et`, not `SplineShapeEntity` outlines.

The catalog architecture has been right since v1.4.1, but two bugs made the output look like the old spline-fallback path:

1. **Rotation was silently dropped.** `_estimate_building_rotation` returned a usable yaw, but the emitter wrote only `coords X Y Z`. Every building faced default-Y regardless of how its street ran. Now emits `angles 0 <yaw> 0` (three-component form, verified against shipped community building layers — DarcMods town01.layer, Overthrow, Coalition).
2. **The spline-fallback path was kept "just in case"** even though every category `extract_building_features` produces now has a `KNOWN_BUILDING_PREFABS` entry (`Building_Generic` catches `building=yes`). Replaced with a warn-and-skip — uncatalogued categories log a clear message pointing at `config/buildings.py` rather than emit a nested-child `SplineShapeEntity` (which hung Workbench at 4% on world load in v1.1.0).

## Stacked on top of #95

This branch was created off `claude/labels-overlay-v1.4.5`, so it contains the v1.4.5 labels-overlay commits. **Merge #95 first**, then this one — GitHub will recompute the diff automatically after #95 squash-merges.

## Why not also tackle size variants / terrain flattening?

Out of scope per the agreed-upon plan (Tier 1 only — close #85, ship clean). Catalog expansion for footprint-area-based prefab selection and per-building terrain flattening are noted as follow-ups.

## Side note: dead duplicate methods

`_generate_buildings_layer`, `_build_road_exclusion_zone`, and `_building_exterior_ring` are each defined twice in `EnfusionProjectGenerator` (Python silently uses the second copy). Out of scope for this PR — flagged as a separate cleanup task.

## Test plan

- [x] `pytest webapp/tests/test_enfusion_buildings_layer.py -v` — 17/17 pass (3 new: rotation-emission, cardinal-omits-angles, uncatalogued-warns-and-skips)
- [x] `pytest webapp/tests/ -k building -v` — 25/25 pass, zero regressions
- [x] Synthetic-input smoke test: rotated building emits `angles 0 87.50 0`, cardinal omits, uncatalogued logs warning + skips
- [x] UI panel shows new "Real `Building_*.et` prefab instances, rotation-aligned to OSM footprint" bullet
- [ ] **Workbench reality check** (pending — needs human in Workbench): load a generated `*_buildings.layer`, confirm buildings face their street axis and no Workbench hang at 4%

🤖 Generated with [Claude Code](https://claude.com/claude-code)