### PR TITLE
v1.5.11: gravel/dirt surface masks use per-feature road classification

### DIFF
--- a/webapp/config/enfusion.py
+++ b/webapp/config/enfusion.py
@@ -15,7 +15,7 @@ Community Wiki (community.bistudio.com) as of 2025-02-09.
 # enfusion_project_generator.py to stamp into every generated file header.
 # Bump here on every release; the README Docker tag pin should match.
 
-APP_VERSION = "1.5.10"
+APP_VERSION = "1.5.11"
 
 # ---------------------------------------------------------------------------
 # Base game dependency

--- a/webapp/services/surface_mask_generator.py
+++ b/webapp/services/surface_mask_generator.py
@@ -323,29 +323,6 @@ def _rasterize_polygons(
     return mask.astype(bool)
 
 
-def _rasterize_lines(
-    features: dict | None,
-    bounds: tuple[float, float, float, float],
-    width: int,
-    height: int,
-    buffer_px: int = 2,
-    filter_tags: dict[str, list[str]] | None = None,
-) -> np.ndarray:
-    """
-    Fast line rasterization wrapper.
-    Returns a boolean mask (True where lines exist, including buffer).
-    """
-    if not features or not features.get("features"):
-        return np.zeros((height, width), dtype=bool)
-
-    mask = rasterize_features_to_mask(
-        features, width, height, bounds,
-        filter_tags=filter_tags,
-        buffer_px=buffer_px,
-    )
-    return mask.astype(bool)
-
-
 # ---------------------------------------------------------------------------
 # Main generation function
 # ---------------------------------------------------------------------------
@@ -444,16 +421,17 @@ def generate_surface_masks(
     if job:
         job.add_log(f"Generating surface masks for {w}x{h} terrain (cell size: {cell_size_m}m)...")
 
-    # Resolution-scaled parameters. Asphalt no longer uses a fixed buffer —
-    # each paved road feature is rasterized at its own OSM-derived width.
+    # Resolution-scaled parameters. All road surfaces (asphalt / gravel / dirt
+    # roads) now rasterize each feature at its own OSM-derived width via
+    # `rasterize_lines_per_feature_width`; only the polygon-derived farmland
+    # dirt layer and the forest/shore soft edges still use scalar widths.
     sigma = max(1.0, 2.0 * (cell_size_m / 2.0))
-    gravel_buffer_px = max(1, int(3.0 / cell_size_m))   # ~3m gravel road half-width
     forest_transition_px = max(3, int(20.0 / cell_size_m))  # ~20m forest edge transition
     sand_transition_px = max(2, int(10.0 / cell_size_m))    # ~10m shoreline transition
 
     logger.debug(
         f"Resolution-scaled params: sigma={sigma:.1f}, "
-        f"gravel_buf={gravel_buffer_px}px, forest_edge={forest_transition_px}px"
+        f"forest_edge={forest_transition_px}px"
     )
 
     # =========================================================================
@@ -500,18 +478,11 @@ def generate_surface_masks(
     # Deciduous = all forest minus coniferous
     deciduous_binary = forest_binary & ~coniferous_binary
 
-    # Paved roads — built later, after `urban_binary` is rasterized, so that
-    # the per-feature surface classification can consult the urban polygons to
-    # decide whether context-dependent highway types (residential / service /
-    # cycleway / unclassified) end up as asphalt vs gravel. See below.
-
-    # Gravel/dirt roads
-    gravel_types = ["track", "path", "footway", "bridleway"]
-    gravel_binary = _rasterize_lines(
-        osm_data.get("roads"), bounds, w, h,
-        buffer_px=gravel_buffer_px,
-        filter_tags={"highway": gravel_types},
-    )
+    # All road surface bitmaps (asphalt / gravel / dirt-roads) are built
+    # later, after `urban_binary` is rasterized, so the per-feature surface
+    # classifier can consult the urban polygons to decide whether context-
+    # dependent highway types (residential / service / cycleway /
+    # unclassified) end up as asphalt vs gravel. See below.
 
     # Water bodies (for sand/shoreline transition)
     if job:
@@ -539,10 +510,20 @@ def generate_surface_masks(
         filter_tags={"type": ["residential", "industrial", "commercial", "retail"]},
     )
 
-    # Paved roads — rasterize each feature at its own width (matching the
+    # Road surfaces — rasterize each feature at its own width (matching the
     # per-feature width used by road_processor when emitting splines) and
-    # classify surface using the same infer_road_surface() helper so the
-    # asphalt mask follows exactly the same road set as the splines.
+    # classify surface using the same infer_road_surface() helper so each
+    # road surface mask follows exactly the same road set as the splines.
+    #
+    # Pre-v1.5.11 only the asphalt mask used this per-feature pipeline;
+    # gravel was built from a fixed `highway in {track,path,footway,bridleway}`
+    # filter which dropped the dominant Swedish-rural case (`highway=service`
+    # with `surface=gravel|unpaved|compacted` — 58 of 78 features in the
+    # tyqklRtexhHYt0o8 export) and dirt-roads weren't rendered at all (only
+    # farmland polygons were). Now all three road surfaces (asphalt, gravel,
+    # dirt) classify each feature through `infer_road_surface()` and share
+    # the same width function, so each OSM road ends up in exactly the mask
+    # that matches its exported spline surface.
     logger.debug("Rasterizing road network (per-feature widths)...")
     if job:
         job.progress = 64
@@ -560,44 +541,65 @@ def generate_surface_masks(
         py = max(0, min(h - 1, py))
         return bool(urban_binary[py, px])
 
-    def _is_asphalt_feature(feature: dict) -> bool:
+    def _classify_road_feature(feature: dict) -> str | None:
+        """Return inferred surface ('asphalt' | 'gravel' | 'dirt') or None for non-roads."""
         geom = feature.get("geometry", {})
         if geom.get("type") not in ("LineString", "MultiLineString"):
-            return False
+            return None
         props = feature.get("properties", {})
         highway = props.get("highway", "")
         if not highway:
-            return False
+            return None
         coords = geom.get("coordinates", [])
         if geom.get("type") == "MultiLineString":
             coords = coords[0] if coords else []
         is_urban = _line_midpoint_in_urban(coords)
-        surface = infer_road_surface(
+        return infer_road_surface(
             highway_type=highway,
             osm_surface=props.get("surface", ""),
             country_code=country_code,
             is_in_forest=False,
             is_in_urban=is_urban,
         )
-        return surface == "asphalt"
 
     def _feature_buffer_px(feature: dict) -> int:
         props = feature.get("properties", {})
+        surface = _classify_road_feature(feature) or "gravel"
         width_m = infer_road_width(
             highway_type=props.get("highway", ""),
             osm_width=props.get("width", ""),
             osm_lanes=props.get("lanes", ""),
-            surface="asphalt",
+            surface=surface,
         )
         return max(1, int(round((width_m / 2.0) / cell_size_m)))
 
+    roads_collection = osm_data.get("roads") or {"features": []}
+
     asphalt_binary = rasterize_lines_per_feature_width(
-        osm_data.get("roads") or {"features": []},
+        roads_collection,
         width=w,
         height=h,
         bbox_wgs84=bounds,
         buffer_px_fn=_feature_buffer_px,
-        filter_fn=_is_asphalt_feature,
+        filter_fn=lambda f: _classify_road_feature(f) == "asphalt",
+    ).astype(bool)
+
+    gravel_binary = rasterize_lines_per_feature_width(
+        roads_collection,
+        width=w,
+        height=h,
+        bbox_wgs84=bounds,
+        buffer_px_fn=_feature_buffer_px,
+        filter_fn=lambda f: _classify_road_feature(f) == "gravel",
+    ).astype(bool)
+
+    dirt_roads_binary = rasterize_lines_per_feature_width(
+        roads_collection,
+        width=w,
+        height=h,
+        bbox_wgs84=bounds,
+        buffer_px_fn=_feature_buffer_px,
+        filter_fn=lambda f: _classify_road_feature(f) == "dirt",
     ).astype(bool)
 
     # =========================================================================
@@ -641,8 +643,12 @@ def generate_surface_masks(
         return soft_edge_mask(gravel_binary, transition_px=2) * 0.8
 
     def _compute_dirt():
-        """Farmland and dirt paths."""
-        return soft_edge_mask(farmland_binary, transition_px=5) * 0.6
+        """Farmland (soft, weighted) plus dirt roads/paths (full strength)."""
+        farmland = soft_edge_mask(farmland_binary, transition_px=5) * 0.6
+        if np.any(dirt_roads_binary):
+            roads = soft_edge_mask(dirt_roads_binary, transition_px=2)
+            return np.maximum(farmland, roads)
+        return farmland
 
     def _compute_sand():
         """Sandy shoreline transition zone around water polygons.

--- a/webapp/tests/test_surface_mask_generator.py
+++ b/webapp/tests/test_surface_mask_generator.py
@@ -87,8 +87,11 @@ def _empty_collection() -> dict:
     return {"type": "FeatureCollection", "features": []}
 
 
-def _run_with(osm_data: dict, tmp_path: Path) -> np.ndarray:
-    """Run generate_surface_masks and return the asphalt mask as a 2-D uint8 array."""
+def _run_and_load(osm_data: dict, tmp_path: Path, surface: str) -> np.ndarray:
+    """Run generate_surface_masks and return the named mask as a 2-D uint8 array.
+
+    Returns a zero array if the mask was skipped (no meaningful coverage).
+    """
     result = generate_surface_masks(
         elevation=_flat_elevation(),
         osm_data=osm_data,
@@ -99,11 +102,15 @@ def _run_with(osm_data: dict, tmp_path: Path) -> np.ndarray:
         heightmap_dimensions=(W, H),
     )
     assert result is not None
-    asphalt_path = tmp_path / "surface_asphalt.png"
-    if not asphalt_path.exists():
-        # The generator skips empty masks; return a zero array.
+    path = tmp_path / f"surface_{surface}.png"
+    if not path.exists():
         return np.zeros((H, W), dtype=np.uint8)
-    return np.array(Image.open(asphalt_path).convert("L"))
+    return np.array(Image.open(path).convert("L"))
+
+
+def _run_with(osm_data: dict, tmp_path: Path) -> np.ndarray:
+    """Run generate_surface_masks and return the asphalt mask as a 2-D uint8 array."""
+    return _run_and_load(osm_data, tmp_path, "asphalt")
 
 
 class TestAsphaltUrbanPolygonsNoLongerPainted:
@@ -254,6 +261,119 @@ class TestAsphaltUsesPerFeatureWidth:
             f"Wider road must produce a thicker asphalt stripe; "
             f"narrow(4m)={narrow_count}, wide(14m)={wide_count}. "
             f"Pre-v1.2.5 both used a fixed 6m buffer regardless of OSM width."
+        )
+
+
+class TestGravelAndDirtMatchRoadProcessorClassification:
+    """v1.5.11: gravel and dirt road masks now classify every OSM road feature
+    through infer_road_surface() (matching the spline export), instead of the
+    old fixed `highway in {track,path,footway,bridleway}` tag filter that
+    dropped the dominant Swedish-rural case (`highway=service` with
+    surface=gravel|unpaved|compacted)."""
+
+    def test_service_road_outside_urban_paints_gravel(self, tmp_path: Path):
+        """Per road_processor.infer_road_surface, 'service' outside urban → gravel."""
+        osm_data = {
+            "roads": {
+                "type": "FeatureCollection",
+                "features": [_road_feature(15.001, 58.0015, 15.004, "service")],
+            },
+            "water": _empty_collection(),
+            "forests": _empty_collection(),
+            "buildings": _empty_collection(),
+            "land_use": _empty_collection(),
+        }
+        gravel = _run_and_load(osm_data, tmp_path, "gravel")
+        assert gravel.sum() > 0, (
+            "A 'service' road outside any urban polygon must paint gravel — "
+            "this is the dominant Swedish-rural case the v1.5.11 fix addresses."
+        )
+
+    def test_service_road_inside_urban_skips_gravel(self, tmp_path: Path):
+        """Same service road inside residential polygon → asphalt, not gravel."""
+        osm_data = {
+            "roads": {
+                "type": "FeatureCollection",
+                "features": [_road_feature(15.001, 58.0015, 15.004, "service")],
+            },
+            "water": _empty_collection(),
+            "forests": _empty_collection(),
+            "buildings": _empty_collection(),
+            "land_use": {
+                "type": "FeatureCollection",
+                "features": [
+                    _landuse_polygon(15.0005, 58.0005, 15.0045, 58.0025, "residential"),
+                ],
+            },
+        }
+        gravel = _run_and_load(osm_data, tmp_path, "gravel")
+        asphalt = _run_and_load(osm_data, tmp_path, "asphalt")
+        assert asphalt.sum() > 0, "service-in-urban must paint asphalt"
+        assert gravel.sum() == 0, (
+            f"service-in-urban must NOT also paint gravel; got {gravel.sum()} px"
+        )
+
+    def test_track_paints_gravel_not_dirt(self, tmp_path: Path):
+        """highway=track defaults to gravel (rules.track_surface_default)."""
+        osm_data = {
+            "roads": {
+                "type": "FeatureCollection",
+                "features": [_road_feature(15.001, 58.0015, 15.004, "track")],
+            },
+            "water": _empty_collection(),
+            "forests": _empty_collection(),
+            "buildings": _empty_collection(),
+            "land_use": _empty_collection(),
+        }
+        gravel = _run_and_load(osm_data, tmp_path, "gravel")
+        dirt = _run_and_load(osm_data, tmp_path, "dirt")
+        assert gravel.sum() > 0, "highway=track must paint gravel"
+        assert dirt.sum() == 0, (
+            f"highway=track must NOT paint dirt; got {dirt.sum()} px"
+        )
+
+    def test_path_paints_dirt_not_gravel(self, tmp_path: Path):
+        """highway=path is unconditionally classified as dirt — pre-v1.5.11
+        it was wrongly painted into the gravel mask by the `gravel_types` list."""
+        osm_data = {
+            "roads": {
+                "type": "FeatureCollection",
+                "features": [_road_feature(15.001, 58.0015, 15.004, "path")],
+            },
+            "water": _empty_collection(),
+            "forests": _empty_collection(),
+            "buildings": _empty_collection(),
+            "land_use": _empty_collection(),
+        }
+        gravel = _run_and_load(osm_data, tmp_path, "gravel")
+        dirt = _run_and_load(osm_data, tmp_path, "dirt")
+        assert dirt.sum() > 0, "highway=path must paint dirt"
+        assert gravel.sum() == 0, (
+            f"highway=path must NOT paint gravel; got {gravel.sum()} px"
+        )
+
+    def test_service_with_explicit_gravel_surface_paints_gravel(self, tmp_path: Path):
+        """OSM `surface=gravel` on a service road in urban context — the
+        explicit surface tag wins over the urban-context default."""
+        feature = _road_feature(15.001, 58.0015, 15.004, "service")
+        feature["properties"]["surface"] = "gravel"
+        osm_data = {
+            "roads": {"type": "FeatureCollection", "features": [feature]},
+            "water": _empty_collection(),
+            "forests": _empty_collection(),
+            "buildings": _empty_collection(),
+            "land_use": {
+                "type": "FeatureCollection",
+                "features": [
+                    _landuse_polygon(15.0005, 58.0005, 15.0045, 58.0025, "residential"),
+                ],
+            },
+        }
+        gravel = _run_and_load(osm_data, tmp_path, "gravel")
+        asphalt = _run_and_load(osm_data, tmp_path, "asphalt")
+        assert gravel.sum() > 0, "explicit surface=gravel must paint gravel"
+        assert asphalt.sum() == 0, (
+            f"explicit surface=gravel must NOT paint asphalt; got {asphalt.sum()} px"
         )
 
 


### PR DESCRIPTION
## Summary
- Gravel and dirt road surface masks now classify every OSM road feature through `infer_road_surface()` (the same per-feature classifier already used by asphalt since v1.2.5), instead of the fixed `highway in {track,path,footway,bridleway}` tag filter.
- Pre-v1.5.11 the gravel mask missed the dominant Swedish-rural case: `highway=service` with `surface=gravel|unpaved|compacted` (58 of 78 features on the reporter's bbox). Those roads showed up as gravel **splines** but never made it into the gravel surface mask. Dirt-roads weren't rendered into any mask at all — only farmland was.
- All three road-surface masks now share `_classify_road_feature()` and `_feature_buffer_px()`, so each OSM road ends up in exactly the mask matching its exported spline surface.
- Adds 5 symmetric tests (`TestGravelAndDirtMatchRoadProcessorClassification`).

## Verification on the reporter's `arma_reforger_map_tyqklRtexhHYt0o8` export
| mask    | shipped px | new px   | ratio |
| ------- | ---------: | -------: | ----: |
| asphalt | 4 621      | 4 621    | 1.00× |
| gravel  | 6 006      | 24 765   | **4.12×** |
| dirt    | 580 020    | 587 098  | 1.01× |

Asphalt diff is only 158 / 4.2M pixels — a normalization shift at overlaps. The gravel mask now traces the full network of service roads branching off the asphalt spine, matching the satellite image.

## Test plan
- [x] `pytest webapp/tests/test_surface_mask_generator.py -q` — 13/13 green
- [x] `pytest webapp/tests/test_rasterize.py webapp/tests/test_phase3_generators.py -q` — 38/38 green
- [x] End-to-end regenerate masks for the reporter's bbox; compare gravel mask visually to satellite

🤖 Generated with [Claude Code](https://claude.com/claude-code)