### PR TITLE
v1.5.8: detect broken Overpass mirrors (closes #131)

### DIFF
--- a/webapp/config/enfusion.py
+++ b/webapp/config/enfusion.py
@@ -15,7 +15,7 @@ Community Wiki (community.bistudio.com) as of 2025-02-09.
 # enfusion_project_generator.py to stamp into every generated file header.
 # Bump here on every release; the README Docker tag pin should match.
 
-APP_VERSION = "1.5.7"
+APP_VERSION = "1.5.8"
 
 # ---------------------------------------------------------------------------
 # Base game dependency

--- a/webapp/services/osm_service.py
+++ b/webapp/services/osm_service.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from datetime import datetime
 from typing import Optional
 
 import httpx
@@ -62,6 +63,24 @@ def _endpoint_label(url: str) -> str:
         return urlparse(url).hostname or url
     except Exception:
         return url
+
+
+def _is_valid_iso_timestamp(value: str) -> bool:
+    """Check that an Overpass `timestamp_osm_base` string parses as an ISO date.
+
+    Healthy mirrors return values like "2026-05-06T03:25:00Z". Broken mirrors
+    have been observed (issue #131) returning bare integers like "114277"
+    alongside an empty `elements` array.
+    """
+    if not isinstance(value, str) or not value:
+        return False
+    try:
+        # fromisoformat doesn't accept the trailing "Z" before Python 3.11,
+        # so strip it. Anything that parses is good enough.
+        datetime.fromisoformat(value.rstrip("Z"))
+        return True
+    except ValueError:
+        return False
 
 
 async def _run_overpass_query(query: str, max_retries: int = 2, job=None) -> Optional[dict]:
@@ -121,6 +140,40 @@ async def _run_overpass_query(query: str, max_retries: int = 2, job=None) -> Opt
                             result = resp.json()
                             element_count = len(result.get("elements", []))
                             data_size_kb = len(resp.content) / 1024
+
+                            # Reject broken/stale mirrors: timestamp_osm_base must be a parseable
+                            # ISO date. Observed 2026-05-18 (issue #131): overpass.osm.ch returned
+                            # 200 OK with `timestamp_osm_base: "114277"` and zero elements for every
+                            # query, masking a genuine result on the next mirror.
+                            timestamp = result.get("osm3s", {}).get("timestamp_osm_base", "")
+                            if not _is_valid_iso_timestamp(timestamp):
+                                logger.warning(
+                                    f"Overpass [{label}] returned corrupt timestamp_osm_base "
+                                    f"({timestamp!r}) — treating as broken mirror, trying next..."
+                                )
+                                if job:
+                                    job.add_log(
+                                        f"Overpass mirror [{label}] returned corrupt data, trying next...",
+                                        "warning",
+                                    )
+                                continue
+
+                            # Soft-error detection: Overpass returns 200 OK with a `remark` field
+                            # for runtime errors (timeouts, memory limits). If elements is empty
+                            # AND remark is present, treat as failure rather than "no data here".
+                            remark = result.get("remark", "")
+                            if element_count == 0 and remark:
+                                logger.warning(
+                                    f"Overpass [{label}] returned 0 elements with remark "
+                                    f"({remark!r}) — treating as soft failure, trying next..."
+                                )
+                                if job:
+                                    job.add_log(
+                                        f"Overpass mirror [{label}] soft error: {remark}",
+                                        "warning",
+                                    )
+                                continue
+
                             logger.info(
                                 f"Successfully fetched {query_type} from Overpass [{label}]: "
                                 f"{element_count} elements, {data_size_kb:.1f} KB"


### PR DESCRIPTION
## Summary

- Closes #131 — road generation silently produced empty results because `overpass.osm.ch` is currently returning 200 OK with `timestamp_osm_base: \"114277\"` and an empty `elements` array for every query. We accepted the bad response as definitive and never fell through to the working mirrors.
- Add two stacked guards in `_run_overpass_query`:
  1. **Corrupt-timestamp guard.** If `osm3s.timestamp_osm_base` doesn't parse as an ISO date, treat as broken mirror and try the next one.
  2. **Remark guard.** If `elements` is empty AND `remark` is present, treat as a soft Overpass error (timeout/memory limit) and try the next mirror.
- Bump `APP_VERSION` to `1.5.8`.

Both checks only trip on already-suspicious responses, so legitimately empty bboxes (e.g. a polygon in the middle of the ocean) still terminate after one mirror without hammering the pool.

## Repro (osm.ch right now)

```
$ curl -s -X POST https://overpass.osm.ch/api/interpreter \
    --data-urlencode 'data=[out:json][timeout:60][bbox:59.179,15.694,59.210,15.755];(way[\"highway\"];);out body geom;'
{
  \"version\": 0.6,
  \"generator\": \"Overpass API 0.7.59.1 2a9d9642\",
  \"osm3s\": { \"timestamp_osm_base\": \"114277\", ... },
  \"elements\": []
}
```

Same query against `kumi.systems` (mirror 3) returns 78 ways with a healthy `timestamp_osm_base: \"2026-05-06T03:25:00Z\"`.

## Test plan

- [ ] Verify a Sweden generation that previously returned 0 roads (reporter's bbox) now returns roads on v1.5.8.
- [ ] Verify a legitimately empty bbox (e.g. middle of the Baltic) still completes without infinite mirror cycling.
- [ ] Verify the warning log fires (`Overpass [osm.ch] returned corrupt timestamp_osm_base ...`) and the next mirror is tried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)