### PR TITLE
v1.6.3: validate raster dimension/encoding contract + harden PNGs (refs #138)

### DIFF
--- a/webapp/config/enfusion.py
+++ b/webapp/config/enfusion.py
@@ -21,7 +21,7 @@ from config.terrain import (
 # enfusion_project_generator.py to stamp into every generated file header.
 # Bump here on every release; the README Docker tag pin should match.
 
-APP_VERSION = "1.6.2"
+APP_VERSION = "1.6.3"
 
 # ---------------------------------------------------------------------------
 # Base game dependency

--- a/webapp/services/map_generator.py
+++ b/webapp/services/map_generator.py
@@ -1229,6 +1229,36 @@ async def run_generation(job: MapGenerationJob):
             feature_sources=job.feature_sources,
         )
 
+        # Step 10b: Validate the raster dimension/encoding contract and harden
+        # PNG encodings. A mismatched mask/heightmap size or an unexpected
+        # channel/profile is a documented first-paint crash trigger
+        # (#100/#111/#115/#138). Non-fatal: log loudly, record in metadata.
+        try:
+            from services.raster_contract import validate_and_harden_rasters
+
+            grid = str(heightmap_result.get("terrain_grid_size", "")).split("x")
+            faces_x = int(grid[0])
+            faces_z = int(grid[1]) if len(grid) > 1 else faces_x
+            raster_report = validate_and_harden_rasters(
+                output_dir, faces_x, faces_z, job=job
+            )
+            metadata["raster_validation"] = raster_report
+            if raster_report["fixes"]:
+                job.add_log(
+                    f"Hardened raster encodings: {', '.join(raster_report['fixes'])}",
+                    "info",
+                )
+            if raster_report["ok"]:
+                job.add_log("Raster dimension/encoding contract OK", "success")
+            else:
+                job.add_log(
+                    f"Raster contract found {len(raster_report['issues'])} "
+                    f"issue(s) — see metadata.json raster_validation",
+                    "warning",
+                )
+        except Exception as exc:  # noqa: BLE001 - validation must never abort
+            logger.warning(f"[{job.job_id}] Raster contract validation skipped: {exc}")
+
         with open(output_dir / "metadata.json", "w") as f:
             json.dump(metadata, f, indent=2)
 

--- a/webapp/services/raster_contract.py
+++ b/webapp/services/raster_contract.py
@@ -1,0 +1,169 @@
+"""
+Raster dimension/encoding contract for generated terrain inputs.
+
+The Enfusion World Editor bakes the terrain's raster inputs (heightmap, surface
+masks, satellite map) into per-block textures. A mismatched dimension or an
+unexpected channel/profile is a documented cause of access-violation crashes on
+the first paint stroke (issues #100/#111/#115/#138). For a terrain of ``N`` faces
+per axis the contract is:
+
+* ``heightmap.asc``   -> ``(N+1) x (N+1)``  (faces + 1 vertices)
+* ``surface_*.png``   -> ``N x N``          (face resolution, 8-bit grayscale "L")
+* ``satellite_map.png`` -> square, plain 8-bit ``RGB`` (no alpha / ICC profile)
+
+``validate_and_harden_rasters`` checks every emitted raster against this
+contract, *auto-fixes* encoding issues it can fix safely (mask mode, satellite
+alpha/profile), and returns a structured report. Dimension mismatches are
+reported as issues (and logged loudly) rather than silently resampled — a wrong
+size means an upstream defect that must be found, not papered over.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+
+def parse_asc_header_dims(path: Path) -> tuple[int, int]:
+    """Return ``(ncols, nrows)`` from an ESRI ASCII grid header."""
+    ncols = nrows = None
+    with open(path, "r") as f:
+        for _ in range(8):  # header is the first ~6 lines
+            line = f.readline()
+            if not line:
+                break
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+            key = parts[0].lower()
+            if key == "ncols":
+                ncols = int(float(parts[1]))
+            elif key == "nrows":
+                nrows = int(float(parts[1]))
+            if ncols is not None and nrows is not None:
+                break
+    if ncols is None or nrows is None:
+        raise ValueError(f"Could not parse ncols/nrows from {path}")
+    return ncols, nrows
+
+
+def validate_and_harden_rasters(
+    output_dir: Path,
+    faces_x: int,
+    faces_z: int,
+    job: Optional[object] = None,
+) -> dict:
+    """
+    Validate the generated rasters against the terrain face grid and harden the
+    PNG encodings in place.
+
+    Args:
+        output_dir: The job's Sourcefiles output directory.
+        faces_x: Terrain faces per axis (X).
+        faces_z: Terrain faces per axis (Z).
+        job: Optional job with ``add_log(msg, level)`` for user-visible warnings.
+
+    Returns:
+        A report dict: ``{"ok": bool, "terrain_faces": [fx, fz],
+        "heightmap": {...}, "masks": [...], "satellite": {...},
+        "issues": [str, ...], "fixes": [str, ...]}``.
+    """
+    issues: list[str] = []
+    fixes: list[str] = []
+    report: dict = {
+        "terrain_faces": [faces_x, faces_z],
+        "expected_heightmap_px": [faces_x + 1, faces_z + 1],
+        "expected_mask_px": [faces_x, faces_z],
+        "heightmap": None,
+        "masks": [],
+        "satellite": None,
+        "issues": issues,
+        "fixes": fixes,
+    }
+
+    def _log_issue(msg: str) -> None:
+        issues.append(msg)
+        logger.error("Raster contract: %s", msg)
+        if job is not None and hasattr(job, "add_log"):
+            job.add_log(f"Raster contract issue: {msg}", "warning")
+
+    # --- heightmap.asc -------------------------------------------------------
+    asc = output_dir / "heightmap.asc"
+    if asc.exists():
+        try:
+            ncols, nrows = parse_asc_header_dims(asc)
+            report["heightmap"] = {"ncols": ncols, "nrows": nrows}
+            if (ncols, nrows) != (faces_x + 1, faces_z + 1):
+                _log_issue(
+                    f"heightmap.asc is {ncols}x{nrows}, expected "
+                    f"{faces_x + 1}x{faces_z + 1} (faces+1)"
+                )
+        except Exception as exc:  # noqa: BLE001 - report, never abort generation
+            _log_issue(f"could not read heightmap.asc header: {exc}")
+    else:
+        _log_issue("heightmap.asc is missing")
+
+    # --- surface_*.png -------------------------------------------------------
+    for mask_path in sorted(output_dir.glob("surface_*.png")):
+        if mask_path.name == "surface_preview.png":
+            continue  # RGB human-readable preview, not a paint mask
+        entry = {"file": mask_path.name, "size": None, "mode": None}
+        try:
+            with Image.open(mask_path) as img:
+                size, mode = img.size, img.mode
+                entry["size"] = list(size)
+                entry["mode"] = mode
+                # Harden encoding: paint masks must be single-channel 8-bit "L".
+                if mode != "L":
+                    img.convert("L").save(str(mask_path), format="PNG")
+                    entry["mode"] = "L"
+                    fixes.append(f"{mask_path.name}: {mode} -> L")
+                if size != (faces_x, faces_z):
+                    _log_issue(
+                        f"{mask_path.name} is {size[0]}x{size[1]}, expected "
+                        f"{faces_x}x{faces_z} (face resolution)"
+                    )
+        except Exception as exc:  # noqa: BLE001
+            _log_issue(f"could not read {mask_path.name}: {exc}")
+        report["masks"].append(entry)
+
+    # --- satellite_map.png ---------------------------------------------------
+    sat = output_dir / "satellite_map.png"
+    if sat.exists():
+        entry = {"file": sat.name, "size": None, "mode": None}
+        try:
+            with Image.open(sat) as img:
+                size, mode = img.size, img.mode
+                entry["size"] = list(size)
+                entry["mode"] = mode
+                # Strip alpha / palette / ICC profile -> plain RGB.
+                has_profile = bool(img.info.get("icc_profile"))
+                if mode != "RGB" or has_profile:
+                    img.convert("RGB").save(str(sat), format="PNG")
+                    entry["mode"] = "RGB"
+                    fixes.append(
+                        f"{sat.name}: {mode}"
+                        f"{'+icc' if has_profile else ''} -> RGB"
+                    )
+                if size[0] != size[1]:
+                    # Non-square is not fatal (Workbench resamples) but flag it.
+                    _log_issue(
+                        f"satellite_map.png is non-square {size[0]}x{size[1]}"
+                    )
+        except Exception as exc:  # noqa: BLE001
+            _log_issue(f"could not read satellite_map.png: {exc}")
+        report["satellite"] = entry
+
+    report["ok"] = not issues
+    logger.info(
+        "Raster contract: faces=%dx%d, heightmap=%s, masks=%d, satellite=%s, "
+        "issues=%d, fixes=%d",
+        faces_x, faces_z, report["heightmap"], len(report["masks"]),
+        report["satellite"], len(issues), len(fixes),
+    )
+    return report

--- a/webapp/tests/test_raster_contract.py
+++ b/webapp/tests/test_raster_contract.py
@@ -1,0 +1,100 @@
+"""
+Raster dimension/encoding contract (issues #100/#111/#115/#138).
+
+For a terrain of N faces per axis:
+  heightmap.asc  -> (N+1) x (N+1)
+  surface_*.png  -> N x N, 8-bit grayscale "L"
+  satellite      -> square, plain RGB (no alpha/ICC)
+"""
+
+import numpy as np
+from PIL import Image
+
+from services.raster_contract import (
+    parse_asc_header_dims,
+    validate_and_harden_rasters,
+)
+
+FACES = 256  # one example terrain grid size (a tile multiple)
+
+
+def _write_asc(path, ncols, nrows):
+    with open(path, "w") as f:
+        f.write(f"ncols         {ncols}\n")
+        f.write(f"nrows         {nrows}\n")
+        f.write("xllcorner     0.0\n")
+        f.write("yllcorner     0.0\n")
+        f.write("cellsize      2.0\n")
+        f.write("NODATA_value  -9999\n")
+        f.write("0.0 0.0\n")
+
+
+def _write_mask(path, w, h, mode="L"):
+    arr = np.zeros((h, w), dtype=np.uint8)
+    Image.fromarray(arr, mode="L").convert(mode).save(str(path))
+
+
+def _good_project(tmp_path):
+    _write_asc(tmp_path / "heightmap.asc", FACES + 1, FACES + 1)
+    _write_mask(tmp_path / "surface_grass.png", FACES, FACES)
+    _write_mask(tmp_path / "surface_asphalt.png", FACES, FACES)
+    Image.new("RGB", (1024, 1024)).save(str(tmp_path / "satellite_map.png"))
+
+
+class TestParseAscHeader:
+    def test_reads_ncols_nrows(self, tmp_path):
+        _write_asc(tmp_path / "h.asc", 513, 513)
+        assert parse_asc_header_dims(tmp_path / "h.asc") == (513, 513)
+
+
+class TestContractHappyPath:
+    def test_well_formed_project_is_ok(self, tmp_path):
+        _good_project(tmp_path)
+        report = validate_and_harden_rasters(tmp_path, FACES, FACES)
+        assert report["ok"] is True
+        assert report["issues"] == []
+        assert report["heightmap"] == {"ncols": FACES + 1, "nrows": FACES + 1}
+
+    def test_preview_png_is_ignored(self, tmp_path):
+        _good_project(tmp_path)
+        # An RGB preview at a different size must not trip the mask check.
+        Image.new("RGB", (512, 512)).save(str(tmp_path / "surface_preview.png"))
+        report = validate_and_harden_rasters(tmp_path, FACES, FACES)
+        assert report["ok"] is True
+
+
+class TestContractDetectsDefects:
+    def test_vertex_resolution_mask_is_flagged(self, tmp_path):
+        # The #100 regression: masks written at N+1 instead of N.
+        _good_project(tmp_path)
+        _write_mask(tmp_path / "surface_grass.png", FACES + 1, FACES + 1)
+        report = validate_and_harden_rasters(tmp_path, FACES, FACES)
+        assert report["ok"] is False
+        assert any("surface_grass.png" in i for i in report["issues"])
+
+    def test_wrong_heightmap_size_is_flagged(self, tmp_path):
+        _good_project(tmp_path)
+        _write_asc(tmp_path / "heightmap.asc", FACES, FACES)  # forgot the +1
+        report = validate_and_harden_rasters(tmp_path, FACES, FACES)
+        assert report["ok"] is False
+        assert any("heightmap.asc" in i for i in report["issues"])
+
+
+class TestEncodingHardening:
+    def test_rgb_mask_is_converted_to_grayscale(self, tmp_path):
+        _good_project(tmp_path)
+        Image.new("RGB", (FACES, FACES)).save(str(tmp_path / "surface_dirt.png"))
+        report = validate_and_harden_rasters(tmp_path, FACES, FACES)
+        with Image.open(tmp_path / "surface_dirt.png") as img:
+            assert img.mode == "L"
+        assert any("surface_dirt.png" in fx for fx in report["fixes"])
+        # Converting encoding must not, by itself, make the project not-ok.
+        assert report["ok"] is True
+
+    def test_rgba_satellite_is_flattened_to_rgb(self, tmp_path):
+        _good_project(tmp_path)
+        Image.new("RGBA", (1024, 1024)).save(str(tmp_path / "satellite_map.png"))
+        report = validate_and_harden_rasters(tmp_path, FACES, FACES)
+        with Image.open(tmp_path / "satellite_map.png") as img:
+            assert img.mode == "RGB"
+        assert report["ok"] is True


### PR DESCRIPTION
The Enfusion paint bake reads the terrain's raster inputs per block. A mismatched
mask/heightmap size or an unexpected channel/profile is a documented first-paint
crash trigger (#100/#111/#115/#138). The previously-fixed causes (terrain GUID,
env block, vertex-vs-face masks) are confirmed gone in the #138 logs, so this PR
adds a **regression-proof guarantee** on the raster inputs themselves.

## New: `services/raster_contract.py`
For a terrain of `N` faces per axis:
- `heightmap.asc` → `(N+1) x (N+1)`
- `surface_*.png` → `N x N`, 8-bit grayscale `L`
- `satellite_map.png` → square, plain `RGB` (no alpha/ICC)

`validate_and_harden_rasters()`:
- **Auto-fixes** encodings it can fix safely: mask → single-channel `L`;
  satellite → `RGB` with alpha/ICC stripped.
- **Reports + logs loudly** on any dimension mismatch (never silently resampled —
  a wrong size is an upstream defect to find, e.g. the #100 vertex-resolution
  mask regression).

## Pipeline
`map_generator` runs the finalize step after `build_metadata`, stores the report
under `metadata["raster_validation"]`, and surfaces fixes/issues in the job log.
Non-fatal — it never aborts a generation.

## Tests
`tests/test_raster_contract.py`: happy path, #100 vertex-res regression, wrong
heightmap size, RGB→L and RGBA→RGB hardening, preview-png skip. Full suite:
`407 passed`, 3 pre-existing baseline failures (host GIS deps).

Refs #138, #100, #111, #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)