### PR TITLE
v1.5.1: skip <3-band STAC Bild COGs to fix orthophoto crash (#107)

### DIFF
--- a/webapp/config/enfusion.py
+++ b/webapp/config/enfusion.py
@@ -15,7 +15,7 @@ Community Wiki (community.bistudio.com) as of 2025-02-09.
 # enfusion_project_generator.py to stamp into every generated file header.
 # Bump here on every release; the README Docker tag pin should match.
 
-APP_VERSION = "1.5.0"
+APP_VERSION = "1.5.1"
 
 # ---------------------------------------------------------------------------
 # Base game dependency

--- a/webapp/services/lantmateriet/stac_orthophoto_service.py
+++ b/webapp/services/lantmateriet/stac_orthophoto_service.py
@@ -142,15 +142,31 @@ def _cog_merge_rgb(
     open_start = time.monotonic()
     with Env(**_gdal_vsicurl_env()):
         # Open all COG files (only the header is fetched at this point)
+        skipped_single_band = 0
         for idx, href in enumerate(vsicurl_hrefs, 1):
             try:
                 ds = rasterio.open(href)
                 source_handles.append(ds)
+                # STAC Bild's primary collection is EPSG:3006 4-band RGBI, but
+                # sibling collections (e.g. se1g — historic single-band
+                # panchromatic) sometimes surface in the same search result.
+                # rasterio.merge() reads the same `indexes=[1,2,3]` from every
+                # source, so a 1-band tile makes the whole merge raise
+                # "band index 2 out of range" and we lose the orthophoto. Skip
+                # those tiles up front — if all returned tiles are single-band
+                # we'll return None and the caller falls back to WMS.
+                if ds.count < 3:
+                    skipped_single_band += 1
+                    logger.info(
+                        f"STAC Bild: skipping COG {idx}/{n_hrefs} — "
+                        f"{ds.count}-band source (need ≥3 for RGB merge): {href}"
+                    )
+                    continue
                 # STAC Bild's primary collection is EPSG:3006, but sibling
-                # collections (e.g. se1g) occasionally surface in the same
-                # search result in a different CRS. rasterio.merge() requires
-                # a homogeneous CRS, so wrap mismatched tiles in a WarpedVRT
-                # that lazily reprojects them on read.
+                # collections occasionally surface in a different CRS.
+                # rasterio.merge() requires a homogeneous CRS, so wrap
+                # mismatched tiles in a WarpedVRT that lazily reprojects
+                # them on read.
                 if ds.crs != target_crs:
                     vrt = WarpedVRT(
                         ds,
@@ -172,9 +188,13 @@ def _cog_merge_rgb(
             except Exception as exc:
                 logger.warning(f"Could not open COG {href}: {exc}")
         open_elapsed = time.monotonic() - open_start
+        skip_note = (
+            f" ({skipped_single_band} skipped as <3-band)"
+            if skipped_single_band else ""
+        )
         logger.info(
             f"STAC Bild: opened {len(datasets)}/{n_hrefs} COG headers "
-            f"in {open_elapsed:.1f}s"
+            f"in {open_elapsed:.1f}s{skip_note}"
         )
         if job:
             job.add_log(


### PR DESCRIPTION
## Summary
- Closes #107
- Skip `<3-band` STAC Bild COGs at open time so a stray single-band tile from sibling collections (e.g. historic panchromatic `se1g`) can no longer crash `rasterio.merge()` and leave the generated map with no satellite image
- Bumps `APP_VERSION` to `1.5.1`

## Why
The fix in #108 (v1.4.8) wrapped non-EPSG:3006 sibling tiles in `WarpedVRT` but assumed every result still had ≥3 bands. STAC search occasionally returns 1-band panchromatic tiles (URL pattern `…/bild/data/orto/se1g/…`). Because `rasterio.merge()` reads the same `indexes=[1,2,3]` from every source, one 1-band tile raises `band index 2 out of range (not in (1,))` and the *whole* merge aborts. The caller logs "COG merge returned no data" and falls back to WMS 2005 — the user just sees a map with no satellite imagery.

## Behaviour after this PR
- 4-band RGBI tiles merge normally
- 1- and 2-band tiles are logged + skipped at open
- The "opened N/M COG headers" summary now reports how many were skipped
- If every returned tile is <3-band the merge returns `None` and the caller falls back to WMS — same outcome as today, no crash

## Test plan
- [ ] Trigger a generation over an area where STAC search returns a mix of multi-band and single-band tiles (the area in the issue's logs is a known repro)
- [ ] Confirm the activity log shows `STAC Bild: skipping COG …` lines and the merge completes
- [ ] Confirm the generated map package now contains the orthophoto instead of the WMS 2005 fallback