### PR TITLE
v1.4.8: reproject mismatched STAC Bild COGs (closes #107)

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ The application is published to GitHub Container Registry and automatically buil
 docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:latest
 
 # Or use a specific version tag
-docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.4.7
+docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.4.8
 ```
 
 The `docker-compose.yml` is pre-configured to use the GHCR.io image. See the [Quick Start Guide](#quick-start-guide) for setup instructions.

--- a/webapp/config/enfusion.py
+++ b/webapp/config/enfusion.py
@@ -15,7 +15,7 @@ Community Wiki (community.bistudio.com) as of 2025-02-09.
 # enfusion_project_generator.py to stamp into every generated file header.
 # Bump here on every release; the README Docker tag pin should match.
 
-APP_VERSION = "1.4.7"
+APP_VERSION = "1.4.8"
 
 # ---------------------------------------------------------------------------
 # Base game dependency

--- a/webapp/services/lantmateriet/stac_orthophoto_service.py
+++ b/webapp/services/lantmateriet/stac_orthophoto_service.py
@@ -125,27 +125,50 @@ def _cog_merge_rgb(
     import time
 
     import rasterio
+    from rasterio.crs import CRS
     from rasterio.env import Env
     from rasterio.enums import Resampling
     from rasterio.merge import merge as rasterio_merge
+    from rasterio.vrt import WarpedVRT
 
     x_min, y_min, x_max, y_max = epsg3006_bounds
     n_hrefs = len(vsicurl_hrefs)
+    target_crs = CRS.from_epsg(3006)
 
+    # Datasets and the underlying file handles are tracked separately because
+    # WarpedVRT wrappers must be closed before the wrapped DatasetReader.
     datasets = []
+    source_handles = []
     open_start = time.monotonic()
     with Env(**_gdal_vsicurl_env()):
         # Open all COG files (only the header is fetched at this point)
         for idx, href in enumerate(vsicurl_hrefs, 1):
             try:
                 ds = rasterio.open(href)
-                datasets.append(ds)
-                # Header-only open should be quick; log every tile so the user
-                # can see the loop progressing (one of ~50 lines per request).
-                logger.info(
-                    f"STAC Bild: opened COG {idx}/{n_hrefs} "
-                    f"({ds.width}×{ds.height} px native)"
-                )
+                source_handles.append(ds)
+                # STAC Bild's primary collection is EPSG:3006, but sibling
+                # collections (e.g. se1g) occasionally surface in the same
+                # search result in a different CRS. rasterio.merge() requires
+                # a homogeneous CRS, so wrap mismatched tiles in a WarpedVRT
+                # that lazily reprojects them on read.
+                if ds.crs != target_crs:
+                    vrt = WarpedVRT(
+                        ds,
+                        crs=target_crs,
+                        resampling=Resampling.bilinear,
+                    )
+                    datasets.append(vrt)
+                    logger.info(
+                        f"STAC Bild: opened COG {idx}/{n_hrefs} "
+                        f"({ds.width}×{ds.height} px native, "
+                        f"reprojecting {ds.crs.to_string()} → EPSG:3006)"
+                    )
+                else:
+                    datasets.append(ds)
+                    logger.info(
+                        f"STAC Bild: opened COG {idx}/{n_hrefs} "
+                        f"({ds.width}×{ds.height} px native)"
+                    )
             except Exception as exc:
                 logger.warning(f"Could not open COG {href}: {exc}")
         open_elapsed = time.monotonic() - open_start
@@ -232,7 +255,15 @@ def _cog_merge_rgb(
         finally:
             heartbeat_stop.set()
             heartbeat_thread.join(timeout=1.0)
+            # Close VRT wrappers before the underlying DatasetReaders they wrap.
             for ds in datasets:
+                if ds in source_handles:
+                    continue
+                try:
+                    ds.close()
+                except Exception:
+                    pass
+            for ds in source_handles:
                 try:
                     ds.close()
                 except Exception:


### PR DESCRIPTION
## Summary

Fixes [#107](https://github.com/tubalainen/arma_reforger_base_map_generator_ng/issues/107) — `rasterio.merge failed for STAC Bild COGs: CRS mismatch with source` occasionally crashed orthophoto fetches and left generated map packages without a satellite image.

- **Root cause**: Lantmäteriet's STAC Bild search occasionally returns COGs from sibling collections (e.g. `se1g`) in a CRS other than the primary EPSG:3006. `rasterio.merge()` requires a homogeneous CRS and raised on the first mismatching dataset, killing the whole fetch. Not a server-resources issue.
- **Fix**: After opening each COG, check `ds.crs`. If it differs from EPSG:3006, wrap it in a `WarpedVRT(crs=EPSG:3006)` so it presents as 3006 to `rasterio.merge()` while reprojecting lazily on read. Matching tiles are passed through unchanged.
- VRT wrappers are tracked separately from source `DatasetReader` handles so they get closed in the right order.
- `APP_VERSION` and the README Docker tag pin bumped to 1.4.8.

## Test plan

- [ ] Generate a Swedish map over a bbox that previously surfaced an `se1g` tile in STAC results — confirm log shows the `reprojecting … → EPSG:3006` line and the merge completes.
- [ ] Generate a Swedish map over a normal area — confirm no regression (no extra reprojection messages, same output as before).
- [ ] Verify the final orthophoto PNG in the generated map package is present and pixel-aligned with the WGS84 warp output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)