### PR TITLE
v1.5.10: fix L.Draw.Square layerType regression (hotfix for v1.5.9)

### DIFF
--- a/webapp/config/enfusion.py
+++ b/webapp/config/enfusion.py
@@ -15,7 +15,7 @@ Community Wiki (community.bistudio.com) as of 2025-02-09.
 # enfusion_project_generator.py to stamp into every generated file header.
 # Bump here on every release; the README Docker tag pin should match.
 
-APP_VERSION = "1.5.9"
+APP_VERSION = "1.5.10"
 
 # ---------------------------------------------------------------------------
 # Base game dependency

--- a/webapp/static/js/app.js
+++ b/webapp/static/js/app.js
@@ -121,8 +121,10 @@ L.Draw.Square = L.Draw.Rectangle.extend({
     },
 
     initialize: function (map, options) {
-        this.type = 'square';
         L.Draw.Rectangle.prototype.initialize.call(this, map, options);
+        // Parent's initialize sets this.type = 'rectangle'; override it
+        // AFTER the super call so CREATED events fire with layerType:'square'.
+        this.type = 'square';
     },
 
     _drawShape: function (latlng) {


### PR DESCRIPTION
## Summary
Hotfix for #128 / v1.5.9: the square draw tool drew a rectangle on the map but the shape vanished on mouseup.

**Root cause.** v1.5.9 simplified the `L.Draw.Event.CREATED` handler from the old dual `layerType !== 'rectangle' && !== 'square'` check down to just `!== 'square'`. That assumed our \`L.Draw.Square\` handler fires CREATED with \`layerType: 'square'\` — but it doesn't. \`L.Draw.Square.initialize\` was setting \`this.type = 'square'\` *before* calling \`L.Draw.Rectangle.prototype.initialize\`, and the parent overwrites it with \`this.type = L.Draw.Rectangle.TYPE = 'rectangle'\`. Result: CREATED fires with \`layerType: 'rectangle'\`, the handler early-returns, the temp shape is disposed by Leaflet.Draw on mouseup, nothing replaces it — selection disappears.

**Fix.** In [\`L.Draw.Square.initialize\`](webapp/static/js/app.js), invoke the parent first and set \`this.type = 'square'\` afterwards so it sticks.

Verified end-to-end via the preview server:
- \`new L.Draw.Square(map, ...).type === 'square'\` ✓
- Synthetic CREATED event lands the layer in \`drawnItems\` (1 layer) ✓
- \`L.Edit.Square\` swapped in + enabled with 4 corner handles + 1 move handle ✓
- Asymmetric \`_resize\` from (59.0, 17.0) to (59.05, 17.20) → 11.43 × 11.42 km (0.08% float-rounding between the two m/deg factors) ✓
- Trash button click → drawnItems empty, generate disabled, selection-info hidden ✓

## Test plan
- [ ] Square tool actually leaves a visible square after mouseup.
- [ ] The square has handles immediately — drag a corner to resize (stays 1:1), drag the centre to move.
- [ ] Sidebar bbox / size updates live during drag.
- [ ] Trash icon clears the selection in one click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)