### PR TITLE
v1.6.1: Height scale uses engine default, not range/65535 (closes #142)

### DIFF
--- a/webapp/config/__init__.py
+++ b/webapp/config/__init__.py
@@ -90,4 +90,5 @@ from config.enfusion import (
     BLOCK_FACE_SIZE, BLOCK_VERTEX_SIZE, MAX_SURFACES_PER_BLOCK,
     RECOMMENDED_MAX_EXTERNAL_MASKS, BLOCK_SURFACE_THRESHOLD,
     snap_to_tile_multiple, compute_height_scale, compute_terrain_size,
+    pick_clean_height_scale,
 )

--- a/webapp/config/enfusion.py
+++ b/webapp/config/enfusion.py
@@ -8,7 +8,11 @@ All paths and GUIDs are verified against the official Bohemia Interactive
 Community Wiki (community.bistudio.com) as of 2025-02-09.
 """
 
-from config.terrain import TERRAIN_TILE_FACES, MAX_TERRAIN_GRID_SIZE
+from config.terrain import (
+    TERRAIN_TILE_FACES,
+    MAX_TERRAIN_GRID_SIZE,
+    DEFAULT_HEIGHT_SCALE,
+)
 
 # ---------------------------------------------------------------------------
 # Generator version
@@ -17,7 +21,7 @@ from config.terrain import TERRAIN_TILE_FACES, MAX_TERRAIN_GRID_SIZE
 # enfusion_project_generator.py to stamp into every generated file header.
 # Bump here on every release; the README Docker tag pin should match.
 
-APP_VERSION = "1.6.0"
+APP_VERSION = "1.6.1"
 
 # ---------------------------------------------------------------------------
 # Base game dependency
@@ -408,6 +412,59 @@ def compute_height_scale(min_elevation: float, max_elevation: float) -> float:
     """
     elev_range = max(max_elevation - min_elevation, 0.01)
     return elev_range / 65535.0
+
+
+# Fraction of the vertical range reserved below world zero by the New Terrain
+# dialog's "Zero height to entity coord" field (default 10%). This is how much
+# of the 16-bit band can represent below-sea-level (negative) elevations.
+ZERO_HEIGHT_TO_ENTITY_FRACTION = 0.10
+
+# Clean, typeable height-scale values to climb when the engine default cannot
+# represent the map's absolute elevation span. Each is a power-of-two fraction
+# so it reads cleanly in the World Editor dialog.
+HEIGHT_SCALE_LADDER = (0.03125, 0.0625, 0.125, 0.25, 0.5, 1.0)
+
+
+def pick_clean_height_scale(
+    min_elevation: float,
+    max_elevation: float,
+    zero_fraction: float = ZERO_HEIGHT_TO_ENTITY_FRACTION,
+) -> float:
+    """
+    Pick the height-scale value the user should type into the "New Terrain"
+    dialog.
+
+    Heightmaps are imported as **absolute metres above sea level** (sea = world
+    Y = 0) with *Resample heights* off, so the dialog's height scale only needs
+    to be large enough to *represent* the elevation span — it does not rescale
+    the data. Per Atlas 2 (p.4) the engine default ``0.03125`` is correct for
+    almost every real-world map, so we return it unless the absolute span
+    genuinely does not fit, in which case we climb a ladder of clean
+    power-of-two fractions. Avoids the un-typeable ``range / 65535`` (issue #142).
+
+    With height scale ``hs`` and a "Zero height to entity coord" reserve of
+    ``zero_fraction`` (default 10%), the representable band is::
+
+        [ -hs * 65535 * zero_fraction ,  +hs * 65535 * (1 - zero_fraction) ]
+
+    Args:
+        min_elevation: Minimum absolute elevation in metres (may be negative).
+        max_elevation: Maximum absolute elevation in metres.
+        zero_fraction: Fraction of the range reserved below zero.
+
+    Returns:
+        A clean height-scale value that represents the span, defaulting to the
+        engine default ``DEFAULT_HEIGHT_SCALE``.
+    """
+    for hs in HEIGHT_SCALE_LADDER:
+        upper = hs * 65535.0 * (1.0 - zero_fraction)
+        lower = -hs * 65535.0 * zero_fraction
+        if max_elevation <= upper and min_elevation >= lower:
+            return hs
+    # Span exceeds the cleanest ladder value (e.g. >5800 m of relief); fall back
+    # to the smallest scale that physically represents the full span.
+    span = max(max_elevation - min_elevation, 0.01)
+    return max(DEFAULT_HEIGHT_SCALE, span / 65535.0)
 
 
 def compute_terrain_size(face_count: int, cell_size: float) -> float:

--- a/webapp/services/heightmap_generator.py
+++ b/webapp/services/heightmap_generator.py
@@ -27,7 +27,7 @@ from scipy.interpolate import NearestNDInterpolator
 # Re-exported here for backward compatibility (surface_mask_generator imports from here).
 from services.utils.rasterize import rasterize_features_to_mask  # noqa: F401
 from services.utils.parallel import parallel_gaussian_filter, parallel_zoom
-from config.enfusion import snap_to_tile_multiple
+from config.enfusion import snap_to_tile_multiple, pick_clean_height_scale
 
 logger = logging.getLogger(__name__)
 
@@ -267,6 +267,7 @@ def generate_heightmap_from_array(
         return np.zeros_like(elevation, dtype=np.uint16), {
             "min_elevation": 0, "max_elevation": 0,
             "elevation_range": 0, "height_scale": 0, "height_offset": 0,
+            "dialog_height_scale": pick_clean_height_scale(0.0, 0.0),
             "width": elevation.shape[1], "height": elevation.shape[0],
         }
 
@@ -285,8 +286,13 @@ def generate_heightmap_from_array(
         "min_elevation": min_elev,
         "max_elevation": max_elev,
         "elevation_range": elev_range,
+        # Encoding scale: round-trips the normalised 16-bit grid back to absolute
+        # metres when writing the .asc (do NOT show this to the user — #142).
         "height_scale": height_scale,
         "height_offset": min_elev,
+        # Dialog scale: the clean value the user types into the "New Terrain"
+        # dialog. Defaults to the engine default (0.03125) per Atlas 2 (#142).
+        "dialog_height_scale": pick_clean_height_scale(min_elev, max_elev),
         "width": heightmap.shape[1],
         "height": heightmap.shape[0],
     }

--- a/webapp/services/map_generator.py
+++ b/webapp/services/map_generator.py
@@ -599,6 +599,8 @@ def build_metadata(
     feature_sources: dict = None,
 ) -> dict:
     """Assemble the output metadata.json content."""
+    from config.enfusion import pick_clean_height_scale
+
     metadata = {
         "generator": "Arma Reforger Base Map Generator",
         "version": "1.0.0",
@@ -616,7 +618,17 @@ def build_metadata(
             "resolution_m": elevation_result["resolution_m"],
             "min_elevation_m": heightmap_result["min_elevation"],
             "max_elevation_m": heightmap_result["max_elevation"],
+            # Encoding scale (round-trips the .asc); not user-facing.
             "height_scale": heightmap_result["height_scale"],
+            # Value the user types into the New Terrain dialog (#142). Derived
+            # from the absolute elevation span; defaults to the engine default.
+            "dialog_height_scale": heightmap_result.get(
+                "dialog_height_scale",
+                pick_clean_height_scale(
+                    heightmap_result["min_elevation"],
+                    heightmap_result["max_elevation"],
+                ),
+            ),
             "height_offset": heightmap_result["height_offset"],
         },
         "heightmap": {
@@ -651,7 +663,7 @@ def build_metadata(
                 "heightmap_resolution_px": heightmap_result["dimensions"],
                 "terrain_size": heightmap_result["terrain_size_m"],
                 "grid_cell_size": heightmap_result["grid_cell_size_m"],
-                "height_scale": heightmap_result["height_scale"],
+                "height_scale": heightmap_result["dialog_height_scale"],
                 "height_offset": heightmap_result["height_offset"],
                 "invert_x_axis": False,
                 "invert_z_axis": True,

--- a/webapp/services/setup_guide_generator.py
+++ b/webapp/services/setup_guide_generator.py
@@ -130,7 +130,7 @@ class SetupGuideGenerator:
         cell_size = self.hm.get("grid_cell_size_m", 2.0)
         min_elev = self.elev.get("min_elevation_m", 0)
         max_elev = self.elev.get("max_elevation_m", 0)
-        height_scale = self.elev.get("height_scale", 0.03125)
+        height_scale = self.elev.get("dialog_height_scale", 0.03125)
         mask_count = self.surf.get("count", 5)
         road_count = self.roads.get("total_segments", 0)
         country_codes = self.input_data.get("countries", []) or []
@@ -148,8 +148,8 @@ class SetupGuideGenerator:
 | **Terrain Size** | {terrain_size} |
 | **Heightmap** | {dims} pixels |
 | **Grid Cell Size** | {cell_size}m |
-| **Height Range** | {min_elev:.1f}m to {max_elev:.1f}m |
-| **Height Scale** | {height_scale:.6g} |
+| **Height Range** | {min_elev:.1f}m to {max_elev:.1f}m (absolute, sea level = 0) |
+| **Height Scale** | {height_scale:.6g} (New Terrain dialog — default) |
 | **Surface Masks** | {mask_count} included |
 | **Recommended Default** | {self.recommended_default} ({self.default_material}) |
 | **Block Violations** | {block_violations}/{total_blocks} blocks |
@@ -214,9 +214,10 @@ You should see this structure inside:
         face_x = vertex_x - 1
         face_z = vertex_z - 1
         cell_size = self.hm.get("grid_cell_size_m", 2.0)
-        height_scale = self.elev.get("height_scale", 0.03125)
+        height_scale = self.elev.get("dialog_height_scale", 0.03125)
         min_elev = self.elev.get("min_elevation_m", 0.0)
         max_elev = self.elev.get("max_elevation_m", 1.0)
+        is_default_scale = abs(height_scale - 0.03125) < 1e-9
 
         return f"""## Phase 2: Terrain Creation (10 minutes)
 
@@ -233,13 +234,23 @@ You should see this structure inside:
 | **Terrain grid size** | **{face_x}** = **{face_z}** |
 | **Blocks per tile** | **4** (default) |
 | **Grid cell size (meters)** | **{cell_size}** |
-| **Height scale (meters)** | **{height_scale:.6g}** |
+| **Height scale (meters)** | **{height_scale:.6g}** {'(leave at the **default** — do not change it)' if is_default_scale else '(this map needs a larger-than-default scale — see note below)'} |
 | **"Zero" height to entity coord** | **10%** (default) |
 | **Surface layer weight bits** | **8 bits (5 surfaces)** (default) |
 
 4. Verify the summary at the bottom of the dialog shows the expected terrain size
 5. Click **Create**
 6. Wait for the terrain to generate (may take a few seconds)
+
+> **About Height scale (issue #142):** the heightmap is imported as **absolute
+> metres above sea level** — sea level is world **0**, land rises above it and
+> any seabed goes below it. With *Resample heights* left **off** (Step 2.2),
+> Workbench reads those metres directly, so **Height scale only sets the vertical
+> precision/range, not the data**. The engine default **0.03125** represents
+> roughly **-205 m to +1843 m**, which covers this map (range
+> **{min_elev:.1f} m to {max_elev:.1f} m**){'' if is_default_scale else f', except its span needs the larger value **{height_scale:.6g}** shown above'}.
+> Do **not** type the old computed fraction (e.g. `0.000185247`) — that value
+> was unnecessary and could not be entered in the dialog.
 
 ### Step 2.2: Import Heightmap
 
@@ -803,8 +814,8 @@ Terrain Grid Size X:    {face_x}
 Terrain Grid Size Z:    {face_x}
 Grid Cell Size:         {self.hm.get('grid_cell_size_m', 2.0)}m
 Terrain Size:           {self.hm.get('terrain_size_m', 'unknown')}
-Height Scale:           {self.elev.get('height_scale', 0.03125):.6g}
-Min Elevation:          {self.elev.get('min_elevation_m', 0):.1f}m
+Height Scale:           {self.elev.get('dialog_height_scale', 0.03125):.6g}  (New Terrain dialog value — leave at default)
+Min Elevation:          {self.elev.get('min_elevation_m', 0):.1f}m  (absolute; sea level = 0)
 Max Elevation:          {self.elev.get('max_elevation_m', 0):.1f}m
 Elevation Range:        {self.elev.get('max_elevation_m', 0) - self.elev.get('min_elevation_m', 0):.1f}m
 
@@ -883,7 +894,10 @@ changes, which is a separate hazard documented in Step 2.2.
 ### Terrain is flat after heightmap import
 - Did you **Save** and reopen the world after import? This is required.
 - Check that you imported `heightmap.asc` (not the preview PNG)
-- Verify the **Height scale** value in the New Terrain dialog was entered correctly
+- Make sure **Resample heights** was left **unchecked** — enabling it with the
+  default Lowest/Highest fields rescales the whole map into a 0–1 m strip
+- Leave **Height scale** at the dialog default (0.03125). It does **not** rescale
+  an `.asc` imported with Resample off, so a non-default value is not the cause
 
 ### Surface masks look wrong
 - Did you import in the correct order? (rock -> forest -> asphalt -> sand/dirt)

--- a/webapp/tests/test_setup_guide_generator.py
+++ b/webapp/tests/test_setup_guide_generator.py
@@ -371,6 +371,7 @@ class TestBuildMetadataFeatureSources:
                 "min_elevation": 0,
                 "max_elevation": 100,
                 "height_scale": 0.03125,
+                "dialog_height_scale": 0.03125,
                 "height_offset": 0,
             },
             "surface_result": {"mask_count": 1, "surfaces": ["grass"]},

--- a/webapp/tests/test_terrain_sizing.py
+++ b/webapp/tests/test_terrain_sizing.py
@@ -7,10 +7,10 @@ is 6400). These tests pin snap_to_tile_multiple() and the size constants it
 depends on.
 """
 
-from config.enfusion import snap_to_tile_multiple
+from config.enfusion import snap_to_tile_multiple, pick_clean_height_scale
 from config.terrain import (
     TERRAIN_TILE_FACES, MAX_TERRAIN_GRID_SIZE, MAX_MAP_EXTENT_M,
-    DEFAULT_GRID_CELL_SIZE,
+    DEFAULT_GRID_CELL_SIZE, DEFAULT_HEIGHT_SCALE,
 )
 
 
@@ -41,6 +41,40 @@ class TestSnapToTileMultiple:
     def test_clamped_to_maximum(self):
         assert snap_to_tile_multiple(20_000) == MAX_TERRAIN_GRID_SIZE
         assert snap_to_tile_multiple(10**9) == MAX_TERRAIN_GRID_SIZE
+
+
+class TestPickCleanHeightScale:
+    """Issue #142 — the New Terrain "Height scale" must be a clean, typeable
+    value (default 0.03125), not the old un-typeable ``range / 65535`` fraction.
+    Heightmaps import as absolute metres (sea = 0) with Resample off, so the
+    scale only has to *represent* the span, not rescale it."""
+
+    def test_142_example_returns_engine_default(self):
+        # The exact range from issue #142 (22.4 m – 34.5 m).
+        assert pick_clean_height_scale(22.4, 34.5) == DEFAULT_HEIGHT_SCALE
+
+    def test_typical_maps_use_default(self):
+        for mn, mx in [(0.0, 1.0), (0.0, 1000.0), (-30.0, 1200.0), (200.0, 800.0)]:
+            assert pick_clean_height_scale(mn, mx) == DEFAULT_HEIGHT_SCALE
+
+    def test_climbs_ladder_when_span_exceeds_default_band(self):
+        # max above the default +1843 m ceiling -> next clean value.
+        assert pick_clean_height_scale(400.0, 1900.0) == 0.0625
+        # seabed below the default -205 m floor -> climb as well.
+        assert pick_clean_height_scale(-300.0, 1500.0) == 0.0625
+
+    def test_result_always_represents_the_span(self):
+        for mn, mx in [(22.4, 34.5), (400.0, 1900.0), (-300.0, 1500.0),
+                       (0.0, 6000.0), (-1000.0, 5000.0)]:
+            hs = pick_clean_height_scale(mn, mx)
+            upper = hs * 65535.0 * 0.9
+            lower = -hs * 65535.0 * 0.1
+            assert mx <= upper + 1e-6
+            assert mn >= lower - 1e-6
+
+    def test_never_below_engine_default(self):
+        # A flat map must not produce a tiny (un-typeable) scale.
+        assert pick_clean_height_scale(50.0, 50.01) >= DEFAULT_HEIGHT_SCALE
 
 
 class TestTerrainConstants:


### PR DESCRIPTION
## Problem (#142)
The generated SETUP_GUIDE instructed users to type a computed **Height scale**
like `0.000185247` (`elevation_range / 65535`) into the World Editor's *New
Terrain* dialog. That value is un-typeable in the dialog and is also unnecessary.

## Analysis
Heightmaps are imported as **absolute metres above sea level** (sea = world `Y=0`,
land above, seabed below) with **Resample heights off**, so the `.asc` values load
directly. The dialog's height scale therefore only needs to be large enough to
**represent** the span — it does **not** rescale the data. Atlas 2 (the golden-
standard guide, p.4) explicitly says *"Height scale — leave at default."* The
engine default `0.03125` represents roughly **-205 m … +1843 m** (with the 10%
"Zero height to entity coord" reserve), covering essentially every real map.

## Change
- New `pick_clean_height_scale(min, max)` returns the engine default `0.03125`,
  climbing a clean power-of-two ladder (`0.0625`, `0.125`, …) **only** when a
  map's absolute span genuinely exceeds the default band.
- A new `dialog_height_scale` flows through the heightmap metadata; the existing
  `height_scale` is **unchanged** and still used solely for the `.asc` absolute
  round-trip.
- SETUP_GUIDE (Step 2.1, Quick Reference, Appendix B, troubleshooting) now shows
  the dialog value, tells users to leave it at default, and explains the sea = 0
  model. Removed the advice to type the old computed fraction.

## Tests
- `TestPickCleanHeightScale` pins the #142 example → `0.03125`, ladder climbing,
  and that the chosen scale always represents the span.
- Full suite: `400 passed`, 3 pre-existing baseline failures (missing host GIS
  deps), no new failures.

Closes #142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)