### PR TITLE
v1.5.5: bump version (PR #124 + #125)

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ The application is published to GitHub Container Registry and automatically buil
 docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:latest
 
 # Or use a specific version tag
-docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.5.0
+docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.5.5
 ```
 
 The `docker-compose.yml` is pre-configured to use the GHCR.io image. See the [Quick Start Guide](#quick-start-guide) for setup instructions.

--- a/webapp/config/enfusion.py
+++ b/webapp/config/enfusion.py
@@ -15,7 +15,7 @@ Community Wiki (community.bistudio.com) as of 2025-02-09.
 # enfusion_project_generator.py to stamp into every generated file header.
 # Bump here on every release; the README Docker tag pin should match.
 
-APP_VERSION = "1.5.4"
+APP_VERSION = "1.5.5"
 
 # ---------------------------------------------------------------------------
 # Base game dependency


### PR DESCRIPTION
## Summary
- Bump `APP_VERSION` 1.5.4 → 1.5.5 and README docker tag pin to match
- Bundles two production-driven fixes against issue #118:
  - [#124](https://github.com/tubalainen/arma_reforger_base_map_generator_ng/pull/124) STAC Bild tile-read retries + 6-worker cap to survive `dl1.lantmateriet.se` connection drops
  - [#125](https://github.com/tubalainen/arma_reforger_base_map_generator_ng/pull/125) Collapse satellite reproject's per-band loop into one multi-band parallel warp (~27s → ~9s)

## Test plan
- [ ] Image builds cleanly via GHCR workflow
- [ ] Generated `.gproj`/`.ent`/`.layer`/`SETUP_GUIDE.md` headers stamp `v1.5.5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)