### PR TITLE
v1.5.3: preview rate-limit exemption (#119) + heightmap-import dialog instructions (#120 partial)

### DIFF
--- a/webapp/config/enfusion.py
+++ b/webapp/config/enfusion.py
@@ -15,7 +15,7 @@ Community Wiki (community.bistudio.com) as of 2025-02-09.
 # enfusion_project_generator.py to stamp into every generated file header.
 # Bump here on every release; the README Docker tag pin should match.
 
-APP_VERSION = "1.5.2"
+APP_VERSION = "1.5.3"
 
 # ---------------------------------------------------------------------------
 # Base game dependency

--- a/webapp/config/enfusion.py
+++ b/webapp/config/enfusion.py
@@ -15,7 +15,7 @@ Community Wiki (community.bistudio.com) as of 2025-02-09.
 # enfusion_project_generator.py to stamp into every generated file header.
 # Bump here on every release; the README Docker tag pin should match.
 
-APP_VERSION = "1.5.1"
+APP_VERSION = "1.5.2"
 
 # ---------------------------------------------------------------------------
 # Base game dependency

--- a/webapp/middleware/rate_limit.py
+++ b/webapp/middleware/rate_limit.py
@@ -118,6 +118,16 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         if path == "/api/health":
             return await call_next(request)
 
+        # Preview images (heightmap / surface) are fetched by the results-page
+        # <img> tags after a job completes. A failed load triggers an immediate
+        # onerror retry with a fresh cache-buster, and on a 429 the browser
+        # loops on the error path — a few hundred requests per second is
+        # easily reachable and starves the user's whole /api/* budget so the
+        # previews never paint (issue #119). Session ownership is already
+        # enforced inside get_preview(); rate-limiting buys nothing here.
+        if path.startswith("/api/job/") and "/preview/" in path:
+            return await call_next(request)
+
         key = self._get_rate_limit_key(request)
         now = datetime.utcnow()
 

--- a/webapp/services/setup_guide_generator.py
+++ b/webapp/services/setup_guide_generator.py
@@ -215,6 +215,8 @@ You should see this structure inside:
         face_z = vertex_z - 1
         cell_size = self.hm.get("grid_cell_size_m", 2.0)
         height_scale = self.elev.get("height_scale", 0.03125)
+        min_elev = self.elev.get("min_elevation_m", 0.0)
+        max_elev = self.elev.get("max_elevation_m", 1.0)
 
         return f"""## Phase 2: Terrain Creation (10 minutes)
 
@@ -245,13 +247,22 @@ You should see this structure inside:
 2. Go to the **Manage** tab
 3. Click **Import Height Map...**
 4. Navigate to: `{self.map_name}/Sourcefiles/heightmap.asc`
-5. Settings:
-   - **Invert X Axis**: No
-   - **Invert Z Axis**: Yes
+5. Settings — **use these exact values, do not accept the dialog defaults**:
+
+   | Field | Value |
+   |-------|-------|
+   | **Invert X Axis** | No |
+   | **Invert Z Axis** | Yes |
+   | **Resample to specified range** | **UNCHECK** (use the raw metres from the .asc file) |
+   | **Min Height** | **{min_elev:.3f}** |
+   | **Max Height** | **{max_elev:.3f}** |
+
+   > **Why this matters:** the dialog defaults are `Resample = ON`, `Min = 0`, `Max = 1`. Accepting them flattens the entire terrain into a 0–1 m strip, which can both produce a paper-flat map *and* leave the world in an inconsistent state that has crashed Workbench on the subsequent reload (issue #120). The `Min`/`Max` numbers above are this map's real elevation range from `Reference/metadata.json` — Workbench uses them as the absolute height bounds for the imported grid.
+
 6. Click **Import**
 
-> **CRITICAL**: After import, you **MUST** save and reopen the world:
-> 1. **File > Save World** (Ctrl+S)
+> **CRITICAL**: After import, you **MUST** save the *world* (not just the terrain) and reopen it:
+> 1. **File > Save World** (Ctrl+S) — *not* the Terrain Tool's Save button, which only writes the .terr file
 > 2. Wait for the save to complete (watch the progress bar in the upper right corner)
 > 3. Close and reopen the world (double-click the .ent file again in the Resource Browser)
 

--- a/webapp/tests/test_rate_limit_middleware.py
+++ b/webapp/tests/test_rate_limit_middleware.py
@@ -131,3 +131,22 @@ class TestNonApiPathsAreExempt:
         for _ in range(20):
             resp = client.get("/static-asset")
             assert resp.status_code == 200
+
+    def test_preview_endpoints_are_not_rate_limited(self, app_with_low_limits):
+        """Issue #119: the results-page <img> retry loop was tripping the
+        general /api/* limit and starving previews into permanent 429s.
+        Preview fetches must be exempt — session ownership is already
+        enforced inside the route handler."""
+
+        @app_with_low_limits.get("/api/job/{job_id}/preview/{image_type}")
+        def preview(job_id: str, image_type: str):
+            return {"ok": True}
+
+        client = TestClient(app_with_low_limits)
+        # Far more than REQUESTS_PER_MINUTE (=3 in this fixture) — none
+        # should be throttled.
+        for _ in range(20):
+            resp = client.get("/api/job/abc/preview/heightmap")
+            assert resp.status_code == 200
+            resp = client.get("/api/job/abc/preview/surface")
+            assert resp.status_code == 200

--- a/webapp/tests/test_setup_guide_generator.py
+++ b/webapp/tests/test_setup_guide_generator.py
@@ -116,6 +116,49 @@ class TestSurfaceCoverageFiltering:
         assert "Import Sand" not in guide
 
 
+class TestHeightmapImportStep:
+    """Issue #120 — the Import Height Map dialog defaults to
+    Resample=ON, Min=0, Max=1, which silently flattens every imported
+    heightmap into a 0–1 m strip. The reporter's project showed this
+    exact failure mode: their heightmap.asc ranged from -1.98 m to
+    +23.29 m, but HeightMap.desc came out as
+    ``ResampleMinHeight 0 / ResampleMaxHeight 1`` because the guide
+    only documented the Invert axes and left the user on the dialog
+    defaults. Pin that the rendered guide names the resample
+    behaviour *and* the project's real Min/Max numbers."""
+
+    def test_heightmap_phase_states_real_min_and_max_height(self):
+        from services.setup_guide_generator import SetupGuideGenerator
+
+        meta = _metadata(["grass"], {"grass": {"percentage": 100.0}})
+        meta["elevation"]["min_elevation_m"] = -1.981
+        meta["elevation"]["max_elevation_m"] = 23.289
+
+        guide = SetupGuideGenerator("TestMap", meta)._phase_terrain_creation()
+
+        # The exact field labels Workbench shows the user.
+        assert "**Min Height**" in guide
+        assert "**Max Height**" in guide
+        # The project's actual elevation range — not 0/1.
+        assert "-1.981" in guide
+        assert "23.289" in guide
+        # Telling the user to unckeck Resample is the load-bearing part.
+        assert "Resample to specified range" in guide
+        assert "UNCHECK" in guide
+
+    def test_heightmap_phase_warns_about_dialog_defaults(self):
+        from services.setup_guide_generator import SetupGuideGenerator
+
+        meta = _metadata(["grass"], {"grass": {"percentage": 100.0}})
+        guide = SetupGuideGenerator("TestMap", meta)._phase_terrain_creation()
+
+        # The narrative that explains *why* the defaults are wrong —
+        # without this, future-us will silently delete the table thinking
+        # the explicit values are redundant.
+        assert "do not accept the dialog defaults" in guide
+        assert "#120" in guide
+
+
 class TestRoadsPhaseGuide:
     """v1.2.3 — §5 documents manual generator attach (the v1.1.0 auto-attach
     nested ``${guid}...`` syntax was reverted because Workbench rejected it


### PR DESCRIPTION
## Summary
Two related fallout fixes from the post-v1.5.1 triage round. Both ship as v1.5.3.

### #119 — preview pane stays blank after generation
- The results-page `<img>` retry loop on `/api/job/<id>/preview/{heightmap,surface}` trips the 60-req/min `/api/*` general limit and locks itself in a 429 cascade (6–10 ms gaps in the reporter's docker log) — previews never paint.
- Skip rate-limiting for `/api/job/*/preview/*` in `webapp/middleware/rate_limit.py`. Same shape as the existing `/api/health` exemption; session ownership is already enforced inside `get_preview()`.

### #120 — Heightmap import dialog leaves a flat terrain (documentation half)
- Inspected the reporter's project (`Worlds/Terrain/.EditorData/HeightMap.desc`): Workbench wrote `ResampleMinHeight 0 / ResampleMaxHeight 1 / Flags 1`. Those are the Import Height Map dialog defaults.
- Their `heightmap.asc` actually ranges from **-1.98 m to +23.29 m** (Halland Vädero is a coastal island; 88% of the cells are seabed). The dialog defaults silently flatten that to a 0–1 m strip.
- The previous SETUP_GUIDE Step 2.2 only documented the Invert X/Z axis checkboxes and left every other field on its defaults.
- New table for the dialog includes the project's real Min/Max height (from `Reference/metadata.json`), an explicit "UNCHECK *Resample to specified range*" line, and a narrative explaining the default-trap. Also clarifies that the post-import save must be **File > Save World** (Ctrl+S), not the Terrain Tool's Save button — the reporter's console.log shows exactly the latter case.
- **This is only the documentation half of #120.** The NVTT cubemap crash on reopen has the same trigger sequence in the report; without a local Workbench I cannot prove it's the env_probe / cubemap baker / something else, so the emission-side "rethink" (drop env_probe in default.layer, etc.) is held until we know whether the import-dialog fix alone clears the crash.

## Test plan
- [x] `pytest webapp/tests/test_rate_limit_middleware.py` — 8/8 pass (incl. new `test_preview_endpoints_are_not_rate_limited`).
- [x] `pytest webapp/tests/test_setup_guide_generator.py` — 14/14 pass (incl. new `TestHeightmapImportStep::test_heightmap_phase_states_real_min_and_max_height` and `…_warns_about_dialog_defaults`).
- [x] Full suite: 358 passed, 6 pre-existing failures in `test_utils.py` / `test_feature_extractor.py` / `test_lantmateriet.py` confirmed unrelated by `git stash` retest against the parent commit.
- [ ] End-to-end uvicorn run: kick off a generation, confirm both preview panes paint and the log has zero 429s on `/api/job/*/preview/*` after `status=completed`.
- [ ] Ask reporter (#120) to regenerate against v1.5.3, follow the new Step 2.2 (UNCHECK Resample, enter real Min/Max), and report whether reopen still crashes.

Closes #119. Refs #120 (the NVTT crash side stays open pending reporter retest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)