### PR TITLE
v1.5.12: match Workbench Import Height Map dialog labels (closes #130)

### DIFF
--- a/webapp/config/enfusion.py
+++ b/webapp/config/enfusion.py
@@ -15,7 +15,7 @@ Community Wiki (community.bistudio.com) as of 2025-02-09.
 # enfusion_project_generator.py to stamp into every generated file header.
 # Bump here on every release; the README Docker tag pin should match.
 
-APP_VERSION = "1.5.11"
+APP_VERSION = "1.5.12"
 
 # ---------------------------------------------------------------------------
 # Base game dependency

--- a/webapp/services/setup_guide_generator.py
+++ b/webapp/services/setup_guide_generator.py
@@ -247,17 +247,18 @@ You should see this structure inside:
 2. Go to the **Manage** tab
 3. Click **Import Height Map...**
 4. Navigate to: `{self.map_name}/Sourcefiles/heightmap.asc`
-5. Settings — **use these exact values, do not accept the dialog defaults**:
+5. Settings — **use these exact values** (the labels below match the Workbench dialog verbatim):
 
    | Field | Value |
    |-------|-------|
-   | **Invert X Axis** | No |
-   | **Invert Z Axis** | Yes |
-   | **Resample to specified range** | **UNCHECK** (use the raw metres from the .asc file) |
-   | **Min Height** | **{min_elev:.3f}** |
-   | **Max Height** | **{max_elev:.3f}** |
+   | **Invert in X axis** | unchecked (default) |
+   | **Invert in Z axis** | **checked** |
+   | **Disable blocks under height** | `-1e+06` (default — leave as-is) |
+   | **Resample heights** | **UNCHECKED** (default — do **not** enable for .asc imports) |
+   | **Lowest source height is** | *(disabled, ignored)* — would be **{min_elev:.3f}** if you ever resample |
+   | **Highest source height is** | *(disabled, ignored)* — would be **{max_elev:.3f}** if you ever resample |
 
-   > **Why this matters:** the dialog defaults are `Resample = ON`, `Min = 0`, `Max = 1`. Accepting them flattens the entire terrain into a 0–1 m strip, which can both produce a paper-flat map *and* leave the world in an inconsistent state that has crashed Workbench on the subsequent reload (issue #120). The `Min`/`Max` numbers above are this map's real elevation range from `Reference/metadata.json` — Workbench uses them as the absolute height bounds for the imported grid.
+   > **Why this matters:** the `.asc` file already contains absolute height values in metres, so leaving **Resample heights** unchecked tells Workbench to use those metres directly. Enabling **Resample heights** *and* accepting the field defaults (`Lowest = 0`, `Highest = 1`) rescales the whole map into a 0–1 m strip, producing a paper-flat terrain and an inconsistent project state that has crashed Workbench on the subsequent reload (issue #120). The `Lowest`/`Highest` values shown above come from this map's real elevation range in `Reference/metadata.json` — only relevant if you deliberately re-enable Resample.
 
 6. Click **Import**
 
@@ -811,8 +812,9 @@ Heightmap Dimensions:   {dims} pixels
 Heightmap Format:       ESRI ASCII Grid (.asc) — recommended
                         16-bit PNG (.png) — alternative
 
-Invert X Axis:          No
-Invert Z Axis:          Yes
+Invert in X axis:       unchecked
+Invert in Z axis:       checked
+Resample heights:       unchecked (use raw metres from .asc)
 
 Default Surface:        {self.recommended_default} ({self.default_material})
 Surface Masks:          {self.surf.get('count', 5)} masks

--- a/webapp/tests/test_setup_guide_generator.py
+++ b/webapp/tests/test_setup_guide_generator.py
@@ -117,17 +117,22 @@ class TestSurfaceCoverageFiltering:
 
 
 class TestHeightmapImportStep:
-    """Issue #120 — the Import Height Map dialog defaults to
-    Resample=ON, Min=0, Max=1, which silently flattens every imported
-    heightmap into a 0–1 m strip. The reporter's project showed this
-    exact failure mode: their heightmap.asc ranged from -1.98 m to
-    +23.29 m, but HeightMap.desc came out as
-    ``ResampleMinHeight 0 / ResampleMaxHeight 1`` because the guide
-    only documented the Invert axes and left the user on the dialog
-    defaults. Pin that the rendered guide names the resample
-    behaviour *and* the project's real Min/Max numbers."""
+    """Issue #120 + #130 — the Import Height Map dialog has labels
+    ``Invert in X axis``, ``Invert in Z axis``, ``Disable blocks under
+    height``, ``Resample heights``, ``Lowest source height is`` and
+    ``Highest source height is``. ``Resample heights`` is UNCHECKED by
+    default; the two source-height fields are disabled while it is off.
+    The original failure mode (#120) was a user enabling Resample and
+    accepting Lowest=0 / Highest=1, which silently flattens every
+    imported heightmap into a 0–1 m strip — their heightmap.asc ranged
+    from -1.98 m to +23.29 m but HeightMap.desc came out as
+    ``ResampleMinHeight 0 / ResampleMaxHeight 1``. v1.5.11 also fixed
+    issue #130: the guide previously named the dialog fields with
+    invented labels (``Invert X Axis``, ``Min Height``, ``Max Height``,
+    ``Resample to specified range``) that don't exist in Workbench,
+    leaving users unable to find them."""
 
-    def test_heightmap_phase_states_real_min_and_max_height(self):
+    def test_heightmap_phase_uses_real_workbench_field_labels(self):
         from services.setup_guide_generator import SetupGuideGenerator
 
         meta = _metadata(["grass"], {"grass": {"percentage": 100.0}})
@@ -136,15 +141,35 @@ class TestHeightmapImportStep:
 
         guide = SetupGuideGenerator("TestMap", meta)._phase_terrain_creation()
 
-        # The exact field labels Workbench shows the user.
-        assert "**Min Height**" in guide
-        assert "**Max Height**" in guide
+        # The exact field labels Workbench shows the user (issue #130).
+        assert "**Invert in X axis**" in guide
+        assert "**Invert in Z axis**" in guide
+        assert "**Disable blocks under height**" in guide
+        assert "**Resample heights**" in guide
+        assert "**Lowest source height is**" in guide
+        assert "**Highest source height is**" in guide
         # The project's actual elevation range — not 0/1.
         assert "-1.981" in guide
         assert "23.289" in guide
-        # Telling the user to unckeck Resample is the load-bearing part.
-        assert "Resample to specified range" in guide
-        assert "UNCHECK" in guide
+        # The load-bearing instruction: keep Resample unchecked.
+        assert "UNCHECKED" in guide
+
+    def test_heightmap_phase_does_not_use_invented_labels(self):
+        """Issue #130 regression — the previous wording invented labels
+        (Min Height / Max Height / Resample to specified range / Invert X
+        Axis) that don't exist in the Workbench dialog. If anyone
+        reintroduces them, this test catches it."""
+        from services.setup_guide_generator import SetupGuideGenerator
+
+        guide = SetupGuideGenerator(
+            "TestMap", _metadata(["grass"], {"grass": {"percentage": 100.0}})
+        )._phase_terrain_creation()
+
+        assert "Min Height" not in guide
+        assert "Max Height" not in guide
+        assert "Resample to specified range" not in guide
+        assert "Invert X Axis" not in guide
+        assert "Invert Z Axis" not in guide
 
     def test_heightmap_phase_warns_about_dialog_defaults(self):
         from services.setup_guide_generator import SetupGuideGenerator
@@ -152,11 +177,11 @@ class TestHeightmapImportStep:
         meta = _metadata(["grass"], {"grass": {"percentage": 100.0}})
         guide = SetupGuideGenerator("TestMap", meta)._phase_terrain_creation()
 
-        # The narrative that explains *why* the defaults are wrong —
-        # without this, future-us will silently delete the table thinking
-        # the explicit values are redundant.
-        assert "do not accept the dialog defaults" in guide
+        # The narrative that explains *why* enabling Resample is wrong
+        # for .asc imports — without this, future-us will silently delete
+        # the table thinking the explicit values are redundant.
         assert "#120" in guide
+        assert "Resample heights" in guide
 
 
 class TestRoadsPhaseGuide:


### PR DESCRIPTION
## Summary
- Step 2.2 of the generated SETUP_GUIDE.md now uses the exact field labels Workbench shows — `Invert in X axis`, `Invert in Z axis`, `Disable blocks under height`, `Resample heights`, `Lowest source height is`, `Highest source height is`.
- Corrects the prior claim that `Resample heights` defaults to ON. It is UNCHECKED by default; the two source-height fields are disabled while it is off, so for `.asc` imports the user just leaves the dialog alone (after ticking Invert Z) and the raw metres are honoured.
- Keeps the project's real min/max elevation numbers in the table as a fallback if the user accidentally enables Resample — preserving the #120 safety net.
- Appendix B parameter dump updated for symmetry; tests updated to pin the new labels and reject the old invented ones.

## Test plan
- [x] `pytest webapp/tests/test_setup_guide_generator.py` (15 passed)
- [ ] Generate a new project, open SETUP_GUIDE.md, confirm the table reads naturally next to the actual Workbench dialog

Closes #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)