### PR TITLE
v1.7.0: crash-audit & Atlas 2 alignment release

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ The application is published to GitHub Container Registry and automatically buil
 docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:latest
 
 # Or use a specific version tag
-docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.5.14
+docker pull ghcr.io/tubalainen/arma_reforger_base_map_generator_ng:v1.7.0
 ```
 
 The `docker-compose.yml` is pre-configured to use the GHCR.io image. See the [Quick Start Guide](#quick-start-guide) for setup instructions.

--- a/webapp/config/enfusion.py
+++ b/webapp/config/enfusion.py
@@ -21,7 +21,7 @@ from config.terrain import (
 # enfusion_project_generator.py to stamp into every generated file header.
 # Bump here on every release; the README Docker tag pin should match.
 
-APP_VERSION = "1.6.5"
+APP_VERSION = "1.7.0"
 
 # ---------------------------------------------------------------------------
 # Base game dependency


### PR DESCRIPTION
Minor release rolling up the 2026-06-07 crash-audit phase (v1.6.1–v1.6.5).

- **v1.6.1** New Terrain "Height scale" uses the engine default, not `range/65535` (closes #142)
- **v1.6.2** SETUP_GUIDE Atlas 2 alignment — Generate Normal Map step, satellite Linear-Color-off + reopen-before-paint, `surface_*.png → .emat` table (refs #103/#120/#138)
- **v1.6.3** raster dimension/encoding contract + PNG hardening (refs #138)
- **v1.6.4** forest/lake polygon clipping + never emit self-intersecting rings (closes #139, refs #105)
- **v1.6.5** verified against Arma Reforger Tools 1.7.0.41

Bumps `APP_VERSION` to 1.7.0 and the README example image tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)