### PR TITLE
v1.5.7: restore GenericWorldEntity world block in default.layer (closes #122)

### DIFF
--- a/webapp/config/enfusion.py
+++ b/webapp/config/enfusion.py
@@ -15,7 +15,7 @@ Community Wiki (community.bistudio.com) as of 2025-02-09.
 # enfusion_project_generator.py to stamp into every generated file header.
 # Bump here on every release; the README Docker tag pin should match.
 
-APP_VERSION = "1.5.6"
+APP_VERSION = "1.5.7"
 
 # ---------------------------------------------------------------------------
 # Base game dependency
@@ -33,17 +33,41 @@ VALID_ENFUSION_VERTEX_COUNTS = [f + 1 for f in VALID_ENFUSION_FACE_COUNTS]
 # => [129, 257, 513, 1025, 2049, 4097, 8193]
 
 # ---------------------------------------------------------------------------
-# Default world entity settings — REMOVED in v1.5.0
+# GenericWorldEntity environment materials — restored in v1.5.7 (issue #122)
 # ---------------------------------------------------------------------------
-# The pre-1.5 generator emitted a hand-built `GenericWorldEntity { SkyPreset
-# { … } PlanetPresets { … } SkyVolCloudsRenderer { … } OceanPreset { … } }`
-# block at the top of every `_default.layer`. Inspection of a Workbench-saved
-# reference layer (Testprojekt/Worlds/testworld_Layers/default.layer) shows
-# none of those classes exist in the current Reforger schema — the parser
-# rejects each one as "Unknown class" and discards everything in the layer
-# that followed. We now emit no environment block at all and let Workbench
-# rebuild the `GenericWorldEntity world { BSP … boundMins … }` block on its
-# own at first save. See issue #111.
+# The v1.5.0 fix for #111 removed the entire environment block because the
+# pre-1.5 form (`SkyPreset { … } PlanetPresets { … } SkyVolCloudsRenderer { … }
+# OceanPreset { … }` as top-level siblings, with wrong class names) was
+# rejected by Workbench as "Unknown class". That was an over-correction —
+# every shipped Reforger map begins `default.layer` with a
+# `GenericWorldEntity world { SkyPreset "…"; PlanetPreset { … }; CloudsRenderer
+# SkyVolCloudsRenderer; CloudsPreset "…"; LensFlaresConfig "…" }` block
+# (verified against BohemiaInteractive/Arma-Reforger-Samples and the Utflandia
+# community map). v1.5.7 emits the correct form. The paint-crash root cause
+# was the inline TerrainGridSizeX/Z + GridCellSize props on the terrain
+# entity (still removed; tested in test_atlas2_alignment.py).
+#
+# Ocean materials (OceanMaterial/Simulation, WaterSimulation, ShoreSimulation)
+# are intentionally NOT shipped. Per Atlas 2 p.5, the user drags the ocean
+# materials onto the GenericWorldEntity's Environment tab in Workbench when
+# their map needs water.
+
+WORLD_ENV_SKY_PRESET = (
+    "{621C7F2EC2763297}Terrains/Common/Sky/Atmosphere/Atmosphere.emat"
+)
+WORLD_ENV_PLANET_PRESET = [
+    "{7037BF6589EEFD5D}Terrains/Common/Sky/Planets/Sun_01.emat",
+    "{63C716F4064F5D43}Terrains/Common/Sky/Planets/Moon_01.emat",
+    "{C8DD10DC67D45E10}Terrains/Common/Sky/Planets/Stars_01.emat",
+    "{E9A96C987913DBD2}Terrains/Common/Sky/Clouds/Clouds_Distant_Semi01.emat",
+]
+WORLD_ENV_CLOUDS_RENDERER = "SkyVolCloudsRenderer"
+WORLD_ENV_CLOUDS_PRESET = (
+    "{D3683C927920C51D}Terrains/Common/Sky/Clouds/Clouds_Volumetric.emat"
+)
+WORLD_ENV_LENS_FLARES_CONFIG = (
+    "{92489E4CCCB3D82F}Configs/LensFlares/LensFlares.conf"
+)
 
 # ---------------------------------------------------------------------------
 # Terrain LOD defaults — REMOVED in v1.5.0

--- a/webapp/services/enfusion_project_generator.py
+++ b/webapp/services/enfusion_project_generator.py
@@ -32,6 +32,11 @@ from config.enfusion import (
     WORLD_PREFAB_GUIDS,
     WORLD_PREFAB_CLASS,
     WORLD_PREFAB_INSTANCE_NAME,
+    WORLD_ENV_SKY_PRESET,
+    WORLD_ENV_PLANET_PRESET,
+    WORLD_ENV_CLOUDS_RENDERER,
+    WORLD_ENV_CLOUDS_PRESET,
+    WORLD_ENV_LENS_FLARES_CONFIG,
     AMBIENT_SOUND_PREFAB_GUIDS,
     PROJECT_NAME_ALLOWED_CHARS,
     PROJECT_NAME_MAX_LENGTH,
@@ -514,28 +519,52 @@ class EnfusionProjectGenerator:
             f"}}\n"
         )
 
+    def _render_world_env_block(self) -> str:
+        """Render the ``GenericWorldEntity world { … }`` block.
+
+        Verified verbatim against BohemiaInteractive/Arma-Reforger-Samples
+        (Assets_Showcase_Base) and the Utflandia community map. Both reference
+        files begin their default.layer with this exact shape.
+
+        BSP / boundMins / boundMaxs / blockSize are intentionally omitted —
+        they are Workbench-authored spatial data, rebuilt on first save.
+        Ocean materials are omitted by policy; user drags them in via Workbench
+        Environment tab per Atlas 2 p.5.
+        """
+        planets = "\n".join(f'  "{p}"' for p in WORLD_ENV_PLANET_PRESET)
+        return (
+            "GenericWorldEntity world {\n"
+            f' SkyPreset "{WORLD_ENV_SKY_PRESET}"\n'
+            " PlanetPreset {\n"
+            f"{planets}\n"
+            " }\n"
+            f" CloudsRenderer {WORLD_ENV_CLOUDS_RENDERER}\n"
+            f' CloudsPreset "{WORLD_ENV_CLOUDS_PRESET}"\n'
+            f' LensFlaresConfig "{WORLD_ENV_LENS_FLARES_CONFIG}"\n'
+            "}\n"
+        )
+
     def _generate_default_layer(self) -> str:
         """Generate the default layer.
 
-        Mirrors the entity set the editor itself writes in
-        ``testworld_Layers/default.layer`` for the Atlas 2 §"Environment"
-        bootstrap: GenericTerrainEntity (no inline props), Lighting, Fog,
-        Post-processing, EnvProbe. Every line uses the verified per-prefab
-        GUID from ``WORLD_PREFAB_GUIDS``. The reference layer's
-        ``GenericWorldEntity world { BSP … boundMins … boundMaxs …
-        blockSize … }`` block is editor-generated spatial data and is not
-        authored here — Workbench rebuilds it on first save.
+        Mirrors the entity set every shipped Reforger map writes: a
+        ``GenericWorldEntity world { Sky/Planet/Clouds/LensFlares }``
+        block first, then ``GenericTerrainEntity Terrain : "{GUID}…"`` (no
+        inline grid/height props — those live in tileMap.conf), then
+        Lighting, Fog, Post-processing, EnvProbe. The world entity's BSP /
+        bounds / blockSize are Workbench-authored spatial data and are
+        rebuilt on first save.
         """
         center_x = self.terrain_width / 2
         center_z = self.terrain_depth / 2
         camera_y = self.max_elevation + 200
 
-        # Terrain entity carries NO inline grid/height properties — those
-        # live in the per-terrain tileMap.conf Workbench writes via the
-        # right-click → "Create new terrain" action. Emitting them inline
-        # is exactly what triggered the issue #111 paint crash.
         parts = [
-            self._render_prefab_instance(key="terrain"),
+            self._render_world_env_block(),
+            self._render_prefab_instance(
+                key="terrain",
+                instance_name="Terrain",
+            ),
             self._render_prefab_instance(
                 key="lighting",
                 coords=(center_x, camera_y, center_z),

--- a/webapp/tests/test_atlas2_alignment.py
+++ b/webapp/tests/test_atlas2_alignment.py
@@ -263,12 +263,13 @@ class TestBootstrapEntities:
                 f"issue #111 regression: {forbidden} still emitted inline"
             )
 
-    def test_default_layer_omits_unknown_environment_classes(self):
-        """Pre-1.5 wrote a hand-built ``GenericWorldEntity { SkyPreset { … }
-        PlanetPresets { … } SkyVolCloudsRenderer { … } OceanPreset { … } }``
-        block. All four classes report as "Unknown class" in current
-        Workbench (Gunnar's error.log). The saved-by-editor reference has
-        no environment block at all — Workbench rebuilds it on save.
+    def test_default_layer_starts_with_generic_world_entity(self):
+        """Issue #122: every shipped Reforger default.layer begins with a
+        ``GenericWorldEntity world { Sky/Planet/Clouds/LensFlares }`` block.
+        Verified against BohemiaInteractive/Arma-Reforger-Samples and the
+        Utflandia community map. Pre-1.5 emitted a broken sibling form that
+        Workbench rejected; v1.5.0-1.5.6 dropped the block entirely (an
+        over-correction); v1.5.7 emits the correct nested form.
         """
         from services.enfusion_project_generator import EnfusionProjectGenerator
 
@@ -276,12 +277,58 @@ class TestBootstrapEntities:
             map_name="TestMap", metadata=_metadata_for_4km(),
         )
         layer = gen._generate_default_layer()
-        for forbidden in (
-            "SkyPreset", "PlanetPresets", "SkyVolCloudsRenderer", "OceanPreset",
+        assert layer.startswith("GenericWorldEntity world {\n"), (
+            "default.layer must begin with the world-entity block"
+        )
+        # Required environment property assignments — exact spelling matters,
+        # Workbench rejects "PlanetPresets" (plural) as Unknown class.
+        for needed in (
+            'SkyPreset "{621C7F2EC2763297}',
+            "PlanetPreset {",                 # singular, sub-block
+            "CloudsRenderer SkyVolCloudsRenderer",
+            'CloudsPreset "{D3683C927920C51D}',
+            'LensFlaresConfig "{92489E4CCCB3D82F}',
         ):
-            assert forbidden not in layer, (
-                f"issue #111 regression: {forbidden} still emitted"
+            assert needed in layer, (
+                f"#122 regression: world-entity block missing {needed!r}"
             )
+        # Ocean materials are deliberately not shipped — user adds them in
+        # Workbench's Environment tab per Atlas 2 p.5.
+        for absent in ("OceanMaterial", "OceanSimulation", "WaterSimulation",
+                       "ShoreSimulation"):
+            assert absent not in layer, (
+                f"Ocean material {absent} was emitted but policy says omit"
+            )
+
+    def test_default_layer_terrain_has_instance_name(self):
+        """The two reference layers both give the terrain entity an explicit
+        instance name (``Terrain`` in BI's Assets_Showcase, ``Terrain_Island``
+        in Utflandia). We use ``Terrain`` to match the BI sample.
+        """
+        from services.enfusion_project_generator import EnfusionProjectGenerator
+
+        gen = EnfusionProjectGenerator(
+            map_name="TestMap", metadata=_metadata_for_4km(),
+        )
+        layer = gen._generate_default_layer()
+        assert (
+            'GenericTerrainEntity Terrain : '
+            '"{221ABC927C672E4E}Prefabs/World/DefaultWorld/GenericTerrain_Default.et"'
+        ) in layer, "terrain entity must carry the instance name 'Terrain'"
+
+    def test_default_layer_has_balanced_braces(self):
+        """Sanity check: the world-entity block plus its PlanetPreset
+        sub-block plus all five anonymous entity blocks must balance.
+        """
+        from services.enfusion_project_generator import EnfusionProjectGenerator
+
+        gen = EnfusionProjectGenerator(
+            map_name="TestMap", metadata=_metadata_for_4km(),
+        )
+        layer = gen._generate_default_layer()
+        assert layer.count("{") == layer.count("}"), (
+            "brace mismatch in default.layer — check world-entity nesting"
+        )
 
     def test_no_legacy_fabricated_prefab_names_anywhere(self):
         """Make sure the fabricated `_<width>m` road names from v1.3.x are


### PR DESCRIPTION
## Summary

- Adds the missing `GenericWorldEntity world { Sky/Planet/Clouds/LensFlares }` block as the first entity in every generated `default.layer`. Verified against [BohemiaInteractive/Arma-Reforger-Samples](https://github.com/BohemiaInteractive/Arma-Reforger-Samples/blob/main/SampleMod_Main/Worlds/Modding/Assets_Showcase_Base_Layers/default.layer) and the [Utflandia community map](https://github.com/pgshka/Utflandia/blob/main/Map/Utflandia/Worlds/Utflandia_Layers/default.layer) — both contain this block in the exact shape we now emit.
- Gives the terrain entity an explicit `Terrain` instance name (matches the BI sample).
- `BSP` / `boundMins` / `boundMaxs` / `blockSize` are intentionally omitted — Workbench rebuilds them on first save.
- Ocean materials are intentionally omitted — per Atlas 2 p.5, the user drags them in via the Environment tab if their map needs water.

## Background

v1.5.0 removed the entire environment block while fixing the paint-crash (#111). The pre-1.5 form was actually broken (top-level sibling classes with wrong names like `PlanetPresets` plural), so dropping it fixed the symptom — but real shipped Reforger maps DO have a `GenericWorldEntity world { ... }` block, just in the correct nested form. This PR restores the correct shape. The inline `TerrainGridSizeX/Z` / `GridCellSize` removal that actually fixed #111 stays.

Closes #122.

## Test plan

- [x] `pytest webapp/tests/test_atlas2_alignment.py -v` — 26 passed (3 new regressions added)
- [x] `pytest webapp/tests/{test_enfusion_project_generator,test_atlas2_alignment,test_enfusion_roads_layer,test_setup_guide_generator}.py` — 56 passed
- [ ] In Workbench: open a generated project, confirm Hierarchy now shows `world - GenericWorldEntity` with Sky/Planet/Clouds pre-populated on its Environment tab, save, confirm Workbench fills in BSP / bounds, paint a surface (regression check for #111).

🤖 Generated with [Claude Code](https://claude.com/claude-code)