### PR TITLE
v1.6.0: derive terrain grid size from the selected area

### DIFF
--- a/webapp/config/__init__.py
+++ b/webapp/config/__init__.py
@@ -12,7 +12,7 @@ Configuration is split into focused modules:
 - buildings: BUILDING_PREFAB_BASE, KNOWN_BUILDING_PREFABS, validate_building_prefab
 - surfaces: SURFACE_CLASSES
 - endpoints: OVERPASS_*, OPENTOPOGRAPHY_*, SENTINEL2_*, CORINE_*, TREE_COVER_*
-- terrain: MAX_TERRAIN_SIZE, DEFAULT_GRID_CELL_SIZE, height scale defaults
+- terrain: MAX_TERRAIN_GRID_SIZE, TERRAIN_TILE_FACES, DEFAULT_GRID_CELL_SIZE, height scale defaults
 """
 
 # Paths & server
@@ -70,7 +70,8 @@ from config.endpoints import (
 
 # Terrain defaults
 from config.terrain import (
-    MAX_MAP_EXTENT_M, MAX_TERRAIN_SIZE, DEFAULT_GRID_CELL_SIZE,
+    MAX_MAP_EXTENT_M, MAX_TERRAIN_GRID_SIZE, TERRAIN_TILE_FACES,
+    DEFAULT_GRID_CELL_SIZE,
     DEFAULT_HEIGHT_SCALE, ENFUSION_HEIGHT_SCALE_DEFAULT,
     ENFUSION_MAX_SURFACES_PER_BLOCK, DEFAULT_TARGET_CRS,
 )
@@ -78,7 +79,6 @@ from config.terrain import (
 # Enfusion Workbench project generation
 from config.enfusion import (
     ARMA_REFORGER_GUID,
-    VALID_ENFUSION_VERTEX_COUNTS, VALID_ENFUSION_FACE_COUNTS,
     SURFACE_MATERIAL_MAP, SURFACE_MATERIAL_ALTERNATIVES,
     SURFACE_MATERIAL_BASE, SURFACE_IMPORT_ORDER,
     WORLD_PREFABS, WORLD_PREFAB_GUIDS, WORLD_PREFAB_CLASS,
@@ -89,5 +89,5 @@ from config.enfusion import (
     PROJECT_NAME_ALLOWED_CHARS, PROJECT_NAME_MAX_LENGTH,
     BLOCK_FACE_SIZE, BLOCK_VERTEX_SIZE, MAX_SURFACES_PER_BLOCK,
     RECOMMENDED_MAX_EXTERNAL_MASKS, BLOCK_SURFACE_THRESHOLD,
-    snap_to_enfusion_size, compute_height_scale, compute_terrain_size,
+    snap_to_tile_multiple, compute_height_scale, compute_terrain_size,
 )

--- a/webapp/config/enfusion.py
+++ b/webapp/config/enfusion.py
@@ -8,6 +8,8 @@ All paths and GUIDs are verified against the official Bohemia Interactive
 Community Wiki (community.bistudio.com) as of 2025-02-09.
 """
 
+from config.terrain import TERRAIN_TILE_FACES, MAX_TERRAIN_GRID_SIZE
+
 # ---------------------------------------------------------------------------
 # Generator version
 # ---------------------------------------------------------------------------
@@ -15,7 +17,7 @@ Community Wiki (community.bistudio.com) as of 2025-02-09.
 # enfusion_project_generator.py to stamp into every generated file header.
 # Bump here on every release; the README Docker tag pin should match.
 
-APP_VERSION = "1.5.14"
+APP_VERSION = "1.6.0"
 
 # ---------------------------------------------------------------------------
 # Base game dependency
@@ -27,10 +29,10 @@ ARMA_REFORGER_GUID = "58D0FB3206B6F859"
 # Valid Enfusion terrain dimensions
 # ---------------------------------------------------------------------------
 
-# Enfusion terrain uses faces (power of 2). Heightmap vertex count = faces + 1.
-VALID_ENFUSION_FACE_COUNTS = [128, 256, 512, 1024, 2048, 4096, 8192]
-VALID_ENFUSION_VERTEX_COUNTS = [f + 1 for f in VALID_ENFUSION_FACE_COUNTS]
-# => [129, 257, 513, 1025, 2049, 4097, 8193]
+# Terrain grid size = number of faces per axis. The "New Terrain" dialog
+# requires it to be a multiple of the tile size (128 faces) — NOT a power of
+# two (Everon is 6400). The imported heightmap PNG is faces + 1 vertices.
+# Snapping is done by snap_to_tile_multiple() below.
 
 # ---------------------------------------------------------------------------
 # GenericWorldEntity environment materials — restored in v1.5.7 (issue #122)
@@ -369,38 +371,25 @@ RECOMMENDED_MAX_EXTERNAL_MASKS = 3
 BLOCK_SURFACE_THRESHOLD = 10  # out of 255
 
 
-def snap_to_enfusion_size(requested_size: int) -> int:
+def snap_to_tile_multiple(face_count: int) -> int:
     """
-    Snap a requested heightmap dimension to the nearest valid Enfusion vertex count.
+    Snap a terrain grid size (faces per axis) to a valid Enfusion value.
 
-    Enfusion terrain uses faces that must be a power of 2.
-    Heightmap = faces + 1 vertices. Valid sizes: 129, 257, 513, 1025, 2049, 4097, 8193.
+    The "New Terrain" dialog requires the terrain grid size to be a multiple of
+    the tile size (``TERRAIN_TILE_FACES`` = 128) — not a power of two. The
+    requested value is rounded to the nearest tile multiple and clamped to
+    ``[TERRAIN_TILE_FACES, MAX_TERRAIN_GRID_SIZE]``. The imported heightmap PNG
+    is ``face_count + 1`` pixels per axis.
 
     Args:
-        requested_size: The user's requested heightmap dimension in pixels.
+        face_count: Desired number of terrain faces per axis.
 
     Returns:
-        The nearest valid Enfusion heightmap vertex count.
+        A valid terrain grid size — a multiple of 128.
     """
-    return min(VALID_ENFUSION_VERTEX_COUNTS, key=lambda x: abs(x - requested_size))
-
-
-def snap_to_enfusion_dimensions(size_x: int, size_z: int) -> tuple[int, int]:
-    """
-    Snap X and Z vertex counts independently to valid Enfusion sizes.
-
-    Enfusion supports non-square terrain — ``TerrainGridSizeX`` and
-    ``TerrainGridSizeZ`` can differ, but each must be a power-of-2 face
-    count (i.e. vertex count = 2^n + 1).
-
-    Args:
-        size_x: Requested vertex count along the X (width) axis.
-        size_z: Requested vertex count along the Z (depth) axis.
-
-    Returns:
-        Tuple of (snapped_x, snapped_z) valid Enfusion vertex counts.
-    """
-    return (snap_to_enfusion_size(size_x), snap_to_enfusion_size(size_z))
+    tiles = max(1, round(face_count / TERRAIN_TILE_FACES))
+    snapped = tiles * TERRAIN_TILE_FACES
+    return max(TERRAIN_TILE_FACES, min(snapped, MAX_TERRAIN_GRID_SIZE))
 
 
 def compute_height_scale(min_elevation: float, max_elevation: float) -> float:

--- a/webapp/config/terrain.py
+++ b/webapp/config/terrain.py
@@ -1,8 +1,23 @@
 """Arma Reforger terrain defaults."""
 
-MAX_MAP_EXTENT_M = 32_000          # max map extent per axis (metres) – 32 km
-MAX_TERRAIN_SIZE = 16384           # max grid dimension (pixels)
-DEFAULT_GRID_CELL_SIZE = 2         # metres per pixel
+# Grid cell size is locked to the Bohemia Interactive 2 m standard. Structures
+# are designed for a 2 m terrain grid; coarser cells make asset placement
+# unreliable (the BI wiki calls 4 m "impossible without holes"). This is no
+# longer a user-facing choice — the generator always produces 2 m terrain.
+DEFAULT_GRID_CELL_SIZE = 2         # metres per face
+
+# Enfusion builds terrain from tiles; one tile is 128 faces
+# (BLOCKS_PER_TILE 4 × BLOCK_FACE_SIZE 32, per the "New Terrain" dialog).
+# Terrain grid size must be an integer multiple of this.
+TERRAIN_TILE_FACES = 128
+
+# Largest terrain grid size we allow (faces per axis). 16384 faces at 2 m is a
+# 32.768 km map; the heightmap PNG is ~0.5 GB at that size.
+MAX_TERRAIN_GRID_SIZE = 16384
+
+# Max map extent per axis (metres) = largest terrain grid size × cell size.
+MAX_MAP_EXTENT_M = MAX_TERRAIN_GRID_SIZE * DEFAULT_GRID_CELL_SIZE  # 32768
+
 DEFAULT_HEIGHT_SCALE = 0.03125     # maps 0-65535 to ~0-2048 m
 ENFUSION_HEIGHT_SCALE_DEFAULT = DEFAULT_HEIGHT_SCALE
 ENFUSION_MAX_SURFACES_PER_BLOCK = 5

--- a/webapp/services/heightmap_generator.py
+++ b/webapp/services/heightmap_generator.py
@@ -27,7 +27,7 @@ from scipy.interpolate import NearestNDInterpolator
 # Re-exported here for backward compatibility (surface_mask_generator imports from here).
 from services.utils.rasterize import rasterize_features_to_mask  # noqa: F401
 from services.utils.parallel import parallel_gaussian_filter, parallel_zoom
-from config.enfusion import snap_to_enfusion_size, VALID_ENFUSION_VERTEX_COUNTS
+from config.enfusion import snap_to_tile_multiple
 
 logger = logging.getLogger(__name__)
 
@@ -621,25 +621,28 @@ def generate_heightmap(
     if output_dir is None:
         output_dir = Path(tempfile.mkdtemp())
 
-    # 0. Normalize target_size to (size_x, size_z) tuple and snap each axis
+    # 0. Normalize target_size to (px_x, px_z) and snap each axis.
+    # target_size is the output heightmap dimension in pixels; an N-face
+    # terrain needs an (N+1)-pixel heightmap. Snap the face count to a valid
+    # tile multiple (×128), then add 1 back for the vertex/pixel count.
     if isinstance(target_size, int):
         target_size = (target_size, target_size)
 
     original_size = target_size
-    size_x = snap_to_enfusion_size(target_size[0])
-    size_z = snap_to_enfusion_size(target_size[1])
+    size_x = snap_to_tile_multiple(target_size[0] - 1) + 1
+    size_z = snap_to_tile_multiple(target_size[1] - 1) + 1
     target_size = (size_x, size_z)
 
     if target_size != original_size:
         logger.info(
             f"Snapped heightmap size from {original_size[0]}x{original_size[1]} "
             f"to {size_x}x{size_z} "
-            f"(Enfusion requires power-of-2 faces per axis)"
+            f"(terrain grid size must be a multiple of 128 faces)"
         )
         if job:
             job.add_log(
                 f"Adjusted heightmap size: {original_size[0]}x{original_size[1]} → "
-                f"{size_x}x{size_z} (Enfusion requires power-of-2 faces per axis)"
+                f"{size_x}x{size_z} (terrain grid size must be a multiple of 128 faces)"
             )
 
     # 1. Parse GeoTIFF
@@ -774,8 +777,11 @@ def generate_heightmap(
         "heightmap_png": png_path,
         "heightmap_asc": asc_path,
         "heightmap_preview": preview_path,
+        # dimensions = heightmap pixels (N+1); terrain_grid_size = faces (N);
+        # terrain_size_m = faces × cell (N×C)
         "dimensions": f"{heightmap.shape[1]}x{heightmap.shape[0]}",
-        "terrain_size_m": f"{heightmap.shape[1] * target_resolution_m:.0f}x{heightmap.shape[0] * target_resolution_m:.0f}",
+        "terrain_grid_size": f"{heightmap.shape[1] - 1}x{heightmap.shape[0] - 1}",
+        "terrain_size_m": f"{(heightmap.shape[1] - 1) * target_resolution_m:.0f}x{(heightmap.shape[0] - 1) * target_resolution_m:.0f}",
         "grid_cell_size_m": target_resolution_m,
         # Intermediate arrays for downstream steps (e.g. surface mask generation)
         # so callers don't need to re-parse the DEM from raw bytes.

--- a/webapp/services/map_generator.py
+++ b/webapp/services/map_generator.py
@@ -114,7 +114,8 @@ def create_job(
 
     Args:
         polygon_coords: List of [lng, lat] coordinates defining the area
-        options: Generation options (heightmap_size, grid_resolution, etc.)
+        options: Generation options (feature toggles). Terrain grid size and
+            grid cell size are derived from the selected area, not options.
         session_id: Session ID of the user creating the job
 
     Returns:
@@ -646,6 +647,8 @@ def build_metadata(
             "road_data": "roads_enfusion.geojson",
             "road_splines": "roads_splines.csv",
             "recommended_settings": {
+                "terrain_grid_size": heightmap_result["terrain_grid_size"],
+                "heightmap_resolution_px": heightmap_result["dimensions"],
                 "terrain_size": heightmap_result["terrain_size_m"],
                 "grid_cell_size": heightmap_result["grid_cell_size_m"],
                 "height_scale": heightmap_result["height_scale"],
@@ -741,33 +744,33 @@ async def run_generation(job: MapGenerationJob):
         logger.info(f"[{job.job_id}] Step 2: Elevation acquisition")
         job.add_log(f"Downloading elevation data ({primary_country})...")
 
-        # Compute per-axis heightmap dimensions from bbox aspect ratio.
-        # Enfusion supports non-square terrain (TerrainGridSizeX ≠ TerrainGridSizeZ).
-        # The longest geographic axis gets the user's selected vertex count;
-        # the shorter axis is proportional and snapped to valid Enfusion size.
-        from config.enfusion import snap_to_enfusion_size
+        # Terrain grid size = faces per axis = real-world metres ÷ grid cell
+        # size, snapped to a valid tile multiple (×128). The heightmap PNG is
+        # faces + 1 pixels. Enfusion supports non-square terrain, so each axis
+        # is derived independently from the selected bbox.
+        from config.enfusion import snap_to_tile_multiple
+        from config.terrain import DEFAULT_GRID_CELL_SIZE
         from services.utils.geo import estimate_bbox_dimensions_m
 
-        user_vertices = job.options.get("heightmap_size", 2048)
-        user_vertices = snap_to_enfusion_size(user_vertices)
-
+        cell_size = DEFAULT_GRID_CELL_SIZE
         width_m, height_m = estimate_bbox_dimensions_m(bbox)
 
-        if width_m >= height_m:
-            target_size_x = user_vertices
-            target_size_z = snap_to_enfusion_size(round(user_vertices * (height_m / width_m)))
-        else:
-            target_size_z = user_vertices
-            target_size_x = snap_to_enfusion_size(round(user_vertices * (width_m / height_m)))
+        faces_x = snap_to_tile_multiple(round(width_m / cell_size))
+        faces_z = snap_to_tile_multiple(round(height_m / cell_size))
+        target_size_x = faces_x + 1
+        target_size_z = faces_z + 1
 
         target_size = (target_size_x, target_size_z)
         logger.info(
-            f"[{job.job_id}] Terrain dimensions: {target_size_x}x{target_size_z} vertices "
-            f"(bbox {width_m:.0f}m x {height_m:.0f}m)"
+            f"[{job.job_id}] Terrain grid size: {faces_x}x{faces_z} faces — "
+            f"{faces_x * cell_size:.0f}x{faces_z * cell_size:.0f} m in-game "
+            f"(bbox {width_m:.0f}x{height_m:.0f} m, "
+            f"heightmap {target_size_x}x{target_size_z} px)"
         )
         job.add_log(
-            f"Terrain dimensions: {target_size_x}x{target_size_z} vertices "
-            f"(area {width_m:.0f}m x {height_m:.0f}m)"
+            f"Terrain grid size: {faces_x}×{faces_z} faces — "
+            f"{faces_x * cell_size:.0f}×{faces_z * cell_size:.0f} m in-game "
+            f"(heightmap {target_size_x}×{target_size_z} px)"
         )
 
         # Pass the heightmap size to the elevation fetcher so it can limit
@@ -850,8 +853,8 @@ async def run_generation(job: MapGenerationJob):
         logger.info(f"[{job.job_id}] Step 4: Heightmap generation")
         job.add_log("Generating heightmap from elevation data...")
 
-        # target_size already set in step 2 (from job.options["heightmap_size"])
-        target_resolution = job.options.get("grid_resolution", 2.0)
+        # target_size (heightmap pixels) was derived from the bbox in step 2.
+        target_resolution = cell_size
 
         from services.heightmap_generator import ElevationTruncatedError
 

--- a/webapp/services/validators.py
+++ b/webapp/services/validators.py
@@ -9,7 +9,9 @@ import math
 import re
 from fastapi import HTTPException
 
-from config.terrain import MAX_MAP_EXTENT_M
+from config.terrain import (
+    MAX_MAP_EXTENT_M, TERRAIN_TILE_FACES, DEFAULT_GRID_CELL_SIZE,
+)
 
 # Job IDs are URL-safe base64, 16-32 characters
 JOB_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{16,64}$")
@@ -127,7 +129,7 @@ def validate_polygon(polygon: list[list[float]]) -> list[list[float]]:
                 detail=f"Latitude out of range at position {i}: {lat}",
             )
 
-    # Validate bounding box size (metric — 20 km max per axis)
+    # Validate bounding box size against the max terrain grid size.
     lngs = [c[0] for c in polygon]
     lats = [c[1] for c in polygon]
     lng_range = max(lngs) - min(lngs)
@@ -138,9 +140,14 @@ def validate_polygon(polygon: list[list[float]]) -> list[list[float]]:
     m_per_deg_lng = 111_320 * math.cos(math.radians(lat_mid))
     width_m = lng_range * m_per_deg_lng
     height_m = lat_range * m_per_deg_lat
+    # Allow one tile of slack: the frontend auto-snaps the square to a terrain
+    # grid size, and this metre estimate can differ slightly from the browser's
+    # due to projection rounding — without slack an exactly-max square is
+    # falsely rejected.
+    max_allowed_m = MAX_MAP_EXTENT_M + TERRAIN_TILE_FACES * DEFAULT_GRID_CELL_SIZE
     max_km = MAX_MAP_EXTENT_M / 1000
 
-    if width_m > MAX_MAP_EXTENT_M or height_m > MAX_MAP_EXTENT_M:
+    if width_m > max_allowed_m or height_m > max_allowed_m:
         raise HTTPException(
             status_code=400,
             detail=(

--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -58,10 +58,6 @@
                                 <td id="info-size">-</td>
                             </tr>
                         </table>
-                        <div id="area-warning" class="alert alert-danger py-1 px-2 mb-0 small d-none">
-                            <i class="bi bi-exclamation-triangle-fill"></i>
-                            <span id="area-warning-text"></span>
-                        </div>
                     </div>
                     <div id="no-selection" class="text-center py-3">
                         <i class="bi bi-hand-index-thumb"></i>
@@ -83,24 +79,14 @@
                         Used for Enfusion project folder name. Auto-generated if blank.
                     </div>
 
-                    <label class="form-label small">Heightmap Resolution</label>
-                    <select class="form-select form-select-sm mb-2" id="heightmap-size">
-                        <option value="1025">1024 × 1024 faces (small test)</option>
-                        <option value="2049" selected>2048 × 2048 faces (standard)</option>
-                        <option value="4097">4096 × 4096 faces (high detail)</option>
-                    </select>
-
-                    <label class="form-label small">Grid Cell Size</label>
-                    <select class="form-select form-select-sm mb-2" id="grid-resolution">
-                        <option value="1">1m (very high detail)</option>
-                        <option value="2" selected>2m (standard)</option>
-                        <option value="4">4m (large terrain)</option>
-                        <option value="8">8m (very large terrain)</option>
-                    </select>
-
-                    <label class="form-label small">Terrain Size</label>
+                    <label class="form-label small">Terrain</label>
                     <div class="small mb-3" id="terrain-size-display">
-                        2048 faces at 2m = <strong>4096m x 4096m</strong> terrain
+                        <span class="text-muted">Draw an area on the map to size the terrain.</span>
+                    </div>
+                    <div class="form-text small mb-3" style="margin-top:-0.5rem; color:#8b949e;">
+                        Derived from your selection — these are the values to
+                        enter in the World Editor "New Terrain" dialog. Grid
+                        cell size is fixed at 2 m (the Arma Reforger standard).
                     </div>
 
                     <label class="form-label small">Features to Generate</label>

--- a/webapp/static/js/app.js
+++ b/webapp/static/js/app.js
@@ -95,6 +95,53 @@ function mPerDegLng(lat) {
     return 111320 * Math.cos(lat * Math.PI / 180);
 }
 
+// ---------------------------------------------------------------------------
+// Terrain sizing — the drawn square is the only size input. Grid cell size is
+// locked at 2 m; the terrain grid size (faces per axis) must be a multiple of
+// the 128-face tile size. Mirrors config/terrain.py + config/enfusion.py.
+// ---------------------------------------------------------------------------
+const GRID_CELL_SIZE_M = 2;
+const TERRAIN_TILE_FACES = 128;
+const MAX_TERRAIN_GRID_SIZE = 16384;
+
+// Derive the Enfusion terrain parameters from a drawn side length in metres.
+function deriveTerrain(sideMetres) {
+    const tiles = Math.min(
+        MAX_TERRAIN_GRID_SIZE / TERRAIN_TILE_FACES,
+        Math.max(1, Math.round(sideMetres / GRID_CELL_SIZE_M / TERRAIN_TILE_FACES)),
+    );
+    const N = tiles * TERRAIN_TILE_FACES;
+    return {
+        N: N,                        // terrain grid size (faces per axis)
+        tiles: tiles,                // tiles per axis (N / 128)
+        sideM: N * GRID_CELL_SIZE_M, // in-game terrain side, metres
+        heightmapPx: N + 1,          // heightmap PNG dimension
+    };
+}
+
+// Side length (metres) of a square Leaflet bounds — uses the larger axis so a
+// slightly non-square bounds still resolves to a single value.
+function squareSideMetres(bounds) {
+    const widthM = (bounds.getEast() - bounds.getWest())
+        * mPerDegLng(bounds.getCenter().lat);
+    const heightM = (bounds.getNorth() - bounds.getSouth()) * M_PER_DEG_LAT;
+    return Math.max(widthM, heightM);
+}
+
+// Resize a square layer in place so its side equals a valid terrain size,
+// keeping it centred where the user left it.
+function snapSquareToTerrain(layer) {
+    const bounds = layer.getBounds();
+    const centre = bounds.getCenter();
+    const { sideM } = deriveTerrain(squareSideMetres(bounds));
+    const halfLat = (sideM / 2) / M_PER_DEG_LAT;
+    const halfLng = (sideM / 2) / mPerDegLng(centre.lat);
+    layer.setBounds(L.latLngBounds(
+        L.latLng(centre.lat - halfLat, centre.lng - halfLng),
+        L.latLng(centre.lat + halfLat, centre.lng + halfLng),
+    ));
+}
+
 // Given a fixed corner and a free corner, return the bounds of the
 // largest square (in metres) that fits the dragged extent. Used by both
 // the draw handler (free corner = cursor) and the edit handler (free corner
@@ -242,6 +289,10 @@ map.on(L.Draw.Event.CREATED, function (event) {
     drawnItems.addLayer(layer);
     currentPolygon = layer;
 
+    // Snap the drawn square to a valid terrain grid size so what the user
+    // sees on the map is exactly the terrain that will be generated.
+    snapSquareToTerrain(layer);
+
     currentPolygonCoords = boundsToCoords(layer.getBounds());
     onPolygonSelected(currentPolygonCoords);
 
@@ -273,8 +324,14 @@ function enableLiveEditing(layer) {
         updateSelectionDisplay(currentPolygonCoords);
     };
     const finishEdit = () => {
+        // Snap to a valid terrain size, then rebuild the edit handles so the
+        // corner markers sit on the snapped bounds. The re-init is deferred so
+        // the current drag event finishes unwinding before its handler is
+        // torn down.
+        snapSquareToTerrain(layer);
         currentPolygonCoords = boundsToCoords(layer.getBounds());
         onPolygonSelected(currentPolygonCoords);
+        setTimeout(() => enableLiveEditing(layer), 0);
     };
 
     markers.forEach((m) => {
@@ -306,12 +363,6 @@ document.getElementById('btn-toggle-console').addEventListener('click', function
     }
 });
 
-// Update terrain size display when options change
-document.getElementById('heightmap-size').addEventListener('change', updateTerrainSizeDisplay);
-document.getElementById('grid-resolution').addEventListener('change', updateTerrainSizeDisplay);
-
-const MAX_MAP_EXTENT_KM = 32; // must match MAX_MAP_EXTENT_M in config/terrain.py
-
 function updateSelectionDisplay(coords) {
     document.getElementById('selection-info').classList.remove('d-none');
     document.getElementById('no-selection').classList.add('d-none');
@@ -331,17 +382,10 @@ function updateSelectionDisplay(coords) {
     document.getElementById('info-size').textContent =
         `~${lngKm.toFixed(1)} x ${latKm.toFixed(1)} km`;
 
-    const warning = document.getElementById('area-warning');
-    const warningText = document.getElementById('area-warning-text');
-    if (lngKm > MAX_MAP_EXTENT_KM || latKm > MAX_MAP_EXTENT_KM) {
-        warningText.textContent =
-            `Area too large (${lngKm.toFixed(1)} x ${latKm.toFixed(1)} km). Max ${MAX_MAP_EXTENT_KM} x ${MAX_MAP_EXTENT_KM} km.`;
-        warning.classList.remove('d-none');
-        document.getElementById('btn-generate').disabled = true;
-    } else {
-        warning.classList.add('d-none');
-        document.getElementById('btn-generate').disabled = false;
-    }
+    // The square auto-snaps to a valid terrain size and is clamped to the
+    // maximum, so any drawn selection is generatable.
+    document.getElementById('btn-generate').disabled = false;
+    updateTerrainSizeDisplay();
 }
 
 function onPolygonSelected(coords) {
@@ -369,13 +413,37 @@ function clearSelection() {
 }
 
 function updateTerrainSizeDisplay() {
-    const vertices = parseInt(document.getElementById('heightmap-size').value);
-    const res = parseFloat(document.getElementById('grid-resolution').value);
-    const faces = vertices - 1;
-    const terrainM = faces * res;
-    document.getElementById('terrain-size-display').innerHTML =
-        `${faces} faces at ${res}m = up to <strong>${terrainM}m x ${terrainM}m</strong> terrain ` +
-        `<span class="text-muted">(proportional to selection)</span>`;
+    const el = document.getElementById('terrain-size-display');
+    if (!currentPolygonCoords) {
+        el.innerHTML =
+            '<span class="text-muted">Draw an area on the map to size the terrain.</span>';
+        return;
+    }
+
+    const lngs = currentPolygonCoords.map(c => c[0]);
+    const lats = currentPolygonCoords.map(c => c[1]);
+    const west = Math.min(...lngs), east = Math.max(...lngs);
+    const south = Math.min(...lats), north = Math.max(...lats);
+    const midLat = (south + north) / 2;
+    const widthM = (east - west) * mPerDegLng(midLat);
+    const heightM = (north - south) * M_PER_DEG_LAT;
+
+    const t = deriveTerrain(Math.max(widthM, heightM));
+    const km = (t.sideM / 1000).toFixed(2);
+    const advisory = t.N > 8192
+        ? '<div class="alert alert-warning py-1 px-2 mb-0 mt-2 small">'
+          + '<i class="bi bi-exclamation-triangle-fill"></i> Large map &mdash; '
+          + 'generation will be slow and memory-heavy.</div>'
+        : '';
+
+    el.innerHTML =
+        '<table class="table table-sm table-dark mb-0">'
+        + `<tr><td>Terrain grid size</td><td><strong>${t.N} &times; ${t.N}</strong></td></tr>`
+        + `<tr><td>Tiles</td><td>${t.tiles} &times; ${t.tiles}</td></tr>`
+        + `<tr><td>In-game size</td><td>${km} &times; ${km} km</td></tr>`
+        + `<tr><td>Heightmap</td><td>${t.heightmapPx} &times; ${t.heightmapPx} px</td></tr>`
+        + `<tr><td>Grid cell size</td><td>${GRID_CELL_SIZE_M} m</td></tr>`
+        + '</table>' + advisory;
 }
 
 // ===========================================================================
@@ -466,8 +534,6 @@ async function startGeneration() {
     const mapName = rawMapName.replace(/[^A-Za-z0-9_]/g, '').substring(0, 32);
 
     const options = {
-        heightmap_size: parseInt(document.getElementById('heightmap-size').value),
-        grid_resolution: parseFloat(document.getElementById('grid-resolution').value),
         features: {
             roads: document.getElementById('opt-roads').checked,
             water: document.getElementById('opt-water').checked,

--- a/webapp/tests/test_setup_guide_generator.py
+++ b/webapp/tests/test_setup_guide_generator.py
@@ -365,6 +365,7 @@ class TestBuildMetadataFeatureSources:
             "elevation_result": {"source": "Lantmäteriet STAC Höjd (1 m)", "resolution_m": 1},
             "heightmap_result": {
                 "dimensions": "2049x2049",
+                "terrain_grid_size": "2048x2048",
                 "terrain_size_m": 4096,
                 "grid_cell_size_m": 2.0,
                 "min_elevation": 0,

--- a/webapp/tests/test_terrain_sizing.py
+++ b/webapp/tests/test_terrain_sizing.py
@@ -1,0 +1,54 @@
+"""
+Terrain grid size derivation.
+
+The Enfusion "New Terrain" dialog requires the terrain grid size (faces per
+axis) to be a multiple of the 128-face tile size — NOT a power of two (Everon
+is 6400). These tests pin snap_to_tile_multiple() and the size constants it
+depends on.
+"""
+
+from config.enfusion import snap_to_tile_multiple
+from config.terrain import (
+    TERRAIN_TILE_FACES, MAX_TERRAIN_GRID_SIZE, MAX_MAP_EXTENT_M,
+    DEFAULT_GRID_CELL_SIZE,
+)
+
+
+class TestSnapToTileMultiple:
+    def test_exact_multiples_unchanged(self):
+        for n in (128, 256, 2048, 4096, 6400, 8192, 16384):
+            assert snap_to_tile_multiple(n) == n
+
+    def test_non_power_of_two_is_valid(self):
+        # 6400 (Everon's grid size) was impossible under the old power-of-2
+        # restriction; it must now round-trip unchanged.
+        assert snap_to_tile_multiple(6400) == 6400
+
+    def test_rounds_to_nearest_tile(self):
+        assert snap_to_tile_multiple(4000) == 3968   # 31.25 tiles -> 31
+        assert snap_to_tile_multiple(4050) == 4096   # 31.64 tiles -> 32
+        assert snap_to_tile_multiple(200) == 256     # 1.56 tiles -> 2
+
+    def test_result_always_multiple_of_128(self):
+        for raw in (1, 100, 333, 5000, 12801, 99999):
+            assert snap_to_tile_multiple(raw) % TERRAIN_TILE_FACES == 0
+
+    def test_clamped_to_minimum(self):
+        assert snap_to_tile_multiple(0) == TERRAIN_TILE_FACES
+        assert snap_to_tile_multiple(1) == TERRAIN_TILE_FACES
+        assert snap_to_tile_multiple(-500) == TERRAIN_TILE_FACES
+
+    def test_clamped_to_maximum(self):
+        assert snap_to_tile_multiple(20_000) == MAX_TERRAIN_GRID_SIZE
+        assert snap_to_tile_multiple(10**9) == MAX_TERRAIN_GRID_SIZE
+
+
+class TestTerrainConstants:
+    def test_tile_is_128_faces(self):
+        assert TERRAIN_TILE_FACES == 128
+
+    def test_max_grid_size_is_a_tile_multiple(self):
+        assert MAX_TERRAIN_GRID_SIZE % TERRAIN_TILE_FACES == 0
+
+    def test_max_map_extent_matches_grid_and_cell(self):
+        assert MAX_MAP_EXTENT_M == MAX_TERRAIN_GRID_SIZE * DEFAULT_GRID_CELL_SIZE


### PR DESCRIPTION
## Summary

Fixes a longstanding bug where generated maps had the wrong size in the Enfusion World Editor.

The web GUI exposed **Heightmap Resolution** (1025/2049/4097) and **Grid Cell Size** (1/2/4/8 m) as two free dropdowns that were never tied to the square drawn on the map. The backend set the heightmap vertex count straight from the dropdown, so the in-game terrain size was fully decoupled from the real-world area — drawing an 8 km square and picking "2048 @ 2 m" produced a 4 km map (a 2× horizontal squash).

### What changed

- **Terrain grid size is now derived**, not chosen: `drawn metres ÷ 2 m cell size`, snapped to a multiple of the 128-face tile size. The heightmap PNG is `N+1` pixels.
- **The drawn square auto-resizes** on the map to the snapped terrain size — what you draw is exactly what you get in-game.
- **Grid cell size is locked at 2 m** (the Bohemia Interactive standard; 4 m/8 m broke asset placement). The "Heightmap Resolution" and "Grid Cell Size" dropdowns are removed.
- The sidebar shows a read-only panel with the exact **"New Terrain"** dialog values (terrain grid size, tiles, in-game size, heightmap px), plus a large-map advisory above 8192 faces.
- **Power-of-2 restriction removed**: `snap_to_enfusion_size` (power-of-2 only) is replaced by `snap_to_tile_multiple` (multiple of 128), so non-power-of-2 sizes like Everon's 6400 are now possible.
- Max terrain grid size raised to 16384 faces (32.768 km at 2 m).
- `terrain_size_m` corrected to report `N × cell` (was `(N+1) × cell`, off by one cell).

## Test plan

- [x] `python -m pytest` — 395 passed; new `test_terrain_sizing.py` covers tile-multiple snapping, clamping and the non-power-of-2 (6400) case. The 3 remaining failures are pre-existing baseline noise (Lantmäteriet auth / feature-extractor), unrelated to this change.
- [x] Verified in a browser via uvicorn: drawing a square auto-resizes it; the derived panel shows correct grid size / tiles / in-game size / heightmap px; 12.8 km → 6400 grid size; oversized draws clamp to 16384 with the advisory; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)