### PR TITLE
feat: record per-generation data sources in SETUP_GUIDE.md (#75)

### DIFF
--- a/webapp/services/map_generator.py
+++ b/webapp/services/map_generator.py
@@ -56,6 +56,11 @@ class MapGenerationJob:
         self.result = None
         self.created_at = datetime.utcnow().isoformat()
         self.completed_at = None
+        # Per-feature-category data source, populated by step_fetch_features.
+        # Maps "roads"/"buildings"/"water"/"forests"/"land_use" → display name
+        # (e.g. "OpenStreetMap (Overpass)", "Lantmäteriet Hydrografi"). Surfaced
+        # in metadata.json + the Data Sources appendix of SETUP_GUIDE.md.
+        self.feature_sources: dict[str, str] = {}
 
     def add_log(self, message: str, level: str = "info"):
         """
@@ -200,6 +205,11 @@ async def step_fetch_osm(
         with open(output_dir / f"osm_{name}.geojson", "w") as f:
             json.dump(data, f)
 
+    if job is not None:
+        osm_label = "OpenStreetMap (Overpass)"
+        for category in ("roads", "buildings", "water", "forests", "land_use"):
+            job.feature_sources[category] = osm_label
+
     return osm_data
 
 
@@ -304,12 +314,16 @@ async def _fetch_features_sweden(
     )
 
     result = {}
+    sources: dict[str, str] = {}
+    osm_label = "OpenStreetMap (Overpass)"
 
     # --- Roads: always OSM ---
     result["roads"] = _safe_result(osm_roads, "roads", job)
+    sources["roads"] = osm_label
 
     # --- Buildings: always OSM ---
     result["buildings"] = _safe_result(osm_buildings, "buildings", job)
+    sources["buildings"] = osm_label
 
     # --- Water: Lantmäteriet Hydrografi primary, OSM fallback ---
     if isinstance(lm_water, Exception) or lm_water is None:
@@ -322,8 +336,10 @@ async def _fetch_features_sweden(
             )
         osm_water = await fetch_water(bbox, job)
         result["water"] = _safe_result(osm_water, "water", job)
+        sources["water"] = f"{osm_label} (Lantmäteriet Hydrografi unavailable)"
     else:
         result["water"] = lm_water
+        sources["water"] = "Lantmäteriet Hydrografi"
 
     # --- Forests + Land use: Lantmäteriet Marktäcke primary, OSM fallback ---
     if isinstance(lm_land_cover, Exception) or lm_land_cover is None:
@@ -338,9 +354,13 @@ async def _fetch_features_sweden(
         osm_land_use = await fetch_land_use(bbox, job)
         result["forests"] = _safe_result(osm_forests, "forests", job)
         result["land_use"] = _safe_result(osm_land_use, "land_use", job)
+        sources["forests"] = f"{osm_label} (Lantmäteriet Marktäcke unavailable)"
+        sources["land_use"] = sources["forests"]
     else:
         result["forests"] = lm_land_cover.get("forests", _empty_fc())
         result["land_use"] = lm_land_cover.get("land_use", _empty_fc())
+        sources["forests"] = "Lantmäteriet Marktäcke"
+        sources["land_use"] = "Lantmäteriet Marktäcke"
 
         # Merge Marktäcke supplementary water (Hav, Sjö, etc.) into water
         marktacke_water = lm_land_cover.get("water", {})
@@ -348,11 +368,17 @@ async def _fetch_features_sweden(
             result["water"] = _merge_feature_collections(
                 result["water"], marktacke_water
             )
+            # If Hydrografi already gave us water, note the supplement.
+            if sources["water"] == "Lantmäteriet Hydrografi":
+                sources["water"] = "Lantmäteriet Hydrografi + Marktäcke"
 
     # Save GeoJSON files (same naming as OSM path for downstream compatibility)
     for name, data in result.items():
         with open(output_dir / f"osm_{name}.geojson", "w") as f:
             json.dump(data, f)
+
+    if job is not None:
+        job.feature_sources = sources
 
     return result
 
@@ -564,6 +590,7 @@ def build_metadata(
     satellite_result: dict = None,
     coordinate_transform: dict = None,
     map_name: str = None,
+    feature_sources: dict = None,
 ) -> dict:
     """Assemble the output metadata.json content."""
     metadata = {
@@ -641,6 +668,12 @@ def build_metadata(
     # Add map name
     if map_name:
         metadata["map_name"] = map_name
+
+    # Per-category vector feature sources (issue #75). Elevation + satellite
+    # sources already live under metadata["elevation"]/["satellite"]; this
+    # block records who provided the OSM/Lantmäteriet vectors for THIS run.
+    if feature_sources:
+        metadata["feature_sources"] = dict(feature_sources)
 
     return metadata
 
@@ -1173,6 +1206,7 @@ async def run_generation(job: MapGenerationJob):
             satellite_result=satellite_result,
             coordinate_transform=coord_verification,
             map_name=map_name,
+            feature_sources=job.feature_sources,
         )
 
         with open(output_dir / "metadata.json", "w") as f:

--- a/webapp/services/setup_guide_generator.py
+++ b/webapp/services/setup_guide_generator.py
@@ -61,6 +61,7 @@ class SetupGuideGenerator:
         self.enfusion = metadata.get("enfusion_import", {})
         self.settings = self.enfusion.get("recommended_settings", {})
         self.coord_info = metadata.get("coordinate_transform", {})
+        self.feature_sources = metadata.get("feature_sources", {})
 
         # Coverage data
         self.coverage = self.surf.get("coverage", {})
@@ -103,6 +104,7 @@ class SetupGuideGenerator:
             self._appendix_files(),
             self._appendix_parameters(),
             self._appendix_troubleshooting(),
+            self._appendix_data_sources(),
             self._appendix_next_steps(),
         ]
 
@@ -869,8 +871,151 @@ about any file it does not recognise. You can safely ignore these warnings.
 - Close unnecessary panels
 - Consider working with a smaller terrain first"""
 
+    def _appendix_data_sources(self) -> str:
+        """Appendix D — concrete record of which APIs/datasets supplied
+        this specific generation (issue #75). Pulls live source strings out
+        of metadata for elevation, satellite, and per-feature-category vector
+        providers, then renders fixed attribution lines."""
+        elev_source = self.elev.get("source", "Unknown")
+        elev_res = self.elev.get("resolution_m")
+        elev_line = f"- **Elevation:** {elev_source}"
+        if elev_res is not None:
+            elev_line += f" ({elev_res} m resolution)"
+
+        sat_lines = []
+        if self.satellite:
+            sat_source = self.satellite.get("source", "Sentinel-2 Cloudless (EOX)")
+            sat_dims = self.satellite.get("dimensions", "")
+            sat_line = f"- **Satellite imagery:** {sat_source}"
+            if sat_dims:
+                sat_line += f" ({sat_dims})"
+            sat_lines.append(sat_line)
+        else:
+            sat_lines.append("- **Satellite imagery:** not generated")
+
+        countries = self.input_data.get("countries") or []
+        if not countries:
+            countries = [self.input_data.get("primary_country", "UNKNOWN")]
+
+        feature_rows = []
+        if self.feature_sources:
+            for category in ("roads", "buildings", "water", "forests", "land_use"):
+                src = self.feature_sources.get(category)
+                if src:
+                    feature_rows.append(f"| {category.replace('_', ' ').title():<10} | {src} |")
+        if not feature_rows:
+            feature_rows.append("| (no per-category source info recorded) | |")
+        feature_table = "\n".join(feature_rows)
+
+        attribution_lines = []
+        sources_seen = set()
+        sources_seen.add(elev_source)
+        if self.satellite:
+            sources_seen.add(self.satellite.get("source", ""))
+        for v in self.feature_sources.values():
+            sources_seen.add(v)
+
+        def _matches(needle: str) -> bool:
+            return any(needle.lower() in s.lower() for s in sources_seen if s)
+
+        if _matches("OpenStreetMap"):
+            attribution_lines.append(
+                "- **OpenStreetMap:** © OpenStreetMap contributors, "
+                "licensed under the [Open Database License (ODbL)]"
+                "(https://www.openstreetmap.org/copyright)."
+            )
+        if _matches("Lantmäteriet") or _matches("Hydrografi") or _matches("Marktäcke") or _matches("STAC"):
+            attribution_lines.append(
+                "- **Lantmäteriet** (STAC Höjd / STAC Bild / Hydrografi / Marktäcke): "
+                "open data under [CC0 1.0]"
+                "(https://creativecommons.org/publicdomain/zero/1.0/) "
+                "via the Lantmäteriet open data programme."
+            )
+        if _matches("Sentinel-2") or _matches("EOX"):
+            attribution_lines.append(
+                "- **Sentinel-2 Cloudless** (EOX): Contains modified Copernicus "
+                "Sentinel data 2024, processed by EOX IT Services GmbH."
+            )
+        if _matches("Copernicus DEM") or _matches("COP30") or _matches("AWS"):
+            attribution_lines.append(
+                "- **Copernicus DEM GLO-30:** © DLR e.V. 2010-2014 and "
+                "© Airbus Defence and Space GmbH 2014-2018, provided under "
+                "the [Copernicus Data License]"
+                "(https://spacedata.copernicus.eu/web/cscda/data-access/cop-dem)."
+            )
+        if _matches("OpenTopography"):
+            attribution_lines.append(
+                "- **OpenTopography:** SRTM / COP30 access via "
+                "[OpenTopography.org](https://opentopography.org/)."
+            )
+        if _matches("ALOS"):
+            attribution_lines.append(
+                "- **ALOS World 3D 30 m (AW3D30):** © JAXA, distributed via the "
+                "[JAXA Earth Observation Research Center]"
+                "(https://www.eorc.jaxa.jp/ALOS/en/dataset/aw3d30/aw3d30_e.htm)."
+            )
+        if _matches("Kartverket"):
+            attribution_lines.append(
+                "- **Kartverket** (Norway): open data under "
+                "[NLOD 2.0](https://data.norge.no/nlod/en/2.0/)."
+            )
+        if _matches("Maa-amet"):
+            attribution_lines.append(
+                "- **Maa-amet** (Estonia): open data, "
+                "[Maa-amet open data terms](https://geoportaal.maaamet.ee/eng/)."
+            )
+        if _matches("NLS"):
+            attribution_lines.append(
+                "- **NLS Finland:** open data under the "
+                "[NLS open data licence]"
+                "(https://www.maanmittauslaitos.fi/en/opendata-licence-version1)."
+            )
+        if _matches("Dataforsyningen"):
+            attribution_lines.append(
+                "- **Dataforsyningen** (Denmark): open data via "
+                "[Dataforsyningen](https://dataforsyningen.dk/)."
+            )
+        if _matches("GUGiK"):
+            attribution_lines.append(
+                "- **GUGiK** (Poland): open data via "
+                "[GUGiK Geoportal](https://www.geoportal.gov.pl/)."
+            )
+        # Country detection is always Natural Earth.
+        attribution_lines.append(
+            "- **Country detection:** [Natural Earth 10m Admin 0 Countries]"
+            "(https://www.naturalearthdata.com/) — public domain."
+        )
+
+        attribution_block = "\n".join(attribution_lines)
+        country_str = ", ".join(countries)
+
+        return f"""## Appendix D: Data Sources
+
+This map was generated using the following sources. Source selection is
+automatic per area — the table below records exactly what was used for
+**this** generation.
+
+### Per-layer providers
+
+{elev_line}
+{chr(10).join(sat_lines)}
+- **Country detection:** Natural Earth 10m Admin 0 Countries (public domain)
+- **Covered countries:** {country_str}
+
+| Feature    | Provider |
+|------------|----------|
+{feature_table}
+
+### Attribution & licences
+
+{attribution_block}
+
+If you republish or redistribute the generated map (e.g. as a Workshop
+upload), please preserve the attribution above so each upstream dataset
+is properly credited."""
+
     def _appendix_next_steps(self) -> str:
-        return f"""## Appendix D: Next Steps
+        return f"""## Appendix E: Next Steps
 
 Once your basic terrain is set up, consider:
 

--- a/webapp/tests/test_setup_guide_generator.py
+++ b/webapp/tests/test_setup_guide_generator.py
@@ -142,3 +142,184 @@ class TestRoadsPhaseGuide:
         # The auto-attach framing from v1.1.0–v1.2.2 must be gone.
         assert "Auto-attached" not in guide
         assert "already carries" not in guide
+
+
+class TestDataSourcesAppendix:
+    """Issue #75 — every generated SETUP_GUIDE.md must include a per-generation
+    record of which APIs/datasets supplied the data, plus attribution."""
+
+    def _meta_with_sources(
+        self,
+        elevation_source: str,
+        elevation_res_m,
+        satellite_source: str | None,
+        feature_sources: dict | None,
+        countries=("SE",),
+    ) -> dict:
+        m = _metadata(["grass"], {"grass": {"percentage": 100.0}})
+        m["elevation"]["source"] = elevation_source
+        m["elevation"]["resolution_m"] = elevation_res_m
+        m["input"]["countries"] = list(countries)
+        m["input"]["primary_country"] = countries[0]
+        if satellite_source is not None:
+            m["satellite"] = {"source": satellite_source, "dimensions": "8192x8192"}
+        if feature_sources is not None:
+            m["feature_sources"] = feature_sources
+        return m
+
+    def test_sweden_with_lantmateriet_lists_actual_providers(self):
+        from services.setup_guide_generator import SetupGuideGenerator
+        meta = self._meta_with_sources(
+            elevation_source="Lantmäteriet STAC Höjd (1 m)",
+            elevation_res_m=1,
+            satellite_source="Lantmäteriet STAC Bild (most recent orthophoto)",
+            feature_sources={
+                "roads": "OpenStreetMap (Overpass)",
+                "buildings": "OpenStreetMap (Overpass)",
+                "water": "Lantmäteriet Hydrografi + Marktäcke",
+                "forests": "Lantmäteriet Marktäcke",
+                "land_use": "Lantmäteriet Marktäcke",
+            },
+            countries=("SE",),
+        )
+
+        guide = SetupGuideGenerator("TestMap", meta)._appendix_data_sources()
+
+        assert "Appendix D: Data Sources" in guide
+        assert "Lantmäteriet STAC Höjd (1 m)" in guide
+        assert "1 m resolution" in guide
+        assert "Lantmäteriet STAC Bild" in guide
+        assert "Lantmäteriet Hydrografi + Marktäcke" in guide
+        assert "Lantmäteriet Marktäcke" in guide
+        assert "OpenStreetMap (Overpass)" in guide
+        # Attribution lines must fire for OSM AND Lantmäteriet.
+        assert "Open Database License" in guide  # OSM ODbL
+        assert "CC0" in guide  # Lantmäteriet
+        # Sentinel-2 attribution must NOT appear when we used Lantmäteriet imagery.
+        assert "Sentinel-2 Cloudless" not in guide
+        # Natural Earth attribution is always present.
+        assert "Natural Earth" in guide
+
+    def test_global_osm_only_path_lists_osm_for_every_category(self):
+        from services.setup_guide_generator import SetupGuideGenerator
+        meta = self._meta_with_sources(
+            elevation_source="Copernicus DEM GLO-30 (AWS Open Data)",
+            elevation_res_m=30,
+            satellite_source="Sentinel-2 Cloudless (EOX)",
+            feature_sources={
+                "roads": "OpenStreetMap (Overpass)",
+                "buildings": "OpenStreetMap (Overpass)",
+                "water": "OpenStreetMap (Overpass)",
+                "forests": "OpenStreetMap (Overpass)",
+                "land_use": "OpenStreetMap (Overpass)",
+            },
+            countries=("US",),
+        )
+
+        guide = SetupGuideGenerator("TestMap", meta)._appendix_data_sources()
+
+        assert "Copernicus DEM GLO-30" in guide
+        assert "30 m resolution" in guide
+        assert "Sentinel-2 Cloudless" in guide
+        # All five feature categories report OSM.
+        assert guide.count("OpenStreetMap (Overpass)") >= 5
+        # Lantmäteriet attribution must NOT appear when nothing came from there.
+        assert "Lantmäteriet" not in guide
+        # Sentinel-2 + Copernicus + OSM attribution all present.
+        assert "Sentinel data 2024" in guide
+        assert "Copernicus Data License" in guide
+        assert "Open Database License" in guide
+
+    def test_appendix_renders_without_feature_sources_metadata(self):
+        """Backwards compatibility: older metadata.json without `feature_sources`
+        must still produce a valid appendix (just without the per-category table
+        contents)."""
+        from services.setup_guide_generator import SetupGuideGenerator
+        meta = self._meta_with_sources(
+            elevation_source="AWS COP30",
+            elevation_res_m=30,
+            satellite_source="Sentinel-2 Cloudless (EOX)",
+            feature_sources=None,
+        )
+
+        guide = SetupGuideGenerator("TestMap", meta)._appendix_data_sources()
+        assert "Appendix D: Data Sources" in guide
+        assert "(no per-category source info recorded)" in guide
+
+    def test_next_steps_renumbered_to_appendix_e(self):
+        from services.setup_guide_generator import SetupGuideGenerator
+        meta = _metadata(["grass"], {"grass": {"percentage": 100.0}})
+        gen = SetupGuideGenerator("TestMap", meta)
+        assert "Appendix E: Next Steps" in gen._appendix_next_steps()
+
+    def test_full_generate_includes_data_sources_section(self, tmp_path):
+        """End-to-end: the new appendix must appear in the actual file written
+        by `.generate()`, not just be callable in isolation."""
+        from services.setup_guide_generator import SetupGuideGenerator
+        meta = self._meta_with_sources(
+            elevation_source="Lantmäteriet STAC Höjd (1 m)",
+            elevation_res_m=1,
+            satellite_source="Lantmäteriet STAC Bild (most recent orthophoto)",
+            feature_sources={
+                "roads": "OpenStreetMap (Overpass)",
+                "buildings": "OpenStreetMap (Overpass)",
+                "water": "Lantmäteriet Hydrografi",
+                "forests": "Lantmäteriet Marktäcke",
+                "land_use": "Lantmäteriet Marktäcke",
+            },
+            countries=("SE",),
+        )
+        meta["map_name"] = "TestMap"
+
+        gen = SetupGuideGenerator("TestMap", meta)
+        path = gen.generate(tmp_path)
+        body = path.read_text(encoding="utf-8")
+
+        assert "Appendix D: Data Sources" in body
+        assert "Appendix E: Next Steps" in body
+        # Data sources section appears before Next Steps in the rendered file.
+        assert body.index("Appendix D: Data Sources") < body.index("Appendix E: Next Steps")
+
+
+class TestBuildMetadataFeatureSources:
+    """Issue #75 — build_metadata must propagate feature_sources into metadata.json."""
+
+    def _minimal_results(self) -> dict:
+        return {
+            "polygon_coords": [[0, 0], [1, 0], [1, 1], [0, 1]],
+            "options": {},
+            "country_info": {
+                "bbox": {"south": 0, "north": 1, "west": 0, "east": 1},
+                "countries": ["SE"],
+                "primary_country": "SE",
+                "crs": "EPSG:3006",
+            },
+            "elevation_result": {"source": "Lantmäteriet STAC Höjd (1 m)", "resolution_m": 1},
+            "heightmap_result": {
+                "dimensions": "2049x2049",
+                "terrain_size_m": 4096,
+                "grid_cell_size_m": 2.0,
+                "min_elevation": 0,
+                "max_elevation": 100,
+                "height_scale": 0.03125,
+                "height_offset": 0,
+            },
+            "surface_result": {"mask_count": 1, "surfaces": ["grass"]},
+            "road_result": {"stats": {"total": 0, "by_surface": {}, "by_type": {}}},
+            "features": {"summary": {}},
+        }
+
+    def test_feature_sources_round_trip(self):
+        from services.map_generator import build_metadata
+        sources = {
+            "roads": "OpenStreetMap (Overpass)",
+            "water": "Lantmäteriet Hydrografi",
+            "forests": "Lantmäteriet Marktäcke",
+        }
+        meta = build_metadata(**self._minimal_results(), feature_sources=sources)
+        assert meta["feature_sources"] == sources
+
+    def test_no_feature_sources_omits_the_key(self):
+        from services.map_generator import build_metadata
+        meta = build_metadata(**self._minimal_results())
+        assert "feature_sources" not in meta


### PR DESCRIPTION
## Summary

Adds a new **Appendix D: Data Sources** to every generated `SETUP_GUIDE.md` that records exactly which APIs and datasets supplied the data for *that* generation — elevation provider + resolution, satellite provider + dimensions, detected country, and a per-feature-category table covering roads, buildings, water, forests, and land use. Includes condition-driven attribution/licence lines so each upstream dataset is properly credited if the user republishes the map.

Closes #75.

## What's new in the user-facing output

```
## Appendix D: Data Sources

### Per-layer providers

- **Elevation:** Lantmäteriet STAC Höjd (1 m) (1 m resolution)
- **Satellite imagery:** Lantmäteriet STAC Bild (most recent orthophoto) (8192x8192)
- **Country detection:** Natural Earth 10m Admin 0 Countries (public domain)
- **Covered countries:** SE

| Feature    | Provider |
|------------|----------|
| Roads      | OpenStreetMap (Overpass) |
| Buildings  | OpenStreetMap (Overpass) |
| Water      | Lantmäteriet Hydrografi + Marktäcke |
| Forests    | Lantmäteriet Marktäcke |
| Land Use   | Lantmäteriet Marktäcke |

### Attribution & licences

- **OpenStreetMap:** © OpenStreetMap contributors, ODbL.
- **Lantmäteriet** (STAC Höjd / STAC Bild / Hydrografi / Marktäcke): CC0 1.0.
- **Country detection:** Natural Earth 10m — public domain.
...
```

Attribution lines fire conditionally — a non-Swedish OSM-only map gets the OSM + Copernicus DEM + Sentinel-2 + Natural Earth credits, no Lantmäteriet line.

## Implementation

- `MapGenerationJob.feature_sources` — new attribute populated by `step_fetch_osm` (always "OpenStreetMap (Overpass)") and `_fetch_features_sweden` (records whether Hydrografi/Marktäcke fired or fell back).
- `build_metadata(..., feature_sources=...)` — new optional kwarg; writes `metadata["feature_sources"]` to `metadata.json`.
- `SetupGuideGenerator._appendix_data_sources()` — renders the new section; previous Appendix D (Next Steps) renumbered to Appendix E.

## Test plan

- [x] `pytest webapp/tests/test_setup_guide_generator.py` — 12 tests pass (5 new):
  - Sweden + Lantmäteriet path lists actual providers, includes ODbL + CC0 attribution, excludes Sentinel-2.
  - OSM-only global path lists OSM for every category, includes Sentinel-2 + Copernicus DEM + ODbL, excludes Lantmäteriet.
  - Backwards-compat: older `metadata.json` without `feature_sources` still produces a valid appendix.
  - Next Steps appendix renumbered to E.
  - End-to-end `.generate()` writes the section before Next Steps.
- [x] `build_metadata` round-trip — provided `feature_sources` is preserved in output; omitted means the key is absent.
- [x] Full webapp suite: 351 pass / 6 pre-existing pyproj-missing failures unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)