### PR TITLE
v1.5.9: square-only selection toolbar with live edit (closes #128)

### DIFF
--- a/webapp/config/enfusion.py
+++ b/webapp/config/enfusion.py
@@ -15,7 +15,7 @@ Community Wiki (community.bistudio.com) as of 2025-02-09.
 # enfusion_project_generator.py to stamp into every generated file header.
 # Bump here on every release; the README Docker tag pin should match.
 
-APP_VERSION = "1.5.8"
+APP_VERSION = "1.5.9"
 
 # ---------------------------------------------------------------------------
 # Base game dependency

--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -38,10 +38,10 @@
                 <div class="sidebar-section">
                     <h6><i class="bi bi-vector-pen"></i> Area Selection</h6>
                     <p class="small mb-2">
-                        Use one of the drawing tools on the map &mdash;
-                        <strong>rectangle</strong> or
-                        <strong>1:1 square</strong> (recommended for Enfusion).
-                        Enfusion only supports square / rectangular terrain.
+                        Click the <strong>square</strong> tool on the map and drag
+                        out a 1:1 area. Once placed, drag the centre handle to move
+                        it or the corner handles to resize &mdash; no separate edit
+                        step. Use the <strong>trash</strong> tool to clear.
                     </p>
                     <div id="selection-info" class="d-none">
                         <table class="table table-sm table-dark mb-1">
@@ -58,17 +58,14 @@
                                 <td id="info-size">-</td>
                             </tr>
                         </table>
-                        <div id="area-warning" class="alert alert-danger py-1 px-2 mb-1 small d-none">
+                        <div id="area-warning" class="alert alert-danger py-1 px-2 mb-0 small d-none">
                             <i class="bi bi-exclamation-triangle-fill"></i>
                             <span id="area-warning-text"></span>
-                        </div>
-                        <div id="aspect-warning" class="alert alert-info py-1 px-2 mb-0 small d-none">
-                            <span id="aspect-warning-text"></span>
                         </div>
                     </div>
                     <div id="no-selection" class="text-center py-3">
                         <i class="bi bi-hand-index-thumb"></i>
-                        <p class="small mt-1">Pick a drawing tool to start</p>
+                        <p class="small mt-1">Pick the square tool to start</p>
                     </div>
                 </div>
 

--- a/webapp/static/js/app.js
+++ b/webapp/static/js/app.js
@@ -79,6 +79,9 @@ map.addLayer(drawnItems);
 // ---------------------------------------------------------------------------
 // Square drawing tool (custom Leaflet.Draw handler)
 // Forces 1:1 aspect ratio in metres so Enfusion heightmap isn't distorted.
+// Only square selections are supported — Enfusion World Editor only handles
+// square / rectangular terrain (issue #50) and the workflow defaults to
+// square. Rectangles were removed in v1.5.9 (issue #128).
 // ---------------------------------------------------------------------------
 const SHAPE_STYLE = {
     color: '#26cd4d',
@@ -87,10 +90,30 @@ const SHAPE_STYLE = {
     weight: 2,
 };
 
+const M_PER_DEG_LAT = 111320;
+function mPerDegLng(lat) {
+    return 111320 * Math.cos(lat * Math.PI / 180);
+}
+
+// Given a fixed corner and a free corner, return the bounds of the
+// largest square (in metres) that fits the dragged extent. Used by both
+// the draw handler (free corner = cursor) and the edit handler (free corner
+// = dragged resize marker).
+function squareBoundsFrom(fixed, free) {
+    const dLat = free.lat - fixed.lat;
+    const dLng = free.lng - fixed.lng;
+    const mLat = M_PER_DEG_LAT;
+    const mLng = mPerDegLng((fixed.lat + free.lat) / 2);
+    const sizeM = Math.max(Math.abs(dLng) * mLng, Math.abs(dLat) * mLat);
+    const newCorner = L.latLng(
+        fixed.lat + (dLat >= 0 ? 1 : -1) * (sizeM / mLat),
+        fixed.lng + (dLng >= 0 ? 1 : -1) * (sizeM / mLng),
+    );
+    return L.latLngBounds(fixed, newCorner);
+}
+
 L.Draw.Square = L.Draw.Rectangle.extend({
-    statics: {
-        TYPE: 'square'
-    },
+    statics: { TYPE: 'square' },
 
     options: {
         shapeOptions: { ...SHAPE_STYLE },
@@ -105,85 +128,77 @@ L.Draw.Square = L.Draw.Rectangle.extend({
     _drawShape: function (latlng) {
         const start = this._startLatLng;
         if (!start) return;
-
-        const dLat = latlng.lat - start.lat;
-        const dLng = latlng.lng - start.lng;
-
-        const midLat = (start.lat + latlng.lat) / 2;
-        const mPerDegLat = 111320;
-        const mPerDegLng = 111320 * Math.cos(midLat * Math.PI / 180);
-
-        const widthM = Math.abs(dLng) * mPerDegLng;
-        const heightM = Math.abs(dLat) * mPerDegLat;
-        const sizeM = Math.max(widthM, heightM);
-
-        const halfLngSpan = (sizeM / mPerDegLng);
-        const halfLatSpan = (sizeM / mPerDegLat);
-
-        const endLng = start.lng + (dLng >= 0 ? halfLngSpan : -halfLngSpan);
-        const endLat = start.lat + (dLat >= 0 ? halfLatSpan : -halfLatSpan);
-
+        const bounds = squareBoundsFrom(start, latlng);
         if (!this._shape) {
-            this._shape = new L.Rectangle(
-                new L.LatLngBounds(start, new L.LatLng(endLat, endLng)),
-                this.options.shapeOptions
-            );
+            this._shape = new L.Rectangle(bounds, this.options.shapeOptions);
             this._map.addLayer(this._shape);
         } else {
-            this._shape.setBounds(
-                new L.LatLngBounds(start, new L.LatLng(endLat, endLng))
-            );
+            this._shape.setBounds(bounds);
         }
     },
 });
 
-L.drawLocal.draw.toolbar.buttons.square = 'Draw a square area (recommended)';
+L.drawLocal.draw.toolbar.buttons.square = 'Draw a square area';
 
-// Standard draw toolbar (rectangle + edit/remove). The Square button is
-// injected into the same toolbar below so both drawing tools live in one
-// uniform control group. The Enfusion World Editor only supports
-// square / rectangular terrain (issue #50), so the polygon tool is
-// disabled.
-const drawControl = new L.Control.Draw({
-    position: 'topleft',
-    draw: {
-        polygon: false,
-        rectangle: {
-            shapeOptions: { ...SHAPE_STYLE },
-        },
-        polyline: false,
-        circle: false,
-        circlemarker: false,
-        marker: false,
-    },
-    edit: {
-        featureGroup: drawnItems,
-        remove: true,
+// Square-aware edit handler: corner-drag preserves 1:1 aspect ratio so the
+// shape stays a square while the user adjusts its size. The center marker
+// (inherited from L.Edit.SimpleShape) handles moves without modification.
+L.Edit.Square = L.Edit.Rectangle.extend({
+    _resize: function (latlng) {
+        const bounds = squareBoundsFrom(this._oppositeCorner, latlng);
+        this._shape.setBounds(bounds);
+        this._moveMarker.setLatLng(bounds.getCenter());
     },
 });
-map.addControl(drawControl);
 
-// Inject a Square button into the same toolbar row as rectangle.
-// Using the existing Leaflet.Draw toolbar gives us identical sizing, borders,
-// and hover styling — see issue #40.
-(function addSquareToolButton() {
-    const rectButton = document.querySelector('.leaflet-draw-draw-rectangle');
-    if (!rectButton || !rectButton.parentNode) return;
-    if (rectButton.parentNode.querySelector('.leaflet-draw-draw-square')) return;
+// Custom selection toolbar (replaces L.Control.Draw entirely so the UI
+// only exposes the two buttons that make sense for this workflow):
+//   • Square — start drawing a new 1:1 selection
+//   • Delete — clear the current selection (no two-step "remove mode")
+// Re-uses Leaflet.Draw's CSS classes so styling matches the rest of the app.
+const SelectionToolbar = L.Control.extend({
+    options: { position: 'topleft' },
 
-    const link = document.createElement('a');
-    link.className = 'leaflet-draw-draw-square';
-    link.href = '#';
-    link.title = 'Draw a square area (recommended for Enfusion)';
-    link.setAttribute('role', 'button');
+    onAdd: function () {
+        const container = L.DomUtil.create(
+            'div', 'leaflet-draw leaflet-control');
 
-    L.DomEvent.on(link, 'click', function (e) {
-        L.DomEvent.stop(e);
-        new L.Draw.Square(map, { shapeOptions: { ...SHAPE_STYLE } }).enable();
-    });
+        const drawSection = L.DomUtil.create(
+            'div', 'leaflet-draw-section', container);
+        const drawToolbar = L.DomUtil.create(
+            'div', 'leaflet-draw-toolbar leaflet-bar', drawSection);
+        const squareBtn = L.DomUtil.create(
+            'a', 'leaflet-draw-draw-square', drawToolbar);
+        squareBtn.href = '#';
+        squareBtn.title = 'Draw a square area';
+        squareBtn.setAttribute('role', 'button');
 
-    rectButton.parentNode.insertBefore(link, rectButton.nextSibling);
-})();
+        const editSection = L.DomUtil.create(
+            'div', 'leaflet-draw-section', container);
+        const editToolbar = L.DomUtil.create(
+            'div', 'leaflet-draw-toolbar leaflet-bar', editSection);
+        const deleteBtn = L.DomUtil.create(
+            'a', 'leaflet-draw-edit-remove', editToolbar);
+        deleteBtn.href = '#';
+        deleteBtn.title = 'Clear selection';
+        deleteBtn.setAttribute('role', 'button');
+
+        L.DomEvent.on(squareBtn, 'click', function (e) {
+            L.DomEvent.stop(e);
+            new L.Draw.Square(map, { shapeOptions: { ...SHAPE_STYLE } }).enable();
+        });
+
+        L.DomEvent.on(deleteBtn, 'click', function (e) {
+            L.DomEvent.stop(e);
+            clearSelection();
+        });
+
+        L.DomEvent.disableClickPropagation(container);
+        return container;
+    },
+});
+
+map.addControl(new SelectionToolbar());
 
 // ===========================================================================
 // State
@@ -204,39 +219,67 @@ let logsSinceCursor = 0;
 // Event handlers
 // ===========================================================================
 
-map.on(L.Draw.Event.CREATED, function (event) {
-    // Only rectangle / square selections are supported — Enfusion World Editor
-    // can only build square or rectangular terrain (issue #50).
-    if (event.layerType !== 'rectangle' && event.layerType !== 'square') {
-        return;
-    }
-
-    // Clear previous selection
-    drawnItems.clearLayers();
-
-    const layer = event.layer;
-    drawnItems.addLayer(layer);
-    currentPolygon = layer;
-
-    // Extract bbox corners as [lng, lat] pairs (closed ring)
-    const bounds = layer.getBounds();
-    const coords = [
+function boundsToCoords(bounds) {
+    // Closed ring as [lng, lat] pairs.
+    return [
         [bounds.getWest(), bounds.getSouth()],
         [bounds.getEast(), bounds.getSouth()],
         [bounds.getEast(), bounds.getNorth()],
         [bounds.getWest(), bounds.getNorth()],
         [bounds.getWest(), bounds.getSouth()],
     ];
+}
 
-    currentPolygonCoords = coords;
-    onPolygonSelected(coords);
+map.on(L.Draw.Event.CREATED, function (event) {
+    if (event.layerType !== 'square') return;
+
+    // Replace any previous selection.
+    drawnItems.clearLayers();
+
+    const layer = event.layer;
+    drawnItems.addLayer(layer);
+    currentPolygon = layer;
+
+    currentPolygonCoords = boundsToCoords(layer.getBounds());
+    onPolygonSelected(currentPolygonCoords);
+
+    // Make the new square immediately editable — the user can drag the
+    // center handle to move it or any corner handle to resize, without
+    // pressing a separate "edit" button (issue #128).
+    enableLiveEditing(layer);
 });
 
-map.on(L.Draw.Event.DELETED, function () {
-    currentPolygon = null;
-    currentPolygonCoords = null;
-    onPolygonCleared();
-});
+function enableLiveEditing(layer) {
+    // Swap in the square-aware edit handler (Leaflet auto-attaches the
+    // standard L.Edit.Rectangle in an init hook). Always disable the
+    // existing handler before replacing — otherwise its markers leak.
+    if (layer.editing) layer.editing.disable();
+    layer.editing = new L.Edit.Square(layer);
+    layer.editing.enable();
+
+    // Update the sidebar bbox / size readout live while the user drags.
+    // Country detection only fires after the drag ends so we don't spam
+    // the detect-countries endpoint on every mousemove.
+    const handler = layer.editing;
+    const markers = [
+        ...(handler._resizeMarkers || []),
+        handler._moveMarker,
+    ].filter(Boolean);
+
+    const liveUpdate = () => {
+        currentPolygonCoords = boundsToCoords(layer.getBounds());
+        updateSelectionDisplay(currentPolygonCoords);
+    };
+    const finishEdit = () => {
+        currentPolygonCoords = boundsToCoords(layer.getBounds());
+        onPolygonSelected(currentPolygonCoords);
+    };
+
+    markers.forEach((m) => {
+        m.on('drag', liveUpdate);
+        m.on('dragend', finishEdit);
+    });
+}
 
 // ===========================================================================
 // UI handlers
@@ -267,11 +310,10 @@ document.getElementById('grid-resolution').addEventListener('change', updateTerr
 
 const MAX_MAP_EXTENT_KM = 32; // must match MAX_MAP_EXTENT_M in config/terrain.py
 
-function onPolygonSelected(coords) {
+function updateSelectionDisplay(coords) {
     document.getElementById('selection-info').classList.remove('d-none');
     document.getElementById('no-selection').classList.add('d-none');
 
-    // Compute bounding box
     const lngs = coords.map(c => c[0]);
     const lats = coords.map(c => c[1]);
     const west = Math.min(...lngs);
@@ -282,15 +324,11 @@ function onPolygonSelected(coords) {
     document.getElementById('info-bbox').textContent =
         `${south.toFixed(4)}, ${west.toFixed(4)} - ${north.toFixed(4)}, ${east.toFixed(4)}`;
 
-    // Estimate size in km
-    const dLat = north - south;
-    const dLng = east - west;
-    const latKm = dLat * 111;
-    const lngKm = dLng * 111 * Math.cos((north + south) / 2 * Math.PI / 180);
+    const latKm = (north - south) * 111;
+    const lngKm = (east - west) * 111 * Math.cos((north + south) / 2 * Math.PI / 180);
     document.getElementById('info-size').textContent =
         `~${lngKm.toFixed(1)} x ${latKm.toFixed(1)} km`;
 
-    // Check area limit
     const warning = document.getElementById('area-warning');
     const warningText = document.getElementById('area-warning-text');
     if (lngKm > MAX_MAP_EXTENT_KM || latKm > MAX_MAP_EXTENT_KM) {
@@ -302,24 +340,10 @@ function onPolygonSelected(coords) {
         warning.classList.add('d-none');
         document.getElementById('btn-generate').disabled = false;
     }
+}
 
-    // Check aspect ratio — inform user about non-square terrain
-    const aspectWarning = document.getElementById('aspect-warning');
-    const aspectWarningText = document.getElementById('aspect-warning-text');
-    const aspectRatio = Math.max(lngKm, latKm) / Math.min(lngKm, latKm);
-    if (aspectRatio > 1.05) {
-        // More than 5% off from square — show info about non-square terrain
-        aspectWarningText.innerHTML =
-            `<i class="bi bi-info-circle-fill"></i> ` +
-            `Non-square selection detected (${lngKm.toFixed(1)} x ${latKm.toFixed(1)} km). ` +
-            `The terrain will use different vertex counts per axis to match the area's aspect ratio ` +
-            `(no stretching or distortion).`;
-        aspectWarning.classList.remove('d-none');
-    } else {
-        aspectWarning.classList.add('d-none');
-    }
-
-    // Detect countries (quick bbox check)
+function onPolygonSelected(coords) {
+    updateSelectionDisplay(coords);
     detectCountries(coords);
 }
 
@@ -332,6 +356,9 @@ function onPolygonCleared() {
 }
 
 function clearSelection() {
+    if (currentPolygon && currentPolygon.editing) {
+        currentPolygon.editing.disable();
+    }
     drawnItems.clearLayers();
     currentPolygon = null;
     currentPolygonCoords = null;


### PR DESCRIPTION
## Summary
- Strip the map selection toolbar down to two buttons — **Square (1:1)** and **Trash** — and drop the rectangle tool entirely. Aspect-ratio warning plumbing goes with it.
- New square is **immediately editable**: corner handles resize while preserving 1:1 (via a new `L.Edit.Square` subclass overriding `_resize`), centre handle moves it. No "edit" button.
- Trash button is wired straight to `clearSelection()` — single click, no two-step remove-mode UX. Sidebar Clear Selection button still works too.
- Replaces `L.Control.Draw` with a small custom `L.Control` that re-uses Leaflet.Draw's CSS classes so styling stays consistent. Sidebar bbox/size updates live during drag; country detection only fires on drag end.

Closes #128.

## Test plan
- [ ] Square button on the map toolbar starts a new 1:1 draw; releasing the mouse leaves a square with visible corner + centre handles (no need to press an edit button).
- [ ] Dragging a corner resizes while staying square; dragging the centre moves it.
- [ ] Sidebar bbox/size updates live during drag; "Countries" row only refreshes on mouseup.
- [ ] Trash button on the toolbar clears the selection in one click.
- [ ] Sidebar "Clear Selection" button still clears.
- [ ] Drawing a second square replaces the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)