### PR TITLE
v1.7.1: skip LiDAR point-cloud assets in STAC Höjd elevation fetch (closes #149)

### DIFF
--- a/webapp/config/enfusion.py
+++ b/webapp/config/enfusion.py
@@ -21,7 +21,7 @@ from config.terrain import (
 # enfusion_project_generator.py to stamp into every generated file header.
 # Bump here on every release; the README Docker tag pin should match.
 
-APP_VERSION = "1.7.0"
+APP_VERSION = "1.7.1"
 
 # ---------------------------------------------------------------------------
 # Base game dependency

--- a/webapp/services/lantmateriet/stac_elevation.py
+++ b/webapp/services/lantmateriet/stac_elevation.py
@@ -50,6 +50,27 @@ from services.lantmateriet.auth import get_basic_auth_header
 logger = logging.getLogger(__name__)
 
 
+def _is_raster_asset(asset: Optional[dict]) -> bool:
+    """
+    True if a STAC 'data' asset is a raster GeoTIFF we can merge.
+
+    The STAC Höjd catalog mixes raster grid products (grid1m, mhm — served as
+    .tif under /grid1m/ and /grid/mhm/) with LiDAR point clouds (COPC LAS/LAZ —
+    served as .copc.laz under /pointcloud/). The point clouds are not rasters:
+    downloading them wastes hundreds of MB and they are then rejected by the
+    TIFF magic-byte check. Filter them out up front (see issue #149).
+    """
+    if not asset:
+        return False
+    href = (asset.get("href") or "").lower()
+    media = (asset.get("type") or "").lower()
+    if href.endswith((".tif", ".tiff")):
+        return True
+    if "tiff" in media or "geotiff" in media:
+        return True
+    return False
+
+
 def _get_download_headers() -> dict:
     """
     Get headers for downloading assets from dl1.lantmateriet.se.
@@ -143,6 +164,27 @@ async def fetch_stac_elevation(
                 return None
 
             logger.info(f"STAC Höjd returned {len(features)} item(s)")
+
+            # Keep only items whose 'data' asset is a raster GeoTIFF. The catalog
+            # also returns LiDAR point-cloud (.copc.laz) items for the same bbox;
+            # those are not mergeable rasters and downloading them just wastes
+            # bandwidth before the TIFF check rejects them (see issue #149).
+            raster_features = [
+                feat for feat in features
+                if _is_raster_asset(feat.get("assets", {}).get("data"))
+            ]
+            skipped_nonraster = len(features) - len(raster_features)
+            if skipped_nonraster:
+                logger.info(
+                    f"STAC Höjd: skipping {skipped_nonraster} non-raster "
+                    f"(point-cloud) item(s), {len(raster_features)} raster tile(s) remain"
+                )
+            features = raster_features
+
+            if not features:
+                logger.warning("No raster elevation tiles found in STAC Höjd search")
+                return None
+
             if job:
                 job.add_log(f"Found {len(features)} elevation tiles to download")
 

--- a/webapp/tests/test_lantmateriet.py
+++ b/webapp/tests/test_lantmateriet.py
@@ -822,6 +822,58 @@ class TestMarktackeTranslation:
 
 
 # ---------------------------------------------------------------------------
+# STAC Höjd asset filtering unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestStacElevationAssetFilter:
+    """Test _is_raster_asset() — keeps GeoTIFF tiles, drops point clouds (#149)."""
+
+    def test_grid1m_tif_is_raster(self):
+        from services.lantmateriet.stac_elevation import _is_raster_asset
+
+        asset = {
+            "href": "https://dl1.lantmateriet.se/hojd/data/grid1m/65_5/50/65600_5425_25.tif",
+            "type": "image/tiff; application=geotiff",
+        }
+        assert _is_raster_asset(asset) is True
+
+    def test_mhm_grid_tif_is_raster(self):
+        from services.lantmateriet.stac_elevation import _is_raster_asset
+
+        asset = {"href": "https://dl1.lantmateriet.se/hojd/data/grid/mhm/65_5/m656_54.tif"}
+        assert _is_raster_asset(asset) is True
+
+    def test_copc_laz_pointcloud_is_not_raster(self):
+        """The exact asset that failed in issue #149."""
+        from services.lantmateriet.stac_elevation import _is_raster_asset
+
+        asset = {
+            "href": "https://dl1.lantmateriet.se/hojd/data/pointcloud/sls/23c024/m23c024-656_53.copc.laz",
+            "type": "application/vnd.laszip+copc",
+        }
+        assert _is_raster_asset(asset) is False
+
+    def test_plain_laz_is_not_raster(self):
+        from services.lantmateriet.stac_elevation import _is_raster_asset
+
+        assert _is_raster_asset({"href": "https://example/tile.laz"}) is False
+
+    def test_raster_detected_via_media_type_only(self):
+        """Href without a clear extension still passes on a TIFF media type."""
+        from services.lantmateriet.stac_elevation import _is_raster_asset
+
+        asset = {"href": "https://example/download?id=42", "type": "image/tiff"}
+        assert _is_raster_asset(asset) is True
+
+    def test_none_asset_is_not_raster(self):
+        from services.lantmateriet.stac_elevation import _is_raster_asset
+
+        assert _is_raster_asset(None) is False
+        assert _is_raster_asset({}) is False
+
+
+# ---------------------------------------------------------------------------
 # Feature dispatch unit tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What #149 actually was

The two "failed tiles" were **not** a transient download failure — so retrying would not help. They downloaded with **HTTP 200 OK** and were correctly rejected by the existing TIFF magic-byte check because their content starts with `LASF`: they are **COPC LiDAR point clouds** (`m23c024-656_53.copc.laz` ≈ 730 MB, `m23c024-656_54.copc.laz` ≈ 180 MB), not raster GeoTIFFs. Note the URL path `/pointcloud/` vs the working tiles' `/grid1m/` and `/grid/mhm/`.

**The affected generation actually succeeded** — the 8 raster tiles fully covered the area (`Merged 8 tiles into 20000x10000 px array` → `3584x3583 px GeoTIFF`). Nothing was missing from the output.

## Why this happened

The STAC Höjd catalog returns point-cloud items alongside the grid raster items for the same bbox. `fetch_stac_elevation()` downloaded the `data` asset of *every* feature, then discarded the point clouds after a full ~900 MB download — wasting bandwidth and emitting alarming `STAC asset is not valid TIFF data` warnings on every Swedish job that overlaps point-cloud coverage.

## Fix

- New module-level `_is_raster_asset()` — true only for assets whose href ends `.tif`/`.tiff` or whose media type is TIFF/GeoTIFF.
- Filter the STAC feature list to raster tiles **before** scheduling downloads. Point-cloud items are skipped up front and logged as *skipped* (not failed), and never hit the network.

Retrying was never the right answer here — it would re-download the identical LAZ files and fail the same way. This stops them being attempted at all.

## Tests

Adds `TestStacElevationAssetFilter` (6 cases, including the exact failing `.copc.laz` href from #149). All pass; rest of the suite green aside from the one documented pre-existing env-dependent baseline failure.

Closes #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)