### PR TITLE
fix: remove dark frame artifact on surface masks (#115)

### DIFF
--- a/webapp/services/surface_mask_generator.py
+++ b/webapp/services/surface_mask_generator.py
@@ -409,10 +409,35 @@ def generate_surface_masks(
             logger.info(
                 f"Resizing elevation for mask generation: {w}x{h} -> {target_w}x{target_h}"
             )
-            from services.utils.parallel import parallel_zoom
-            zoom_y = target_h / h
-            zoom_x = target_w / w
-            elevation = parallel_zoom(elevation, (zoom_y, zoom_x), order=3)
+            # The vertex→face resize is always exactly N+1 → N (issue #100
+            # introduced this step in v1.4.9). Use direct face-centre
+            # averaging instead of a cubic spline zoom: every face value is
+            # the average of its 4 corner vertices, which is what a terrain
+            # face physically is. The previous parallel_zoom(order=3) path
+            # used scipy's default mode='constant', cval=0.0 which pulled
+            # the outermost rows/columns of the elevation toward zero. That
+            # boundary discontinuity then spiked np.gradient (the slope
+            # input to the rock mask), saturating rock along the perimeter;
+            # normalization redistributed that to pine/forest_floor and
+            # produced the dark "frame" artifact reported as issue #115.
+            if (w, h) == (target_w + 1, target_h + 1):
+                elevation = 0.25 * (
+                    elevation[:-1, :-1].astype(np.float32)
+                    + elevation[1:, :-1].astype(np.float32)
+                    + elevation[:-1, 1:].astype(np.float32)
+                    + elevation[1:, 1:].astype(np.float32)
+                )
+            else:
+                # Fallback for any unexpected non-(N+1→N) call: use a
+                # boundary-preserving spline resample. mode='reflect' mirrors
+                # values across the boundary so the cubic kernel doesn't pad
+                # with zeros (the cval=0 default that caused issue #115).
+                from scipy.ndimage import zoom
+                zoom_y = target_h / h
+                zoom_x = target_w / w
+                elevation = zoom(
+                    elevation, (zoom_y, zoom_x), order=3, mode="reflect"
+                )
             h, w = elevation.shape
 
     logger.info(f"Generating surface masks for {w}x{h} terrain (cell size: {cell_size_m}m)")


### PR DESCRIPTION
## Summary
- Closes #115
- Replaces the vertex→face elevation resample in `surface_mask_generator.generate_surface_masks` with direct face-centre averaging, removing the dark "frame" the user saw around `pine_floor` (and the complementary bright frame on `grass`)
- No `APP_VERSION` bump — assumes this ships alongside #116 in the next v1.5.1 release

## Root cause
v1.4.9 (PR #109) introduced this resample step so masks are generated at face resolution (N) from the heightmap's vertex resolution (N+1). It went through `parallel_zoom(order=3)`, which calls `scipy.ndimage.zoom` without a `mode` argument — scipy's default is `mode='constant', cval=0.0`. The cubic kernel padded outside the array with zeros, pulling the outermost rows/columns of the resampled elevation toward 0.

Downstream:
1. `np.gradient(elevation)` in `generate_slope_mask` reads a steep step at the boundary
2. `slope_ramp_mask(start_deg=25, full_deg=40)` saturates rock to 1.0 on the perimeter; `gaussian_filter(sigma≈2)` smears that a few pixels inward
3. Mask normalisation (`total_non_grass > 1.0 → scale down`) takes the rock budget out of pine/forest_floor → dark frame on pine, complementary bright frame on grass

The artifact has been present since v1.4.9, but the per-prefab GUID bug (#111) made Workbench refuse to paint, so the user had no way to see it. v1.5.0 fixed paint → #115 became visible.

I checked `edt==2.4.1` (used by `parallel_edt` for the soft-edge transform) directly: its `black_border` defaults to `False`, so EDT boundary semantics are **not** the cause.

## Fix
The vertex→face resample is always exactly N+1 → N when called from `map_generator` after the v1.4.9 `mask_dims` change. Replace the cubic zoom with the direct face-centre average:

```python
e = 0.25 * (e[:-1,:-1] + e[1:,:-1] + e[:-1,1:] + e[1:,1:])
```

That's what a terrain face physically is — the average of its four corner vertices — and it needs no boundary padding, so the slope/rock spike disappears. A `mode='reflect'` cubic-zoom fallback is kept for any future call with different proportions (also avoiding cval=0).

## Test plan
- [ ] Regenerate the same Nordic map shown in the issue and confirm `surface_pine_floor.png` no longer has a dark frame at the perimeter
- [ ] Confirm `surface_grass.png` no longer has the complementary bright frame
- [ ] Confirm `surface_preview.png` looks clean to the edge
- [ ] Confirm no regression on a mountain map (where the rock mask legitimately reaches the map edge)
- [ ] Workbench: import the surface masks and paint near the perimeter — should not crash NVTT (v1.4.9's paint-crash fix must stay intact)

## Release note
This and #116 are both bug-only fixes. If they ship together, the v1.5.1 changelog should mention:
- #107 STAC Bild orthophoto crash (single-band tiles)
- #115 dark frame artifact on surface masks