### PR TITLE
v1.6.2: SETUP_GUIDE correctness — normal map, satellite linear-color/reopen, mask→.emat table

### DIFF
--- a/webapp/config/enfusion.py
+++ b/webapp/config/enfusion.py
@@ -21,7 +21,7 @@ from config.terrain import (
 # enfusion_project_generator.py to stamp into every generated file header.
 # Bump here on every release; the README Docker tag pin should match.
 
-APP_VERSION = "1.6.1"
+APP_VERSION = "1.6.2"
 
 # ---------------------------------------------------------------------------
 # Base game dependency

--- a/webapp/services/setup_guide_generator.py
+++ b/webapp/services/setup_guide_generator.py
@@ -273,12 +273,33 @@ You should see this structure inside:
 
 6. Click **Import**
 
+> **About Invert in Z axis:** real-world `.asc` rows run north→south, but
+> Workbench's importer reads them south→north, so we leave **Invert in Z axis
+> checked** to keep north at the top. If your terrain looks mirrored against
+> `heightmap_preview.png` after import, re-import with this box **unchecked** —
+> Atlas 2 notes the correct setting can vary by data source.
+
+### Step 2.3: Generate the Normal Map
+
+After importing, generate the normal map so lighting and the paint tool have
+valid surface normals to work with:
+
+1. In the **Terrain Tool**, click **Generate normal map**
+2. If a **"Set normal map options"** dialog appears, click **OK** to accept the defaults
+3. Wait for it to finish
+
+> **Why this matters:** Atlas 2 lists this as a required post-import step, and a
+> missing/stale normal map is the documented cause of the "big square over part
+> of the terrain" artifact — regenerating the normal map fixes it.
+
+### Step 2.4: Save and Reopen
+
 > **CRITICAL**: After import, you **MUST** save the *world* (not just the terrain) and reopen it:
 > 1. **File > Save World** (Ctrl+S) — *not* the Terrain Tool's Save button, which only writes the .terr file
 > 2. Wait for the save to complete (watch the progress bar in the upper right corner)
 > 3. Close and reopen the world (double-click the .ent file again in the Resource Browser)
 
-### Step 2.3: Verify Terrain Shape
+### Step 2.5: Verify Terrain Shape
 
 After reopening, you should see your terrain with real-world elevation:
 - Mountains/hills at the correct positions
@@ -286,10 +307,7 @@ After reopening, you should see your terrain with real-world elevation:
 
 > **Tip**: Use the **heightmap_preview.png** in Sourcefiles/ as a visual reference
 > to verify the terrain shape matches expectations. You may need to navigate the
-> camera to see the terrain — try pressing **F** to focus on the selected entity.
-
-> **Note**: If a **"Set normal map options"** dialog appears, click **OK** to accept
-> the defaults."""
+> camera to see the terrain — try pressing **F** to focus on the selected entity."""
 
     def _phase_bootstrap_entities(self) -> str:
         """
@@ -398,8 +416,21 @@ The default surface covers 100% of your terrain as the base layer.
         lines.append("""
 ### Step 3.4: Import Surface Masks
 
-Import masks in this specific order (most specific surfaces first):
+Import masks in this specific order (most specific surfaces first).
 
+> **Mask file → material reference (issue #103):** the generated PNG file names
+> describe the *surface class*, while the Paint panel shows the *material* name.
+> They map like this:
+
+| Source mask file | World Editor material (.emat) |
+|------------------|-------------------------------|""")
+
+        for surface_name in present_ordered:
+            material = SURFACE_MATERIAL_MAP.get(surface_name, "Unknown.emat")
+            material_short = material.split("/")[-1]
+            lines.append(f"| `surface_{surface_name}.png` | `{material_short}` |")
+
+        lines.append("""
 > **Batch Import Option**: Right-click in the surface list > **Batch import surface masks**
 > to import all masks at once. If using batch import, ensure files are named to match
 > the surface materials. Otherwise, import individually:""")
@@ -467,8 +498,18 @@ manually later via Terrain Tool (Ctrl+T) > Manage tab > Import Satellite Map."""
 2. Go to the **Manage** tab
 3. Click **Import Satellite Map...**
 4. Navigate to: `{self.map_name}/Sourcefiles/satellite_map.png`
-5. Click **Import**
-6. **File > Save World** (Ctrl+S)
+5. **Turn OFF "Linear Color Space"** — the PNG is already in sRGB, so leaving
+   this on darkens the imagery. (If it still looks too dark, re-import with it on.)
+6. Click **Import**
+
+> **CRITICAL — Save and reopen before doing anything else:** Atlas 2 (p.8)
+> requires this after a satellite import.
+> 1. **File > Save World** (Ctrl+S)
+> 2. Close and reopen the world (double-click the .ent file in the Resource Browser)
+>
+> Do **not** start painting surfaces on the freshly-imported, not-yet-reopened
+> satellite state — re-baking the terrain in that state has been a source of
+> Workbench crashes on the first paint stroke.
 
 ### Step 4.2: Verify Alignment
 
@@ -476,6 +517,10 @@ The satellite image should align with your terrain features:
 - Roads visible in the satellite should match the terrain surface masks
 - Water bodies should align with terrain low points
 - Forest areas should match the forest floor surface mask
+
+> **Tip (Atlas 2 p.21):** to see the satellite imagery up close instead of only
+> from altitude, select the **Terrain** entity and turn its **Middle Distance
+> Max** all the way down in Object Properties.
 
 > **Source**: {self.satellite.get('source', 'Sentinel-2 Cloudless')} imagery ({self.satellite.get('dimensions', 'unknown')} pixels)"""
 


### PR DESCRIPTION
Aligns the generated `SETUP_GUIDE.md` with the **Atlas 2** golden-standard World
Editor workflow and closes several reporting gaps. Docs-only — no engine-file
changes.

## Changes
**Phase 2 — Terrain (M4 + invert-Z reasoning)**
- New explicit **Step 2.3: Generate the Normal Map** after heightmap import.
  Atlas 2 lists it as required, and a missing/stale normal map is the documented
  cause of the "big square over the terrain" artifact.
- Documented the **Invert in Z axis** reasoning (real `.asc` rows run north→south;
  setting can vary by data source — re-import unchecked if mirrored).

**Phase 5 — Satellite (M3, crash-path mitigation)**
- Instruct turning **OFF "Linear Color Space"** (Atlas 2 p.8).
- Mandatory **Save World + reopen** after satellite import, with an explicit
  warning **not to paint on a freshly-imported, not-yet-reopened satellite
  state** — the exact path in the #138 crash logs (sat import → paint → crash).
- Added the **Middle Distance Max** tip to view imagery up close (p.21).

**Phase 4 — Surfaces (#103)**
- Added a `surface_<name>.png → <Material>.emat` reference table so the generated
  mask file names line up with the material names shown in the Paint panel.

## Notes
- `SURFACE_IMPORT_ORDER` left unchanged (no certainty a reorder helps; the
  dirt-before-grass Atlas 2 note already ships).
- Full suite: `400 passed`, 3 pre-existing baseline failures (host GIS deps).

Refs #138 (sequencing mitigation), #103, #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)