### PR TITLE
v1.7.3: print app version banner on container startup (closes #153)

### DIFF
--- a/webapp/config/enfusion.py
+++ b/webapp/config/enfusion.py
@@ -21,7 +21,7 @@ from config.terrain import (
 # enfusion_project_generator.py to stamp into every generated file header.
 # Bump here on every release; the README Docker tag pin should match.
 
-APP_VERSION = "1.7.2"
+APP_VERSION = "1.7.3"
 
 # ---------------------------------------------------------------------------
 # Base game dependency

--- a/webapp/entrypoint.sh
+++ b/webapp/entrypoint.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -e
 
+# Print app version up front so `docker compose logs -f` immediately shows
+# which build of the generator is running (issue #153). Reads from the
+# single source of truth in config/enfusion.py.
+APP_VERSION=$(python -c "from config.enfusion import APP_VERSION; print(APP_VERSION)" 2>/dev/null || echo "unknown")
+echo "=================================================="
+echo "  Arma Reforger Base Map Generator NG  v${APP_VERSION}"
+echo "=================================================="
+
 # Create images directory if it doesn't exist
 mkdir -p /app/static/images
 

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -103,7 +103,9 @@ async def startup_event():
     """
     from services.session_service import clear_all_sessions
 
-    logger.info("Application starting up...")
+    logger.info(f"==================================================")
+    logger.info(f"  Arma Reforger Base Map Generator NG  v{APP_VERSION}")
+    logger.info(f"==================================================")
     cleared_count = clear_all_sessions()
     logger.info(f"Startup cleanup: cleared {cleared_count} hanging sessions")
 


### PR DESCRIPTION
## Summary

Print the running app version in `docker compose logs -f` as soon as the container starts, so operators can confirm at a glance which build is live.

- `entrypoint.sh` prints a 3-line banner *before* uvicorn starts (resolves the version by importing `config.enfusion.APP_VERSION`). Visible even if uvicorn startup hangs.
- `main.py` `startup_event()` logs the same banner via the structured logger so it shows up in any future log shipper.

`APP_VERSION` → **1.7.3**.

Closes #153

## Test plan

- [x] `python -c "from config.enfusion import APP_VERSION; ..."` resolves correctly
- [x] `main.py` parses; banner string present in `startup_event`
- [x] `entrypoint.sh` references `APP_VERSION` and the banner string
- [ ] `docker compose up -d && docker compose logs -f` shows the banner on the first lines (user to verify on next deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)