### PR TITLE
v1.7.2: fix naming, crash triggers, and farmland classification from #151 feedback

### DIFF
--- a/webapp/config/enfusion.py
+++ b/webapp/config/enfusion.py
@@ -95,53 +95,64 @@ WORLD_ENV_LENS_FLARES_CONFIG = (
 # Base path for all Enfusion surface materials
 SURFACE_MATERIAL_BASE = "ArmaReforger/Terrains/Common/Surfaces"
 
-# Map from our generated mask name -> Enfusion material resource path
+# Map from our generated mask name -> Enfusion material resource path.
+# Entries marked in SURFACE_MATERIAL_VERIFIED below have been confirmed to
+# exist in the Resource Browser under ArmaReforger/Terrains/Common/Surfaces/.
+# Unverified entries are flagged in the SETUP_GUIDE with a "browse to find"
+# note rather than a hardcoded path the user may not have.
 SURFACE_MATERIAL_MAP = {
-    "grass": f"{SURFACE_MATERIAL_BASE}/Grass_01.emat",
-    "forest_floor": f"{SURFACE_MATERIAL_BASE}/ForestFloor_01.emat",
-    "pine_floor": f"{SURFACE_MATERIAL_BASE}/ForestFloor_Pine_01.emat",
-    "asphalt": f"{SURFACE_MATERIAL_BASE}/Asphalt_01.emat",
-    "gravel": f"{SURFACE_MATERIAL_BASE}/Gravel_01.emat",
-    "dirt": f"{SURFACE_MATERIAL_BASE}/Dirt_01.emat",
-    "rock": f"{SURFACE_MATERIAL_BASE}/Rock_01.emat",
-    "sand": f"{SURFACE_MATERIAL_BASE}/Sand_01.emat",
-    "water_edge": f"{SURFACE_MATERIAL_BASE}/Mud_01.emat",
+    "grass":        f"{SURFACE_MATERIAL_BASE}/Grass_01.emat",
+    "forest_floor": f"{SURFACE_MATERIAL_BASE}/ForestFloor_01.emat",  # UNVERIFIED — see #151
+    "pine_floor":   f"{SURFACE_MATERIAL_BASE}/ForestFloor_Pine_01.emat",  # UNVERIFIED — see #151
+    "asphalt":      f"{SURFACE_MATERIAL_BASE}/Asphalt_01.emat",
+    "gravel":       f"{SURFACE_MATERIAL_BASE}/Gravel_01.emat",
+    "crop":         f"{SURFACE_MATERIAL_BASE}/Crop_01.emat",
+    "dirt":         f"{SURFACE_MATERIAL_BASE}/Dirt_01.emat",
+    "rock":         f"{SURFACE_MATERIAL_BASE}/Rock_01.emat",
+    "sand":         f"{SURFACE_MATERIAL_BASE}/Sand_01.emat",
+    "water_edge":   f"{SURFACE_MATERIAL_BASE}/Mud_01.emat",  # UNVERIFIED — see #151
 }
 
-# Alternative materials the user can swap to (for SETUP_GUIDE reference)
+# Materials confirmed to exist in a vanilla Reforger install's Resource Browser
+# under ArmaReforger/Terrains/Common/Surfaces/. Names NOT in this set are shown
+# with a "browse to find" instruction in the SETUP_GUIDE instead of a hardcoded
+# path. Update this set when a user confirms a name is valid.
+SURFACE_MATERIAL_VERIFIED: frozenset[str] = frozenset({
+    "grass",
+    "asphalt",
+    "gravel",
+    "crop",
+    "dirt",
+    "rock",
+    "sand",
+})
+
+# Alternative materials the user can swap to (for SETUP_GUIDE reference).
+# Only list alternatives that are confirmed to exist; remove any that have
+# been reported as non-existent (Mud_01, Asphalt_Cracked_01, Rock_Granite_01
+# were unverified — removed in v1.8.0, issue #151).
 SURFACE_MATERIAL_ALTERNATIVES = {
     "grass": [
         f"{SURFACE_MATERIAL_BASE}/Grass_02.emat",
         f"{SURFACE_MATERIAL_BASE}/Grass_03.emat",
     ],
-    "forest_floor": [
-        f"{SURFACE_MATERIAL_BASE}/Moss_01.emat",
-    ],
-    "pine_floor": [
-        f"{SURFACE_MATERIAL_BASE}/ForestFloor_01.emat",
-        f"{SURFACE_MATERIAL_BASE}/Moss_01.emat",
-    ],
     "asphalt": [
         f"{SURFACE_MATERIAL_BASE}/Concrete_01.emat",
-        f"{SURFACE_MATERIAL_BASE}/Asphalt_Cracked_01.emat",
     ],
     "gravel": [
         f"{SURFACE_MATERIAL_BASE}/Rock_01.emat",
         f"{SURFACE_MATERIAL_BASE}/Dirt_01.emat",
     ],
+    "crop": [
+        f"{SURFACE_MATERIAL_BASE}/Crop_02.emat",
+    ],
     "dirt": [
-        f"{SURFACE_MATERIAL_BASE}/Mud_01.emat",
         f"{SURFACE_MATERIAL_BASE}/Sand_01.emat",
     ],
     "rock": [
-        f"{SURFACE_MATERIAL_BASE}/Rock_Granite_01.emat",
         f"{SURFACE_MATERIAL_BASE}/Gravel_01.emat",
     ],
     "sand": [
-        f"{SURFACE_MATERIAL_BASE}/Dirt_01.emat",
-    ],
-    "water_edge": [
-        f"{SURFACE_MATERIAL_BASE}/Sand_01.emat",
         f"{SURFACE_MATERIAL_BASE}/Dirt_01.emat",
     ],
 }
@@ -149,7 +160,7 @@ SURFACE_MATERIAL_ALTERNATIVES = {
 # Recommended import order (most specific -> least specific)
 SURFACE_IMPORT_ORDER = [
     "rock", "pine_floor", "forest_floor", "asphalt",
-    "gravel", "dirt", "sand", "water_edge",
+    "gravel", "crop", "dirt", "sand", "water_edge",
 ]
 
 # ---------------------------------------------------------------------------

--- a/webapp/config/enfusion.py
+++ b/webapp/config/enfusion.py
@@ -21,7 +21,7 @@ from config.terrain import (
 # enfusion_project_generator.py to stamp into every generated file header.
 # Bump here on every release; the README Docker tag pin should match.
 
-APP_VERSION = "1.7.1"
+APP_VERSION = "1.7.2"
 
 # ---------------------------------------------------------------------------
 # Base game dependency
@@ -130,7 +130,7 @@ SURFACE_MATERIAL_VERIFIED: frozenset[str] = frozenset({
 # Alternative materials the user can swap to (for SETUP_GUIDE reference).
 # Only list alternatives that are confirmed to exist; remove any that have
 # been reported as non-existent (Mud_01, Asphalt_Cracked_01, Rock_Granite_01
-# were unverified — removed in v1.8.0, issue #151).
+# were unverified — removed in v1.7.2, issue #151).
 SURFACE_MATERIAL_ALTERNATIVES = {
     "grass": [
         f"{SURFACE_MATERIAL_BASE}/Grass_02.emat",

--- a/webapp/config/surfaces.py
+++ b/webapp/config/surfaces.py
@@ -3,7 +3,8 @@
 SURFACE_CLASSES: dict[str, dict] = {
     "asphalt":      {"color": 128, "description": "Paved roads and urban areas"},
     "gravel":       {"color": 160, "description": "Gravel roads and paths"},
-    "dirt":         {"color": 140, "description": "Dirt paths and plowed fields"},
+    "crop":         {"color": 145, "description": "Agricultural land / crop fields"},
+    "dirt":         {"color": 140, "description": "Dirt roads and paths"},
     "grass":        {"color": 100, "description": "Grassland and meadows"},
     "forest_floor": {"color":  80, "description": "Forest floor - deciduous"},
     "pine_floor":   {"color":  70, "description": "Forest floor - coniferous"},

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -617,10 +617,19 @@ async def download_result(request: Request, job_id: str, token: Optional[str] = 
 
         logger.info(f"Download started for job {job_id[:8]}... via {auth_method}")
 
+        # Use the map name as the download filename so the user sees e.g.
+        # "SE_59N_18E.zip" rather than a random job-ID string.
+        raw_map_name = (job.result or {}).get("metadata", {}).get("map_name", "")
+        if raw_map_name:
+            from services.enfusion_project_generator import sanitize_project_name as _san
+            download_name = f"{_san(raw_map_name)}.zip"
+        else:
+            download_name = f"arma_reforger_map_{job_id[:8]}.zip"
+
         return FileResponse(
             path=str(zip_path),
             media_type="application/zip",
-            filename=f"arma_reforger_map_{job_id[:16]}.zip",
+            filename=download_name,
             headers={
                 "X-File-Retention": retention_msg,
             },

--- a/webapp/services/export_service.py
+++ b/webapp/services/export_service.py
@@ -165,6 +165,7 @@ def organize_export_structure(output_dir: Path, map_name: str, job=None):
         "surface_pine_floor.png",
         "surface_asphalt.png",
         "surface_gravel.png",
+        "surface_crop.png",
         "surface_dirt.png",
         "surface_rock.png",
         "surface_sand.png",

--- a/webapp/services/map_generator.py
+++ b/webapp/services/map_generator.py
@@ -23,6 +23,7 @@ import math
 import secrets
 import shutil
 import threading
+import zipfile
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
@@ -1355,11 +1356,17 @@ async def run_generation(job: MapGenerationJob):
 
         job.progress = 95
         job.add_log("Creating ZIP archive...")
-        zip_path = OUTPUT_DIR / f"map_{job.job_id}"
-        shutil.make_archive(str(zip_path), "zip", output_dir)
-
-        # Verify ZIP file exists before marking as completed
         zip_file = OUTPUT_DIR / f"map_{job.job_id}.zip"
+
+        # Write ZIP with {sanitized_name}/ as top-level folder so the user
+        # can copy that named folder straight into their addons directory,
+        # matching the SETUP_GUIDE "Copy the {map_name}/ folder" instruction.
+        with zipfile.ZipFile(str(zip_file), "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            for fpath in output_dir.rglob("*"):
+                if fpath.is_file():
+                    arcname = sanitized_name + "/" + str(fpath.relative_to(output_dir))
+                    zf.write(str(fpath), arcname)
+
         if not zip_file.exists():
             raise RuntimeError("ZIP file was not created successfully")
 

--- a/webapp/services/setup_guide_generator.py
+++ b/webapp/services/setup_guide_generator.py
@@ -21,6 +21,7 @@ from config.enfusion import (
     APP_VERSION,
     SURFACE_MATERIAL_MAP,
     SURFACE_MATERIAL_ALTERNATIVES,
+    SURFACE_MATERIAL_VERIFIED,
     SURFACE_IMPORT_ORDER,
     DEFAULT_ADDON_DIR,
     MANDATORY_BOOTSTRAP_KEYS,
@@ -91,6 +92,7 @@ class SetupGuideGenerator:
         sections = [
             self._header(),
             self._quick_reference(),
+            self._quick_path(),
             self._prerequisites(),
             self._phase_project_setup(),
             self._phase_terrain_creation(),
@@ -159,6 +161,29 @@ class SetupGuideGenerator:
 | **Ambient Sound** | {ambient_prefab} |
 | **Estimated Setup Time** | ~20-30 minutes |"""
 
+    def _quick_path(self) -> str:
+        """Compact 8-step summary for experienced World Editor creators."""
+        dims = self.hm.get("dimensions", "")
+        parts = dims.split("x")
+        face_x = int(parts[0]) - 1 if parts and parts[0].isdigit() else "?"
+        cell_size = self.hm.get("grid_cell_size_m", 2.0)
+        height_scale = self.elev.get("dialog_height_scale", 0.03125)
+
+        return f"""## Quick Path (experienced users)
+
+> Skip straight to the number you need. Every value is pre-computed — nothing to calculate.
+
+1. **Copy** `{self.map_name}/` from the ZIP → `{DEFAULT_ADDON_DIR}\\`
+2. **Add project** in Workbench launcher → `{self.map_name}\\addon.gproj` → open `{self.map_name}.ent`
+3. **Create terrain** (right-click **Terrain** in hierarchy): grid `{face_x}×{face_x}`, cell `{cell_size}m`, height scale `{height_scale:.6g}` (default)
+4. **Import heightmap**: `Sourcefiles/heightmap.asc` — ✓ Invert Z axis, ✗ Resample heights → **Generate normal map** → **File > Save World** → reopen
+5. **Paint surfaces** (Terrain Tool → Paint tab): for each surface, right-click the `.emat` in the Resource Browser → **Fill surface layer** → right-click surface in panel → **Priority Surface Mask Import** → pick `Sourcefiles/surface_<name>.png`
+6. **Import satellite**: `Sourcefiles/satellite_map.png` — turn **off** Linear Color Space → **File > Save World** → reopen
+7. **Roads**: each `SplineShapeEntity` in the `roads` layer needs a **RoadGeneratorEntity** child; prefab names are in `Reference/roads_reference.csv`
+8. **Play** (F5) — spawn in Game Master mode to verify terrain, surfaces, and roads
+
+> Full step-by-step instructions with screenshots references start at **Phase 1** below."""
+
     def _prerequisites(self) -> str:
         return """## Prerequisites
 
@@ -223,9 +248,9 @@ You should see this structure inside:
 
 ### Step 2.1: Create New Terrain
 
-1. In the World Editor, select the **GenericTerrainEntity** in the hierarchy
-   (it should already be at position 0, 0, 0)
-2. Right-click the terrain entity > **Create new terrain...**
+1. In the World Editor, select the **Terrain** entity in the hierarchy
+   (its class type is `GenericTerrainEntity` — should be at position 0, 0, 0)
+2. Right-click the **Terrain** entity > **Create new terrain...**
 3. In the **New Terrain** dialog, enter these **exact** values:
 
 | Parameter | Value |
@@ -372,11 +397,13 @@ We'll import pre-generated surface masks to paint it with realistic materials.
 
 The default surface covers 100% of your terrain as the base layer.
 
-1. The first surface in the Paint panel is the default — it cannot be removed
-2. Right-click it > **Change layer's material...**
-3. In the Resource Browser, navigate to:
-   `{self.default_material}`
-4. Select it and click **OK**
+> ⚠️ **Do NOT use "Change layer's material..." on the first (default) layer.** That action
+> has triggered Workbench NVTT crashes on multiple reports. Use **Fill surface layer** instead:
+
+1. In the **Resource Browser**, navigate to `ArmaReforger/Terrains/Common/Surfaces/`
+2. Find **`{self.default_material.split("/")[-1]}`** (search by name if needed)
+3. Right-click it → **Fill surface layer**
+4. The default layer now shows the correct material — no dialog interaction needed
 
 > **Why {self.recommended_default}?** Your terrain is {self.coverage_per_surface.get(self.recommended_default, {}).get('percentage', 'N/A')}% {self.recommended_default},
 > making it the optimal default surface."""]
@@ -406,11 +433,17 @@ The default surface covers 100% of your terrain as the base layer.
 
         for i, surface_name in enumerate(present_ordered, 1):
             material = SURFACE_MATERIAL_MAP.get(surface_name, "Unknown.emat")
+            material_short = material.split("/")[-1]
+            verified = surface_name in SURFACE_MATERIAL_VERIFIED
             alternatives = SURFACE_MATERIAL_ALTERNATIVES.get(surface_name, [])
             alt_str = f" (alternatives: {', '.join(a.split('/')[-1] for a in alternatives)})" if alternatives else ""
 
-            lines.append(f"""
-{i}. Drag **`{material}`** from the Resource Browser into the surface layer list{alt_str}""")
+            if verified:
+                lines.append(f"""
+{i}. Drag **`{material_short}`** from the Resource Browser into the surface layer list{alt_str}""")
+            else:
+                lines.append(f"""
+{i}. In the Resource Browser navigate to `ArmaReforger/Terrains/Common/Surfaces/` and find the **{surface_name.replace('_', ' ')}** material (suggested name: `{material_short}` — verify it exists in your install){alt_str}. Drag it into the surface layer list.""")
 
         # Step 3.4: Import masks
         lines.append("""
@@ -882,6 +915,28 @@ Countries:              {', '.join(self.input_data.get('countries', ['Unknown'])
 
     def _appendix_troubleshooting(self) -> str:
         return """## Appendix C: Troubleshooting
+
+### World crashes when reopening after surface painting (issue #151)
+Symptom: surface painting works normally, but the next time you double-click the world
+`.ent` to reopen, Workbench crashes.
+
+Most likely cause: one or more materials in the Paint panel do not exist in your
+Resource Browser. Workbench silently saves a reference to the missing path; on reload
+NVTT fails to resolve it and crashes. This can happen if you followed an older guide
+that mentioned `ForestFloor_01.emat` or `Mud_01.emat` — those names do not exist in all
+Reforger installs.
+
+Fix:
+1. Open the project in Workbench (if it won't open, create a new empty world first to get
+   access to the Resource Browser)
+2. In the Resource Browser, confirm every material listed in your Paint panel exists under
+   `ArmaReforger/Terrains/Common/Surfaces/`
+3. Remove any unrecognised materials from the Paint panel before saving
+4. Use **Fill surface layer** (right-click `.emat` in Resource Browser) rather than
+   "Change layer's material..." on the default layer — the latter has been a crash trigger
+
+If the world will not open at all, restore from a backup before the surface painting
+step, or regenerate the map and follow the updated Step 3.2 instructions.
 
 ### Workbench crashes the instant you brush any surface paint (issue #111)
 Look in `error.log` for lines like:

--- a/webapp/services/surface_mask_generator.py
+++ b/webapp/services/surface_mask_generator.py
@@ -642,13 +642,15 @@ def generate_surface_masks(
         """Gravel/unpaved roads."""
         return soft_edge_mask(gravel_binary, transition_px=2) * 0.8
 
+    def _compute_crop():
+        """Agricultural land: farmland polygons (farmland, farmyard, allotments, orchard)."""
+        return soft_edge_mask(farmland_binary, transition_px=8) * 0.7
+
     def _compute_dirt():
-        """Farmland (soft, weighted) plus dirt roads/paths (full strength)."""
-        farmland = soft_edge_mask(farmland_binary, transition_px=5) * 0.6
+        """Dirt roads and paths only (farmland is now classified as crop)."""
         if np.any(dirt_roads_binary):
-            roads = soft_edge_mask(dirt_roads_binary, transition_px=2)
-            return np.maximum(farmland, roads)
-        return farmland
+            return soft_edge_mask(dirt_roads_binary, transition_px=2)
+        return np.zeros((h, w), dtype=np.float32)
 
     def _compute_sand():
         """Sandy shoreline transition zone around water polygons.
@@ -675,13 +677,14 @@ def generate_surface_masks(
             return soft_edge_mask(edge_only, transition_px=sand_transition_px) * 0.7
         return np.zeros((h, w), dtype=np.float32)
 
-    # Run all 8 mask computations in parallel threads
-    with ThreadPoolExecutor(max_workers=8) as pool:
+    # Run all 9 mask computations in parallel threads
+    with ThreadPoolExecutor(max_workers=9) as pool:
         future_rock = pool.submit(_compute_rock)
         future_forest = pool.submit(_compute_forest_floor)
         future_pine = pool.submit(_compute_pine_floor)
         future_asphalt = pool.submit(_compute_asphalt)
         future_gravel = pool.submit(_compute_gravel)
+        future_crop = pool.submit(_compute_crop)
         future_dirt = pool.submit(_compute_dirt)
         future_sand = pool.submit(_compute_sand)
         future_water_edge = pool.submit(_compute_water_edge)
@@ -691,6 +694,7 @@ def generate_surface_masks(
         pine_float = future_pine.result()
         asphalt_float = future_asphalt.result()
         gravel_float = future_gravel.result()
+        crop_float = future_crop.result()
         dirt_float = future_dirt.result()
         sand_float = future_sand.result()
         water_edge_float = future_water_edge.result()
@@ -715,6 +719,7 @@ def generate_surface_masks(
     pine_float[water_mask_bool] = 0
     asphalt_float[water_mask_bool] = 0
     gravel_float[water_mask_bool] = 0
+    crop_float[water_mask_bool] = 0
     dirt_float[water_mask_bool] = 0
     sand_float[water_mask_bool] = 0
     water_edge_float[water_mask_bool] = 0
@@ -722,7 +727,7 @@ def generate_surface_masks(
     # Stack all non-grass masks
     mask_stack = np.stack([
         rock_float, forest_float, pine_float, asphalt_float,
-        gravel_float, dirt_float, sand_float, water_edge_float,
+        gravel_float, crop_float, dirt_float, sand_float, water_edge_float,
     ], axis=-1)
 
     # Total of all non-grass masks at each pixel
@@ -750,9 +755,10 @@ def generate_surface_masks(
     pine_float = mask_stack[..., 2]
     asphalt_float = mask_stack[..., 3]
     gravel_float = mask_stack[..., 4]
-    dirt_float = mask_stack[..., 5]
-    sand_float = mask_stack[..., 6]
-    water_edge_float = mask_stack[..., 7]
+    crop_float = mask_stack[..., 5]
+    dirt_float = mask_stack[..., 6]
+    sand_float = mask_stack[..., 7]
+    water_edge_float = mask_stack[..., 8]
 
     # =========================================================================
     # Step 5: Convert to uint8 and save
@@ -770,6 +776,7 @@ def generate_surface_masks(
         "pine_floor": to_uint8(pine_float),
         "asphalt": to_uint8(asphalt_float),
         "gravel": to_uint8(gravel_float),
+        "crop": to_uint8(crop_float),
         "dirt": to_uint8(dirt_float),
         "rock": to_uint8(rock_float),
         "sand": to_uint8(sand_float),


### PR DESCRIPTION
## Summary

Patch release addressing the senior World Editor creator feedback in issue #151. Six of the seven fixes ship in this PR; Fix 4 (verified `.emat` material names) is deferred until the reporter confirms the canonical names from his Resource Browser.

- **ZIP packaging**: ZIP now contains `{map_name}/` as the only top-level folder (was flat); download filename is now `{map_name}.zip` instead of a random job-ID string — matches what SETUP_GUIDE Step 1.1 instructs the user to copy
- **Hierarchy label**: Step 2.1 corrected from "GenericTerrainEntity" (class type) to "Terrain" (instance name shown in the WE hierarchy)
- **Crash-safe default surface workflow**: Step 3.2 replaces "Change layer's material..." with right-click `.emat` in Resource Browser → **Fill surface layer** + ⚠️ warning; the old workflow has triggered NVTT crashes on multiple reports
- **Unverified `.emat` names (Fix 4, partial)**: `SURFACE_MATERIAL_VERIFIED` frozenset added; `ForestFloor_01.emat`, `ForestFloor_Pine_01.emat`, `Mud_01.emat` are flagged unverified and the guide says "browse to Surfaces/ and find" for them rather than prescribing a name the user may not have. Removed `Mud_01`/`Asphalt_Cracked_01`/`Rock_Granite_01` from alternatives (reported non-existent). **Full fix pending Resource Browser list from the reporter.**
- **Crop surface (new 10th surface)**: farmland/farmyard/allotments/orchard OSM polygons now produce `surface_crop.png` → `Crop_01.emat`; `dirt` becomes dirt-roads only. Previously ~70% of agricultural maps was classified as dirt
- **Troubleshooting**: new Appendix C entry "World crashes when reopening after surface painting" — explains missing-material-reference root cause + recovery steps
- **Quick Path**: compact 8-step summary at the top of SETUP_GUIDE for experienced creators who don't need step-by-step instructions

`APP_VERSION` bumped to **1.7.2**.

## Deferred to a follow-up

- **Fix 4 full**: once the reporter confirms the exact `.emat` names that exist in his Resource Browser under `ArmaReforger/Terrains/Common/Surfaces/` (especially for forest floor / pine needles / water edge), update `SURFACE_MATERIAL_MAP` with the verified names and extend `SURFACE_MATERIAL_VERIFIED` accordingly.

## Test plan

- [x] `python -m pytest` — 402 passed, 3 pre-existing baseline failures unchanged
- [x] ZIP smoke test: `{map_name}/` confirmed as sole top-level folder
- [x] SETUP_GUIDE smoke test: all 6 shipped-fix assertions pass
- [ ] Agricultural-area generation: confirm `surface_crop.png` is non-trivially covered (end-to-end run)
- [ ] Pending: verified `.emat` names from reporter (Fix 4 follow-up)

Refs #151