### PR TITLE
ui: remove "Generated map includes" sidebar panel (#98)

### DIFF
--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -158,19 +158,6 @@
                     </div>
                 </div>
 
-                <!-- Atlas 2 alignment info (v1.4.0) -->
-                <div class="sidebar-section">
-                    <h6><i class="bi bi-stars"></i> Generated map includes</h6>
-                    <div class="small">
-                        <div><i class="bi bi-check-circle"></i> 12 bootstrap entities auto-wired (Atlas 2)</div>
-                        <div><i class="bi bi-check-circle"></i> Biome-matched ambient sound</div>
-                        <div><i class="bi bi-check-circle"></i> OSM-named splines (no more <code>Road_1, Road_2</code>)</div>
-                        <div><i class="bi bi-check-circle"></i> Canonical <code>RG_Road_*_E_01..03</code> prefabs</div>
-                        <div><i class="bi bi-check-circle"></i> Real <code>Building_*.et</code> prefab instances, rotation-aligned to OSM footprint</div>
-                        <div><i class="bi bi-check-circle"></i> <code>surface_assignments.json</code> sidecar</div>
-                    </div>
-                </div>
-
                 <!-- Version info -->
                 <div class="sidebar-section version-info">
                     <div class="text-center small">


### PR DESCRIPTION
## Summary

Removes the v1.4.0 "Generated map includes" sidebar panel from `webapp/static/index.html`. Per the screenshot on #98, that's the panel listing the 12 bootstrap entities, ambient sound, OSM-named splines, canonical road prefab names, building prefab instances, and the `surface_assignments.json` sidecar.

The underlying features stay — only the marketing list in the sidebar is dropped.

Closes #98.

## Test plan

- [x] `grep` confirms no JS references the removed block — pure markup deletion.
- [x] Surrounding HTML (`<!-- Available data sources -->` above, `<!-- Version info -->` below) reads cleanly with no orphan tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)